### PR TITLE
Task 4: Build prompt-loader Tool

### DIFF
--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -20,6 +20,9 @@ You are the Coder for this project. You implement code changes across the entire
 6. **After any text sweep** (removing/replacing references, renaming, relocating files, changing counts across multiple files) — after the first pass, run a grep for the original term/path across the **entire workspace** (not just changed files) to confirm no residual occurrences remain. Include documentation files (`.md`), READMEs, and config files in the search — stale references in docs are a recurring source of review findings. Include **filenames and directory names** as search terms, not just full paths — inventory-style READMEs and index files list files by name rather than path.
 7. **Before returning to the Orchestrator**, delete all temporary or investigation files created during the task.
 8. **When auto-formatters modify files outside the task scope** (e.g., ruff reformats unrelated files) — flag this to the Orchestrator on handoff so formatting-only changes can be committed separately from functional changes. Do not silently mix formatting fixes with implementation.
+9. **Security: subprocess and path handling.**
+   - **TypeScript tool wrappers:** Never use `execSync()` or `exec()` with string concatenation for subprocess calls. Use `execFileSync()` or `spawnSync()` with explicit argument arrays — these bypass the shell and prevent command injection (CWE-78).
+   - **Python tools with file paths:** When resolving user-provided names to file paths, always validate the resolved absolute path starts with the intended base directory using `resolved.resolve()` and `.is_relative_to(base)`. Reject any path that traverses outside the base (CWE-22).
 
 > **When dispatched by the Orchestrator** (implementation or regression fix), do NOT commit, push, or post PR comments. The Orchestrator owns all git/GitHub operations. Just implement, lint, and return.
 

--- a/.github/agents/reflection.agent.md
+++ b/.github/agents/reflection.agent.md
@@ -203,7 +203,7 @@ See `.github/notes/reflections/TEMPLATE.md` for the canonical template and `.git
 
 1. **Never break existing workflows** — if unsure whether a change is safe, classify as major
 2. **Preserve formatting** — match the existing style of each file type
-3. **Append-only notes** — never delete reflection notes, only archive them
+3. **Append-only notes** — never delete reflection notes from the archive. "Archiving" means **move** the active note to `archive/` (copy, then delete the active copy). Once a note exists in the archive, the active copy is a stale duplicate and must be removed.
 4. **One improvement per edit** — make targeted changes, not wholesale rewrites
 5. **Test mentally** — before applying, trace through how the change affects agent behaviour
 

--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -80,6 +80,14 @@ Prompt templates are **Markdown files** stored in the top-level `prompts/` direc
 | _unused/ | 12 | Deprecated templates |
 | root-level | 3 | Base context extraction, story start date, chapter events |
 
+## Tools
+
+The first custom tool — `prompt-loader` — implements the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md). TypeScript wrapper (`.opencode/tools/prompt-loader.ts`) calls Python script (`src/tools/prompt_loader.py`) via subprocess. The Python script reuses `PromptLoader` from `src/infrastructure/prompts/prompt_loader.py`.
+
+Pattern: `.opencode/tools/*.ts` (Zod schema + execSync) → `src/tools/*.py` (argparse + domain logic) → `src/infrastructure/` or `src/domain/`.
+
+See [Tools Reference](docs/tools.md) for full documentation.
+
 ## Planned Architecture (Post-Migration)
 
 See [PRD](docs/planning/opencode-migration/prd.md) and ADRs:

--- a/.github/notes/reflections/archive/issue-3-stale-reflection-2026-04-13.md
+++ b/.github/notes/reflections/archive/issue-3-stale-reflection-2026-04-13.md
@@ -1,0 +1,30 @@
+---
+date: "2026-04-13"
+issue: 3
+pr: 32
+category: agent
+targets:
+  - ".github/agents/reflection.agent.md"
+severity: minor
+status: archived
+---
+
+## Reflection agent leaves stale active notes after archiving
+
+### Finding
+
+After the issue #30 reflection was processed and archived to `.github/notes/reflections/archive/issue-30-2026-04-13.md`, the original `issue-30.md` was left in the active reflections directory. The file was marked `status: archived` in its frontmatter but not removed from the active directory. This was discovered during the issue #3 collation.
+
+### Observation
+
+The Reflection agent's archival process should move notes from `reflections/` to `reflections/archive/` — copy then delete the original. The "append-only — never delete reflection notes, only archive them" constraint means notes should not be destroyed, but once a note exists in the archive, the active copy is a stale duplicate and should be removed.
+
+The likely root cause is that the Reflection agent (or Orchestrator) copied the note to the archive but did not delete the active copy, possibly because the "never delete" constraint was interpreted too broadly. Alternatively, the archival happened but the deletion was not committed.
+
+### Suggested Improvement
+
+Clarify in the Reflection agent instructions that "archive" means **move** (copy to archive, then delete the active copy), and that the "never delete" constraint applies to the archive — not to active copies after successful archival.
+
+### Action Taken
+
+Applied: Clarified Reflection agent constraint #3 in `.github/agents/reflection.agent.md` to explicitly state "archive" means move (copy + delete active copy). Stale `issue-30.md` needs manual removal from active directory.

--- a/.github/notes/reflections/issue-3.md
+++ b/.github/notes/reflections/issue-3.md
@@ -1,0 +1,48 @@
+---
+date: "2026-04-13"
+issue: 3
+pr: 32
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: major
+status: active
+---
+
+## Coder creates shell injection and path traversal vulnerabilities in first tool implementation
+
+### Finding
+
+During issue #3 (Build prompt-loader Tool), the Coder implemented a TypeScript OpenCode tool wrapper (`.opencode/tools/prompt-loader.ts`) that called a Python script via `execSync`. Two critical security vulnerabilities were introduced:
+
+1. **Shell injection (CWE-78):** The TypeScript wrapper used `execSync(cmd + ' ' + args.join(' '))` to invoke the Python script, passing user-controlled arguments directly into a shell command string. An attacker could inject arbitrary shell commands via crafted prompt names (e.g., `; rm -rf /`).
+
+2. **Path traversal (CWE-22):** The Python tool script (`src/tools/prompt_loader.py`) did not validate that the resolved prompt file path remained within the `prompts/` directory. A request for `../../etc/passwd` would traverse out of the intended directory.
+
+Both vulnerabilities were caught by the Synthesized Review and fixed before merge.
+
+### Observation
+
+This is the **first tool** created following the hybrid architecture pattern (ADR 001: TypeScript wrapper → Python script via subprocess). The security issues are systemic patterns that will recur in every future tool unless addressed:
+
+- **Shell injection via `execSync`** is a well-known antipattern. The safe alternative is `execFileSync` (no shell interpretation) or `spawnSync` with explicit argument arrays. The Coder had no specific guidance about subprocess invocation patterns in TypeScript.
+- **Path traversal** is a standard OWASP Top 10 vulnerability. The Coder's instructions reference OWASP generically via `copilot-instructions.md` (`<securityRequirements>`), but there is no actionable rule about validating file paths against a base directory.
+
+The `copilot-instructions.md` `<securityRequirements>` section says "Ensure your code is free from security vulnerabilities outlined in the OWASP Top 10" — but this is too abstract to prevent specific implementation mistakes. The Coder needs concrete, actionable rules for the two most common vulnerability patterns in this architecture:
+
+1. **Subprocess invocation** — every tool wrapper calls a Python script
+2. **Path validation** — many tools will resolve user-provided names to file paths
+
+### Suggested Improvement
+
+Add a new **Rule 9** to the Coder agent instructions:
+
+```
+9. **Security: subprocess and path handling.**
+   - **TypeScript tool wrappers:** Never use `execSync()` or `exec()` with string concatenation for subprocess calls. Use `execFileSync()` or `spawnSync()` with explicit argument arrays — these bypass the shell and prevent command injection (CWE-78).
+   - **Python tools with file paths:** When resolving user-provided names to file paths, always validate the resolved absolute path starts with the intended base directory using `resolved.resolve()` and `.is_relative_to(base)`. Reject any path that traverses outside the base (CWE-22).
+```
+
+### Action Taken
+
+Proposed for approval — this is a new rule (structural change to the Coder agent).

--- a/.github/notes/reviews/2026-04-13-pr32-synthesis.md
+++ b/.github/notes/reviews/2026-04-13-pr32-synthesis.md
@@ -1,0 +1,35 @@
+## Synthesized Code Review — 2026-04-13
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-3-prompt-loader-tool
+**PR:** #32
+**Issue:** #3 — Build prompt-loader Tool
+**Model Agreement Score:** 9/10
+**Overall Assessment:** Needs Fixes
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 1        | 1       | 0          |
+| ★★☆ Majority      | 0        | 2       | 1          |
+| ★☆☆ Singular      | 0        | 0       | 4          |
+
+### Key Findings
+
+- [U-C-01] Shell injection via execSync(args.join(" ")) in TypeScript wrapper (★★★)
+- [U-W-01] No path traversal guard on prompt_id in Python script (★★★)
+- [M-W-02] Docs template propagates vulnerable execSync pattern (★★☆)
+- [M-W-03] Variable type validation missing after json.loads (★★☆)
+- [M-S-01] Tests depend on real prompt template files on disk (★★☆)
+
+### Divergences
+
+- [D-01] Severity of docs template vuln: GPT=Critical, Gemini=implicit Warning, Claude=not flagged → resolved as Warning
+- [D-02] Variable validation depth: GPT=dict+string values, Claude=dict only, Gemini=not reported → adopted GPT's stricter check
+- [D-03] Test fragility: Claude+Gemini=template coupling, GPT=missing adversarial tests → both included
+
+### Actions Required
+
+- Findings requiring fixes: 4 (U-C-01, U-W-01, M-W-02, M-W-03)
+- Findings deferred: 5 (suggestions — non-blocking)

--- a/.opencode/tools/prompt-loader.ts
+++ b/.opencode/tools/prompt-loader.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { execSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "prompt-loader",
+  description:
+    "Load a prompt template by ID and substitute variables. Returns the rendered prompt text.",
+  parameters: z.object({
+    promptId: z
+      .string()
+      .describe("Prompt template ID (e.g., 'chapters/create_content')"),
+    variables: z
+      .record(z.string())
+      .optional()
+      .describe("Key-value pairs to substitute in the template"),
+  }),
+  execute: async ({
+    promptId,
+    variables,
+  }: {
+    promptId: string;
+    variables?: Record<string, string>;
+  }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = ["python3", "src/tools/prompt_loader.py", "--prompt-id", promptId];
+
+    if (variables && Object.keys(variables).length > 0) {
+      args.push("--variables", JSON.stringify(variables));
+    }
+
+    try {
+      const stdout = execSync(args.join(" "), {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message = execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};

--- a/.opencode/tools/prompt-loader.ts
+++ b/.opencode/tools/prompt-loader.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { resolve } from "path";
 
 export default {
@@ -23,14 +23,14 @@ export default {
     variables?: Record<string, string>;
   }) => {
     const projectRoot = resolve(__dirname, "../..");
-    const args = ["python3", "src/tools/prompt_loader.py", "--prompt-id", promptId];
+    const args = ["src/tools/prompt_loader.py", "--prompt-id", promptId];
 
     if (variables && Object.keys(variables).length > 0) {
       args.push("--variables", JSON.stringify(variables));
     }
 
     try {
-      const stdout = execSync(args.join(" "), {
+      const stdout = execFileSync("python3", args, {
         cwd: projectRoot,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,10 @@
 
 - [Architecture Notes](../.github/notes/architecture.md) — System architecture, layer structure, pipeline flow, prompt template categories
 
+## Tools
+
+- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader tool, guide for adding new tools
+
 ## Planning
 
 - [PRD: OpenCode Migration](./planning/opencode-migration/prd.md) — Full product requirements for the agentic architecture migration

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,200 @@
+# Tools Reference
+
+> Custom tools in the hybrid agent-tool architecture — TypeScript wrappers calling Python domain logic via subprocess.
+
+## Overview
+
+Tools follow the pattern established in [ADR 001](./planning/adr/001-hybrid-agent-tool-architecture.md): OpenCode agents handle orchestration and creative decisions; tools handle deterministic operations with single correct outputs for given inputs.
+
+Each tool consists of two layers:
+
+| Layer | Location | Language | Responsibility |
+|-------|----------|----------|----------------|
+| **Wrapper** | `.opencode/tools/<tool-name>.ts` | TypeScript | Argument parsing (Zod schema), OpenCode integration, subprocess invocation |
+| **Script** | `src/tools/<tool_name>.py` | Python | Domain logic, reuses classes from `src/infrastructure/` and `src/domain/` |
+
+The TypeScript wrapper calls the Python script via `execSync`, passing arguments as CLI flags. The Python script writes its result to stdout and errors to stderr, using conventional exit codes (0 = success, 1 = domain error, 2 = argument error).
+
+```
+┌──────────────────────┐     subprocess      ┌─────────────────────┐
+│  .opencode/tools/    │ ──────────────────▶  │  src/tools/         │
+│  prompt-loader.ts    │     execSync         │  prompt_loader.py   │
+│  (Zod schema, I/O)   │ ◀──────────────────  │  (argparse, logic)  │
+└──────────────────────┘     stdout/stderr    └─────────────────────┘
+                                                       │
+                                                       ▼
+                                              ┌─────────────────────┐
+                                              │  src/infrastructure/ │
+                                              │  (PromptLoader, etc) │
+                                              └─────────────────────┘
+```
+
+---
+
+## prompt-loader
+
+Loads a prompt template by ID and substitutes variables, returning the rendered prompt text.
+
+**Source files:**
+- `.opencode/tools/prompt-loader.ts` — TypeScript wrapper
+- `src/tools/prompt_loader.py` — Python CLI script
+- `src/infrastructure/prompts/prompt_loader.py` — Underlying `PromptLoader` class
+
+### Purpose
+
+Prompt templates are Markdown files in the `prompts/` directory (131 templates across 10 categories). This tool provides deterministic template loading and variable substitution so agents can retrieve rendered prompts without managing file paths or parsing logic.
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `promptId` | string | Yes | Template ID matching the file path under `prompts/` without `.md` extension |
+| `variables` | `Record<string, string>` | No | Key-value pairs substituted into `{{key}}` and `{key}` placeholders |
+
+### CLI Interface (Python script)
+
+```bash
+python3 src/tools/prompt_loader.py --prompt-id <id> [--variables '<json>']
+```
+
+**Examples:**
+
+```bash
+# Load a chapter content prompt with variables
+python3 src/tools/prompt_loader.py \
+  --prompt-id chapters/create_content \
+  --variables '{"chapter_num": "1"}'
+
+# Load a root-level prompt without variables
+python3 src/tools/prompt_loader.py --prompt-id extract_base_context
+```
+
+### Prompt ID Format
+
+The prompt ID maps directly to the file path under `prompts/`, minus the `.md` extension:
+
+| Prompt ID | File Path |
+|-----------|-----------|
+| `chapters/create_content` | `prompts/chapters/create_content.md` |
+| `extract_base_context` | `prompts/extract_base_context.md` |
+| `recap/generate` | `prompts/recap/generate.md` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — rendered prompt printed to stdout |
+| 1 | Domain error — prompt not found, invalid JSON in `--variables` |
+| 2 | Argument error — missing required `--prompt-id` flag |
+
+### Variable Substitution
+
+The underlying `PromptLoader` supports two placeholder formats:
+- `{{variable_name}}` — double-brace format
+- `{variable_name}` — single-brace format
+
+Both are replaced with the string value from the variables dictionary.
+
+---
+
+## Adding a New Tool
+
+Follow this pattern to add tools to the system:
+
+### 1. Create the Python script
+
+Create `src/tools/<tool_name>.py` with:
+- `argparse` for CLI argument parsing
+- `sys.path` manipulation to import from `src/`
+- Domain logic reused from `src/infrastructure/` or `src/application/`
+- Output to stdout, errors to stderr
+- Exit codes: 0 (success), 1 (domain error), 2 (argument error)
+
+```python
+"""CLI tool for <description>."""
+
+import argparse
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from domain.exceptions import ConfigurationError  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="<description>")
+    parser.add_argument("--arg-name", required=True, help="<help text>")
+    args = parser.parse_args()
+
+    try:
+        result = do_work(args.arg_name)
+    except ConfigurationError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(result)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### 2. Create the TypeScript wrapper
+
+Create `.opencode/tools/<tool-name>.ts` with:
+- Zod schema for parameter validation
+- `execSync` to call the Python script
+- Error handling that captures stderr
+
+```typescript
+import { z } from "zod";
+import { execSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "<tool-name>",
+  description: "<description>",
+  parameters: z.object({
+    argName: z.string().describe("<description>"),
+  }),
+  execute: async ({ argName }: { argName: string }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = ["python3", "src/tools/<tool_name>.py", "--arg-name", argName];
+
+    try {
+      const stdout = execSync(args.join(" "), {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message = execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};
+```
+
+### 3. Write tests
+
+Create `tests/unit/test_<tool_name>_tool.py` testing:
+- Successful execution with expected arguments
+- Missing required arguments (exit code 2)
+- Domain errors (exit code 1)
+- Direct class usage (bypasses CLI layer)
+
+### 4. Verify
+
+```bash
+ruff check --fix . && ruff format . && mypy src/
+pytest tests/unit/test_<tool_name>_tool.py -v
+```
+
+## Related
+
+- [ADR 001: Hybrid Agent-Tool Architecture](./planning/adr/001-hybrid-agent-tool-architecture.md) — Architectural decision establishing the tool pattern
+- [Architecture Notes](../.github/notes/architecture.md) — System architecture overview

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -13,12 +13,12 @@ Each tool consists of two layers:
 | **Wrapper** | `.opencode/tools/<tool-name>.ts` | TypeScript | Argument parsing (Zod schema), OpenCode integration, subprocess invocation |
 | **Script** | `src/tools/<tool_name>.py` | Python | Domain logic, reuses classes from `src/infrastructure/` and `src/domain/` |
 
-The TypeScript wrapper calls the Python script via `execSync`, passing arguments as CLI flags. The Python script writes its result to stdout and errors to stderr, using conventional exit codes (0 = success, 1 = domain error, 2 = argument error).
+The TypeScript wrapper calls the Python script via `execFileSync`, passing arguments as an array. The Python script writes its result to stdout and errors to stderr, using conventional exit codes (0 = success, 1 = domain error, 2 = argument error).
 
 ```
 ┌──────────────────────┐     subprocess      ┌─────────────────────┐
 │  .opencode/tools/    │ ──────────────────▶  │  src/tools/         │
-│  prompt-loader.ts    │     execSync         │  prompt_loader.py   │
+│  prompt-loader.ts    │     execFileSync     │  prompt_loader.py   │
 │  (Zod schema, I/O)   │ ◀──────────────────  │  (argparse, logic)  │
 └──────────────────────┘     stdout/stderr    └─────────────────────┘
                                                        │
@@ -145,12 +145,12 @@ if __name__ == "__main__":
 
 Create `.opencode/tools/<tool-name>.ts` with:
 - Zod schema for parameter validation
-- `execSync` to call the Python script
+- `execFileSync` to call the Python script
 - Error handling that captures stderr
 
 ```typescript
 import { z } from "zod";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { resolve } from "path";
 
 export default {
@@ -161,10 +161,10 @@ export default {
   }),
   execute: async ({ argName }: { argName: string }) => {
     const projectRoot = resolve(__dirname, "../..");
-    const args = ["python3", "src/tools/<tool_name>.py", "--arg-name", argName];
+    const args = ["src/tools/<tool_name>.py", "--arg-name", argName];
 
     try {
-      const stdout = execSync(args.join(" "), {
+      const stdout = execFileSync("python3", args, {
         cwd: projectRoot,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],

--- a/src/tools/prompt_loader.py
+++ b/src/tools/prompt_loader.py
@@ -1,0 +1,50 @@
+"""CLI tool for loading and rendering prompt templates."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from domain.exceptions import ConfigurationError  # noqa: E402
+from infrastructure.prompts.prompt_loader import PromptLoader  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Load a prompt template by ID.")
+    parser.add_argument(
+        "--prompt-id",
+        required=True,
+        help="Prompt template ID (e.g., 'chapters/create_content')",
+    )
+    parser.add_argument(
+        "--variables",
+        default=None,
+        help="JSON object string of variables to substitute",
+    )
+    args = parser.parse_args()
+
+    variables = None
+    if args.variables:
+        try:
+            variables = json.loads(args.variables)
+        except json.JSONDecodeError as e:
+            print(f"Invalid JSON in --variables: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    prompts_dir = PROJECT_ROOT / "prompts"
+    loader = PromptLoader(prompts_dir=str(prompts_dir))
+
+    try:
+        result = loader.load_prompt(args.prompt_id, variables)
+    except ConfigurationError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/prompt_loader.py
+++ b/src/tools/prompt_loader.py
@@ -33,8 +33,21 @@ def main() -> None:
         except json.JSONDecodeError as e:
             print(f"Invalid JSON in --variables: {e}", file=sys.stderr)
             sys.exit(1)
+        if not isinstance(variables, dict):
+            print("Error: --variables must be a JSON object", file=sys.stderr)
+            sys.exit(1)
 
     prompts_dir = PROJECT_ROOT / "prompts"
+
+    # Validate prompt_id does not escape the prompts directory
+    resolved_path = (prompts_dir / f"{args.prompt_id}.md").resolve()
+    if not resolved_path.is_relative_to(prompts_dir.resolve()):
+        print(
+            f"Error: prompt ID escapes prompts directory: {args.prompt_id}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     loader = PromptLoader(prompts_dir=str(prompts_dir))
 
     try:

--- a/tests/unit/test_prompt_loader_tool.py
+++ b/tests/unit/test_prompt_loader_tool.py
@@ -1,0 +1,117 @@
+"""Verification tests for Issue #3 — prompt-loader Tool.
+
+Confirms the CLI tool (src/tools/prompt_loader.py) and the underlying
+PromptLoader class correctly load, render, and validate prompt templates.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+TOOL_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "prompt_loader.py")
+
+
+def test_load_prompt_with_variables():
+    """CLI: prompt with variables substitutes values correctly."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            TOOL_SCRIPT,
+            "--prompt-id",
+            "chapters/create_content",
+            "--variables",
+            '{"chapter_num": "1"}',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Expected exit 0, got {result.returncode}: {result.stderr}"
+    )
+    assert "chapter 1" in result.stdout.lower(), (
+        f"Expected 'chapter 1' in output, got: {result.stdout[:200]}"
+    )
+
+
+def test_load_prompt_without_variables():
+    """CLI: root-level prompt loads successfully without variables."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            TOOL_SCRIPT,
+            "--prompt-id",
+            "extract_base_context",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Expected exit 0, got {result.returncode}: {result.stderr}"
+    )
+    assert len(result.stdout.strip()) > 0, "Expected non-empty output"
+
+
+def test_missing_prompt_returns_error():
+    """CLI: nonexistent prompt ID returns exit 1 with 'not found' in stderr."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            TOOL_SCRIPT,
+            "--prompt-id",
+            "nonexistent/prompt",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, f"Expected exit 1, got {result.returncode}"
+    assert "not found" in result.stderr.lower(), (
+        f"Expected 'not found' in stderr, got: {result.stderr}"
+    )
+
+
+def test_invalid_json_variables_returns_error():
+    """CLI: malformed JSON in --variables returns exit 1 with 'Invalid JSON'."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            TOOL_SCRIPT,
+            "--prompt-id",
+            "chapters/create_content",
+            "--variables",
+            "invalid json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, f"Expected exit 1, got {result.returncode}"
+    assert "Invalid JSON" in result.stderr, (
+        f"Expected 'Invalid JSON' in stderr, got: {result.stderr}"
+    )
+
+
+def test_prompt_loader_class_direct():
+    """Direct: PromptLoader class loads and substitutes variables."""
+    from infrastructure.prompts.prompt_loader import PromptLoader
+
+    prompts_dir = str(PROJECT_ROOT / "prompts")
+    loader = PromptLoader(prompts_dir=prompts_dir)
+    result = loader.load_prompt("chapters/create_content", {"chapter_num": "1"})
+    assert "chapter 1" in result.lower(), (
+        f"Expected 'chapter 1' in rendered prompt, got: {result[:200]}"
+    )
+
+
+def test_missing_prompt_id_argument():
+    """CLI: omitting --prompt-id returns exit 2 (argparse error)."""
+    result = subprocess.run(
+        [sys.executable, TOOL_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2, f"Expected exit 2, got {result.returncode}"


### PR DESCRIPTION
## Summary

First custom tool in the hybrid agent-tool architecture (ADR 001). The `prompt-loader` tool loads a prompt template by ID (e.g., `chapters/create_content`), substitutes variables, and returns the rendered prompt text. TypeScript wrapper validates inputs and calls a Python CLI script via subprocess.

## Closes

Closes #3

## Changes

- [x] `src/tools/__init__.py` — package init
- [x] `src/tools/prompt_loader.py` — Python CLI script (argparse, PromptLoader reuse, error handling)
- [x] `.opencode/tools/prompt-loader.ts` — TypeScript tool wrapper (Zod schema, execSync subprocess)
- [x] `tests/unit/test_prompt_loader_tool.py` — 6 verification tests (all passing)

## Acceptance Criteria

- [x] `.opencode/tools/prompt-loader.ts` exists with proper tool definition
- [x] `src/tools/prompt_loader.py` exists, accepts `--prompt-id` and `--variables` (JSON)
- [x] Loading `chapters/create_content` with `{chapter_num: 1}` returns correctly rendered text
- [x] Missing prompt ID returns a clear error message
- [x] Invalid variables are handled gracefully
- [ ] Tool is visible in OpenCode's tool list (requires OpenCode runtime — manual verification)

## Plan

1. ~~Create `src/tools/__init__.py`~~ ✅
2. ~~Create `src/tools/prompt_loader.py`~~ ✅
3. ~~Create `.opencode/tools/prompt-loader.ts`~~ ✅
4. ~~Write verification tests~~ ✅ (6/6 passing)