### PR TITLE
Task 5: Build story-state Tool

### DIFF
--- a/.github/notes/reflections/archive/issue-3-2026-04-13.md
+++ b/.github/notes/reflections/archive/issue-3-2026-04-13.md
@@ -6,7 +6,7 @@ category: agent
 targets:
   - ".github/agents/coder.agent.md"
 severity: major
-status: active
+status: archived
 ---
 
 ## Coder creates shell injection and path traversal vulnerabilities in first tool implementation
@@ -45,4 +45,4 @@ Add a new **Rule 9** to the Coder agent instructions:
 
 ### Action Taken
 
-Proposed for approval — this is a new rule (structural change to the Coder agent).
+Applied: Coder Rule 9 added to `.github/agents/coder.agent.md`. Confirmed effective — issue #8 Coder correctly used `execFileSync` and `is_relative_to()` following this rule.

--- a/.github/notes/reflections/issue-8-coder-role-boundary.md
+++ b/.github/notes/reflections/issue-8-coder-role-boundary.md
@@ -1,0 +1,42 @@
+---
+date: "2026-04-13"
+issue: 8
+pr: 33
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: major
+status: active
+---
+
+## Coder writes 20 tests that should be Test Writer's responsibility
+
+### Finding
+
+During issue #8 (Build story-state Tool), the Coder wrote 20 comprehensive verification tests in `tests/unit/test_story_state_tool.py`. This is the Test Writer's responsibility — the Orchestrator's Step 5 explicitly delegates test writing to the Test Writer agent.
+
+The tests were well-written and comprehensive, but:
+- One test (`test_write_missing_value`) had a missing assertion (caught by Synthesized Review)
+- The Test Writer was bypassed entirely — it never had a chance to apply its own research workflow (checking gotchas, querying ChromaDB for patterns, etc.)
+
+### Observation
+
+The **Orchestrator** already has an explicit prohibition: "Never write or edit test files. Always delegate to the Test Writer." However, the **Coder agent** has no matching constraint. The Coder's rules enumerate what it should do (lint, type-check, sweep references, security patterns) but never say "don't write tests."
+
+When a Coder sees an opportunity to write tests alongside implementation, there's no guardrail preventing it. This creates two problems:
+1. The Test Writer's specialised research workflow is bypassed
+2. Test quality may suffer (as shown by the missing assertion)
+
+The Orchestrator's prohibition prevents the Orchestrator from writing tests — it doesn't prevent the Coder from spontaneously doing so during implementation.
+
+### Suggested Improvement
+
+Add a new rule to the Coder agent (`.github/agents/coder.agent.md`):
+
+```markdown
+10. **Do not write verification tests.** If you identify test scenarios during implementation, note them in your handoff summary for the Test Writer. The Orchestrator will dispatch the Test Writer separately. You may create minimal throwaway test scripts for debugging during implementation, but delete them before handoff (per Rule 7).
+```
+
+### Action Taken
+
+Proposed for approval — this adds a new numbered rule to the Coder agent.

--- a/.github/notes/reflections/issue-8.md
+++ b/.github/notes/reflections/issue-8.md
@@ -1,0 +1,38 @@
+---
+date: "2026-04-13"
+issue: 8
+pr: 33
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Synthesized Review catches TOCTOU, temp file leak, and missing assertion — system working correctly
+
+### Finding
+
+During issue #8 (Build story-state Tool), the Synthesized Review caught three implementation defects:
+
+1. **[U-W-01] Missing test assertion:** `test_write_missing_value` had no `assert` statement — the Coder omitted `assert result.returncode == 2`.
+2. **[M-W-01] TOCTOU race in cmd_write:** The file read was performed outside the lock, creating a time-of-check-time-of-use race condition with concurrent writers.
+3. **[U-S-01] Temp file leaked on os.replace() failure:** The temp file created for atomic writes was not cleaned up if `os.replace()` raised an exception.
+
+All three were fixed before merge.
+
+**Positive signal:** The Coder correctly used `execFileSync` for the TypeScript wrapper and `is_relative_to()` for path validation — demonstrating that the Rule 9 addition from issue #3 reflection is being followed. The security patterns proposed in that reflection are now established practice.
+
+### Observation
+
+The three defects are standard coding quality issues — not systemic patterns requiring new rules. The Synthesized Review caught all three, which is the system working as designed. The TOCTOU and temp-file-leak patterns are specific to the file-locking logic in `story_state.py` and unlikely to be a recurring cross-tool pattern.
+
+The missing assertion (#1) is a symptom of the Coder writing tests — a role boundary issue addressed in a separate reflection note (`issue-8-coder-role-boundary.md`).
+
+### Suggested Improvement
+
+No agent rule changes needed for the technical findings. The review layer is catching these effectively.
+
+### Action Taken
+
+Recorded. No agent changes applied — the Synthesized Review is functioning as intended.

--- a/.github/notes/reviews/2026-04-13-issue-8-synthesis.md
+++ b/.github/notes/reviews/2026-04-13-issue-8-synthesis.md
@@ -1,0 +1,34 @@
+## Synthesized Code Review — 2026-04-13 (Issue #8)
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-8-story-state-tool
+**Model Agreement Score:** 8/10
+**Overall Assessment:** Needs Minor Fixes
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 1       | 1          |
+| ★★☆ Majority      | 0        | 1       | 1          |
+| ★☆☆ Singular      | 0        | 0       | 2          |
+
+### Key Findings
+
+- [U-W-01] test_write_missing_value has no assertions — passes vacuously (★★★)
+- [M-W-01] Read-modify-write TOCTOU in cmd_write — docs claim safety not met (★★☆)
+- [U-S-01] Temp file leaked on os.replace() failure (★★★)
+- [S-S-01] Unused STORIES_DIR constant in test file (★☆☆)
+- [M-S-01] fcntl Unix-only portability note (★★☆)
+- [S-S-02] Argument-validation tests skip isolation (★☆☆)
+
+### Divergences
+
+- [D-01] Temp file leak severity: Claude+GPT=Suggestion, Gemini=Warning → resolved as Suggestion
+- [D-02] TOCTOU reporting: Claude+Gemini reported, GPT omitted → resolved as Warning (majority)
+
+### Actions Required
+
+- Findings requiring fixes before merge: 2 (U-W-01, M-W-01)
+- Findings recommended before merge: 1 (U-S-01)
+- Findings deferred/optional: 3 (S-S-01, M-S-01, S-S-02)

--- a/.opencode/tools/story-state.ts
+++ b/.opencode/tools/story-state.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "story-state",
+  description:
+    "Manage story state: init, read, write, or list stories. Handles story_context, characters, plot_threads, and chapters.",
+  parameters: z.object({
+    operation: z
+      .enum(["init", "read", "write", "list"])
+      .describe("Operation to perform"),
+    name: z.string().optional().describe("Story name"),
+    field: z
+      .string()
+      .optional()
+      .describe("Dot-notation field path (e.g., 'story_context.tone_style')"),
+    value: z
+      .string()
+      .optional()
+      .describe("JSON string value for write operation"),
+  }),
+  execute: async ({
+    operation,
+    name,
+    field,
+    value,
+  }: {
+    operation: "init" | "read" | "write" | "list";
+    name?: string;
+    field?: string;
+    value?: string;
+  }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = ["src/tools/story_state.py", "--operation", operation];
+
+    if (name) {
+      args.push("--name", name);
+    }
+    if (field) {
+      args.push("--field", field);
+    }
+    if (value !== undefined) {
+      args.push("--value", value);
+    }
+
+    try {
+      const stdout = execFileSync("python3", args, {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message =
+        execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 ## Tools
 
-- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader tool, guide for adding new tools
+- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader and story-state tools, guide for adding new tools
 
 ## Planning
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -97,6 +97,108 @@ Both are replaced with the string value from the variables dictionary.
 
 ---
 
+## story-state
+
+Manages story state on disk — initialises story directory structures, reads/writes state fields with deep-merge semantics, and lists available stories.
+
+**Source files:**
+- `.opencode/tools/story-state.ts` — TypeScript wrapper
+- `src/tools/story_state.py` — Python CLI script
+
+### Purpose
+
+Each story is stored as a directory under `stories/<name>/` containing a `state.json` file and subdirectories for chapters, characters, settings, and savepoints. This tool provides atomic, locked access to the state file so agents can safely initialise, inspect, and update story state without race conditions or data loss.
+
+The state JSON schema matches the legacy `StoryContext`, `CharacterState`, `PlotThread`, and `ChapterState` structures:
+
+```json
+{
+  "story_context": {
+    "story_direction": "",
+    "tone_style": "",
+    "target_audience": "",
+    "story_pacing": "medium",
+    "current_themes": [],
+    "world_rules": [],
+    "genre_conventions": [],
+    "current_tension": 1,
+    "story_goals": [],
+    "completed_arcs": []
+  },
+  "characters": {},
+  "plot_threads": {},
+  "chapters": {}
+}
+```
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `operation` | `"init" \| "read" \| "write" \| "list"` | Yes | Operation to perform |
+| `name` | string | For `init`, `read`, `write` | Story name (maps to directory under `stories/`) |
+| `field` | string | For `write`; optional for `read` | Dot-notation path into the state JSON (e.g., `story_context.tone_style`) |
+| `value` | string | For `write` | JSON-encoded value to set at the target field |
+
+### CLI Interface (Python script)
+
+```bash
+python3 src/tools/story_state.py --operation <op> [--name <name>] [--field <path>] [--value '<json>']
+```
+
+**Examples:**
+
+```bash
+# Initialise a new story
+python3 src/tools/story_state.py --operation init --name my-story
+
+# Read full state
+python3 src/tools/story_state.py --operation read --name my-story
+
+# Read a nested field
+python3 src/tools/story_state.py --operation read --name my-story --field story_context.current_tension
+
+# Write a field (deep-merges dicts, replaces scalars)
+python3 src/tools/story_state.py --operation write --name my-story \
+  --field story_context --value '{"tone_style": "noir", "current_tension": 7}'
+
+# List all stories
+python3 src/tools/story_state.py --operation list
+```
+
+### Operations
+
+| Operation | Effect | Output |
+|-----------|--------|--------|
+| `init` | Creates `stories/<name>/` with subdirectories (`chapters/`, `characters/`, `settings/`, `savepoints/`) and an empty `state.json` | `{"status": "created", "story": "<name>"}` |
+| `read` | Reads full state or a nested field via `--field` dot-notation | JSON state object or field value |
+| `write` | Deep-merges a JSON value into the field at `--field`; sibling fields are preserved | `{"status": "updated", "field": "<path>"}` |
+| `list` | Scans `stories/` for directories containing `state.json` | JSON array of story names |
+
+### Deep Merge Semantics
+
+The `write` operation uses deep merge when both the existing value and the new value are dictionaries. This means writing to `story_context` with `{"tone_style": "noir"}` updates only `tone_style` — all sibling fields (`story_direction`, `current_themes`, etc.) remain unchanged.
+
+For non-dict values (scalars, arrays), the new value replaces the old one entirely.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — result printed to stdout as JSON |
+| 1 | Domain error — story already exists (init), story/field not found (read/write), invalid JSON in `--value` |
+| 2 | Argument error — missing required flag for the chosen operation |
+
+### Security
+
+- **Path traversal prevention** — story names are validated with `Path.is_relative_to()` to ensure they cannot escape the `stories/` directory (e.g., `../../etc/passwd` is rejected)
+- **Atomic writes** — state is written to a temporary file then moved into place with `os.replace()`, preventing partial writes on crash
+- **File locking** — `fcntl.flock(LOCK_EX)` prevents concurrent writes from corrupting state
+- **Shell injection prevention** — the TypeScript wrapper uses `execFileSync` with an argument array, never shell interpolation
+- **Test isolation** — the `STORIES_DIR` environment variable overrides the default stories directory, ensuring tests never touch production data
+
+---
+
 ## Adding a New Tool
 
 Follow this pattern to add tools to the system:

--- a/src/tools/story_state.py
+++ b/src/tools/story_state.py
@@ -1,0 +1,221 @@
+"""CLI tool for managing story state (init, read, write, list)."""
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+STORIES_DIR = Path(os.environ.get("STORIES_DIR", str(PROJECT_ROOT / "stories")))
+
+INITIAL_STATE = {
+    "story_context": {
+        "story_direction": "",
+        "tone_style": "",
+        "target_audience": "",
+        "story_pacing": "medium",
+        "current_themes": [],
+        "world_rules": [],
+        "genre_conventions": [],
+        "current_tension": 1,
+        "story_goals": [],
+        "completed_arcs": [],
+    },
+    "characters": {},
+    "plot_threads": {},
+    "chapters": {},
+}
+
+
+def _validate_story_name(name: str) -> Path:
+    """Validate story name does not escape the stories directory."""
+    story_dir = (STORIES_DIR / name).resolve()
+    if not story_dir.is_relative_to(STORIES_DIR.resolve()):
+        print(
+            f"Error: story name escapes stories directory: {name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return story_dir
+
+
+def _get_nested(data: dict, field: str) -> object:
+    """Get a nested value from a dict using dot-notation."""
+    keys = field.split(".")
+    current: object = data
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            print(f"Error: field not found: {field}", file=sys.stderr)
+            sys.exit(1)
+        current = current[key]
+    return current
+
+
+def _set_nested(data: dict, field: str, value: object) -> None:
+    """Set a nested value in a dict using dot-notation, with deep merge for dicts."""
+    keys = field.split(".")
+    current = data
+    for key in keys[:-1]:
+        if key not in current or not isinstance(current[key], dict):
+            current[key] = {}
+        current = current[key]
+
+    last_key = keys[-1]
+    # Deep merge if both existing and new values are dicts
+    if (
+        isinstance(value, dict)
+        and last_key in current
+        and isinstance(current[last_key], dict)
+    ):
+        _deep_merge(current[last_key], value)
+    else:
+        current[last_key] = value
+
+
+def _deep_merge(target: dict, source: dict) -> None:
+    """Recursively merge source into target without clobbering sibling fields."""
+    for key, val in source.items():
+        if key in target and isinstance(target[key], dict) and isinstance(val, dict):
+            _deep_merge(target[key], val)
+        else:
+            target[key] = val
+
+
+def _read_state(state_path: Path) -> dict:
+    """Read state.json from disk."""
+    if not state_path.exists():
+        print(f"Error: state file not found: {state_path}", file=sys.stderr)
+        sys.exit(1)
+    with open(state_path) as f:
+        return json.load(f)
+
+
+def _write_state_atomic(state_path: Path, data: dict) -> None:
+    """Write state.json atomically with file locking."""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = None
+    try:
+        fd = os.open(str(state_path), os.O_RDWR | os.O_CREAT)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=str(state_path.parent),
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(data, tmp, indent=2)
+            tmp.write("\n")
+            tmp_path = tmp.name
+        os.replace(tmp_path, str(state_path))
+    finally:
+        if fd is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+
+def cmd_init(name: str) -> None:
+    """Initialize a new story directory with empty state."""
+    story_dir = _validate_story_name(name)
+    if story_dir.exists():
+        print(f"Error: story already exists: {name}", file=sys.stderr)
+        sys.exit(1)
+
+    for subdir in ("chapters", "characters", "settings", "savepoints"):
+        (story_dir / subdir).mkdir(parents=True, exist_ok=True)
+
+    state_path = story_dir / "state.json"
+    _write_state_atomic(state_path, INITIAL_STATE)
+    print(json.dumps({"status": "created", "story": name}))
+
+
+def cmd_read(name: str, field: str | None) -> None:
+    """Read story state, optionally extracting a nested field."""
+    story_dir = _validate_story_name(name)
+    state_path = story_dir / "state.json"
+    data = _read_state(state_path)
+
+    if field:
+        result = _get_nested(data, field)
+    else:
+        result = data
+
+    print(json.dumps(result, indent=2))
+
+
+def cmd_write(name: str, field: str, value_str: str) -> None:
+    """Write a value to a nested field in story state."""
+    story_dir = _validate_story_name(name)
+    state_path = story_dir / "state.json"
+
+    try:
+        value = json.loads(value_str)
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON in --value: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    data = _read_state(state_path)
+    _set_nested(data, field, value)
+    _write_state_atomic(state_path, data)
+    print(json.dumps({"status": "updated", "field": field}))
+
+
+def cmd_list() -> None:
+    """List available story names."""
+    if not STORIES_DIR.exists():
+        print(json.dumps([]))
+        return
+
+    stories = sorted(
+        d.name
+        for d in STORIES_DIR.iterdir()
+        if d.is_dir() and (d / "state.json").exists()
+    )
+    print(json.dumps(stories))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage story state.")
+    parser.add_argument(
+        "--operation",
+        required=True,
+        choices=["init", "read", "write", "list"],
+        help="Operation to perform",
+    )
+    parser.add_argument("--name", default=None, help="Story name")
+    parser.add_argument("--field", default=None, help="Dot-notation field path")
+    parser.add_argument("--value", default=None, help="JSON string value for write")
+    args = parser.parse_args()
+
+    if args.operation == "init":
+        if not args.name:
+            print("Error: --name is required for init", file=sys.stderr)
+            sys.exit(2)
+        cmd_init(args.name)
+
+    elif args.operation == "read":
+        if not args.name:
+            print("Error: --name is required for read", file=sys.stderr)
+            sys.exit(2)
+        cmd_read(args.name, args.field)
+
+    elif args.operation == "write":
+        if not args.name:
+            print("Error: --name is required for write", file=sys.stderr)
+            sys.exit(2)
+        if not args.field:
+            print("Error: --field is required for write", file=sys.stderr)
+            sys.exit(2)
+        if args.value is None:
+            print("Error: --value is required for write", file=sys.stderr)
+            sys.exit(2)
+        cmd_write(args.name, args.field, args.value)
+
+    elif args.operation == "list":
+        cmd_list()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/story_state.py
+++ b/src/tools/story_state.py
@@ -100,16 +100,25 @@ def _write_state_atomic(state_path: Path, data: dict) -> None:
     try:
         fd = os.open(str(state_path), os.O_RDWR | os.O_CREAT)
         fcntl.flock(fd, fcntl.LOCK_EX)
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            dir=str(state_path.parent),
-            suffix=".tmp",
-            delete=False,
-        ) as tmp:
-            json.dump(data, tmp, indent=2)
-            tmp.write("\n")
-            tmp_path = tmp.name
-        os.replace(tmp_path, str(state_path))
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=str(state_path.parent),
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                json.dump(data, tmp, indent=2)
+                tmp.write("\n")
+                tmp_path = tmp.name
+            os.replace(tmp_path, str(state_path))
+        except BaseException:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            raise
     finally:
         if fd is not None:
             fcntl.flock(fd, fcntl.LOCK_UN)
@@ -156,9 +165,44 @@ def cmd_write(name: str, field: str, value_str: str) -> None:
         print(f"Error: invalid JSON in --value: {e}", file=sys.stderr)
         sys.exit(1)
 
-    data = _read_state(state_path)
-    _set_nested(data, field, value)
-    _write_state_atomic(state_path, data)
+    if not state_path.exists():
+        print(f"Error: state file not found: {state_path}", file=sys.stderr)
+        sys.exit(1)
+
+    fd = None
+    try:
+        fd = os.open(str(state_path), os.O_RDWR)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+
+        # Read, modify, write all under the same lock to prevent TOCTOU
+        with open(state_path) as f:
+            data = json.load(f)
+        _set_nested(data, field, value)
+
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=str(state_path.parent),
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                json.dump(data, tmp, indent=2)
+                tmp.write("\n")
+                tmp_path = tmp.name
+            os.replace(tmp_path, str(state_path))
+        except BaseException:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            raise
+    finally:
+        if fd is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
     print(json.dumps({"status": "updated", "field": field}))
 
 

--- a/tests/unit/test_story_state_tool.py
+++ b/tests/unit/test_story_state_tool.py
@@ -239,7 +239,7 @@ class TestWrite:
         assert result.returncode == 2
 
     def test_write_missing_value(self, story_dir: Path) -> None:
-        _run_tool(
+        result = _run_tool(
             "--operation",
             "write",
             "--name",
@@ -248,6 +248,7 @@ class TestWrite:
             "x",
             stories_dir=story_dir,
         )
+        assert result.returncode == 2
 
 
 class TestList:

--- a/tests/unit/test_story_state_tool.py
+++ b/tests/unit/test_story_state_tool.py
@@ -1,0 +1,295 @@
+"""Verification tests for Issue #8 — story-state Tool.
+
+Confirms the CLI tool (src/tools/story_state.py) correctly manages
+story state: init, read, write, and list operations.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOL_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "story_state.py")
+STORIES_DIR = PROJECT_ROOT / "stories"
+
+
+@pytest.fixture()
+def story_dir(tmp_path: Path) -> Path:
+    """Provide a temp stories directory for isolation via env var."""
+    return tmp_path / "stories"
+
+
+def _run_tool(
+    *args: str, stories_dir: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    if stories_dir is not None:
+        env["STORIES_DIR"] = str(stories_dir)
+    return subprocess.run(
+        [sys.executable, TOOL_SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestInit:
+    def test_init_creates_story(self, story_dir: Path) -> None:
+        result = _run_tool(
+            "--operation", "init", "--name", "my-tale", stories_dir=story_dir
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "created"
+        assert (story_dir / "my-tale" / "state.json").exists()
+        assert (story_dir / "my-tale" / "chapters").is_dir()
+        assert (story_dir / "my-tale" / "characters").is_dir()
+        assert (story_dir / "my-tale" / "settings").is_dir()
+        assert (story_dir / "my-tale" / "savepoints").is_dir()
+
+    def test_init_state_matches_schema(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "schema-test", stories_dir=story_dir)
+        state = json.loads((story_dir / "schema-test" / "state.json").read_text())
+        assert "story_context" in state
+        assert "characters" in state
+        assert "plot_threads" in state
+        assert "chapters" in state
+        assert state["story_context"]["story_pacing"] == "medium"
+        assert state["story_context"]["current_tension"] == 1
+
+    def test_init_duplicate_fails(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "dup", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation", "init", "--name", "dup", stories_dir=story_dir
+        )
+        assert result.returncode == 1
+        assert "already exists" in result.stderr
+
+    def test_init_missing_name(self) -> None:
+        result = _run_tool("--operation", "init")
+        assert result.returncode == 2
+
+
+class TestRead:
+    def test_read_full_state(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "reader", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation", "read", "--name", "reader", stories_dir=story_dir
+        )
+        assert result.returncode == 0
+        state = json.loads(result.stdout)
+        assert "story_context" in state
+
+    def test_read_nested_field(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "nested", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation",
+            "read",
+            "--name",
+            "nested",
+            "--field",
+            "story_context.story_pacing",
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == "medium"
+
+    def test_read_nonexistent_story(self, story_dir: Path) -> None:
+        result = _run_tool(
+            "--operation", "read", "--name", "ghost", stories_dir=story_dir
+        )
+        assert result.returncode == 1
+        assert "not found" in result.stderr
+
+    def test_read_nonexistent_field(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "badfield", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation",
+            "read",
+            "--name",
+            "badfield",
+            "--field",
+            "story_context.nonexistent",
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 1
+        assert "field not found" in result.stderr
+
+    def test_read_missing_name(self) -> None:
+        result = _run_tool("--operation", "read")
+        assert result.returncode == 2
+
+
+class TestWrite:
+    def test_write_leaf_field(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "writer", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation",
+            "write",
+            "--name",
+            "writer",
+            "--field",
+            "story_context.tone_style",
+            "--value",
+            '"dark"',
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 0
+        read_result = _run_tool(
+            "--operation",
+            "read",
+            "--name",
+            "writer",
+            "--field",
+            "story_context.tone_style",
+            stories_dir=story_dir,
+        )
+        assert json.loads(read_result.stdout) == "dark"
+
+    def test_write_preserves_siblings(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "sibling", stories_dir=story_dir)
+        _run_tool(
+            "--operation",
+            "write",
+            "--name",
+            "sibling",
+            "--field",
+            "story_context",
+            "--value",
+            '{"tone_style": "gothic"}',
+            stories_dir=story_dir,
+        )
+        read_result = _run_tool(
+            "--operation",
+            "read",
+            "--name",
+            "sibling",
+            "--field",
+            "story_context",
+            stories_dir=story_dir,
+        )
+        ctx = json.loads(read_result.stdout)
+        assert ctx["tone_style"] == "gothic"
+        assert ctx["story_pacing"] == "medium"
+
+    def test_write_new_character(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "chars", stories_dir=story_dir)
+        char_data = json.dumps(
+            {
+                "name": "Alice",
+                "current_role": "protagonist",
+                "personality_traits": ["brave"],
+                "motivations": ["justice"],
+            }
+        )
+        result = _run_tool(
+            "--operation",
+            "write",
+            "--name",
+            "chars",
+            "--field",
+            "characters.Alice",
+            "--value",
+            char_data,
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 0
+        read_result = _run_tool(
+            "--operation",
+            "read",
+            "--name",
+            "chars",
+            "--field",
+            "characters.Alice.current_role",
+            stories_dir=story_dir,
+        )
+        assert json.loads(read_result.stdout) == "protagonist"
+
+    def test_write_invalid_json_value(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "badjson", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation",
+            "write",
+            "--name",
+            "badjson",
+            "--field",
+            "story_context.tone_style",
+            "--value",
+            "not valid json",
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 1
+        assert "invalid json" in result.stderr.lower()
+
+    def test_write_missing_field(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "nofield", stories_dir=story_dir)
+        result = _run_tool(
+            "--operation",
+            "write",
+            "--name",
+            "nofield",
+            "--value",
+            '"x"',
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 2
+
+    def test_write_missing_value(self, story_dir: Path) -> None:
+        _run_tool(
+            "--operation",
+            "write",
+            "--name",
+            "noval",
+            "--field",
+            "x",
+            stories_dir=story_dir,
+        )
+
+
+class TestList:
+    def test_list_empty(self, story_dir: Path) -> None:
+        result = _run_tool("--operation", "list", stories_dir=story_dir)
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == []
+
+    def test_list_stories(self, story_dir: Path) -> None:
+        _run_tool("--operation", "init", "--name", "alpha", stories_dir=story_dir)
+        _run_tool("--operation", "init", "--name", "beta", stories_dir=story_dir)
+        result = _run_tool("--operation", "list", stories_dir=story_dir)
+        assert result.returncode == 0
+        stories = json.loads(result.stdout)
+        assert stories == ["alpha", "beta"]
+
+
+class TestSecurity:
+    def test_path_traversal_blocked(self, story_dir: Path) -> None:
+        result = _run_tool(
+            "--operation",
+            "init",
+            "--name",
+            "../../etc/passwd",
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 1
+        assert "escapes" in result.stderr
+
+    def test_path_traversal_read(self, story_dir: Path) -> None:
+        result = _run_tool(
+            "--operation",
+            "read",
+            "--name",
+            "../secrets",
+            stories_dir=story_dir,
+        )
+        assert result.returncode == 1
+        assert "escapes" in result.stderr
+
+
+class TestArgparse:
+    def test_missing_operation(self) -> None:
+        result = _run_tool()
+        assert result.returncode == 2


### PR DESCRIPTION
## Summary
Build the story-state tool for managing story state JSON files. Implements init, read, write, and list operations following the hybrid agent-tool pattern (ADR 001).

## Closes
Closes #8

## Changes
- [x] `src/tools/story_state.py` — Python CLI with init/read/write/list operations
- [x] `.opencode/tools/story-state.ts` — TypeScript OpenCode wrapper
- [x] `tests/unit/test_story_state_tool.py` — 20 verification tests
- [x] Atomic writes via tempfile + os.replace for concurrent safety
- [x] File locking via fcntl.flock
- [x] Path traversal prevention via is_relative_to()
- [x] Shell injection prevention via execFileSync with argument arrays
- [x] State schema matches StoryContext/CharacterState/PlotThread/ChapterState

## Plan
- [x] Implementation: Python tool + TypeScript wrapper
- [x] Verification tests: 20 tests, all passing
- [x] Lint: clean
- [x] All tests passing (47/47, 0 regressions)