### PR TITLE
Task 6: Build savepoint-mgr Tool

### DIFF
--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -81,6 +81,8 @@ Based on the changes, determine what documentation needs to be created or update
 > - For directory tree diagrams: re-run `ls` or `find` on the actual directory and regenerate from real disk state — never infer file paths or replacement names. When a task removes a file entry from a diagram, always check the directory's current contents to determine the correct updated listing; do not pattern-match from the task description.
 > - For file paths referenced in prose: verify each path exists on disk before writing it.
 > - For relative links: test they resolve from the doc's directory (e.g., from `docs/` to `.github/` requires `../`).
+> - For tool output formats: read the Python tool's `cmd_*` functions to verify the exact JSON structure returned (dict vs array, field names, status codes).
+> - For file extensions: check the Python tool's save/load logic to verify the actual file format used on disk — do not infer from the domain name.
 > - No hardcoded URLs — reference the project's routing conventions instead.
 > - Scan the entire file for `TODO`, `[placeholder]`, `...` stubs, and trivially short sections (3 lines or fewer where substance is expected). Remove or complete them before committing.
 

--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -82,9 +82,15 @@ Prompt templates are **Markdown files** stored in the top-level `prompts/` direc
 
 ## Tools
 
-The first custom tool — `prompt-loader` — implements the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md). TypeScript wrapper (`.opencode/tools/prompt-loader.ts`) calls Python script (`src/tools/prompt_loader.py`) via subprocess. The Python script reuses `PromptLoader` from `src/infrastructure/prompts/prompt_loader.py`.
+Three tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
 
-Pattern: `.opencode/tools/*.ts` (Zod schema + execSync) → `src/tools/*.py` (argparse + domain logic) → `src/infrastructure/` or `src/domain/`.
+| Tool | Wrapper | Script | Infrastructure |
+|------|---------|--------|---------------|
+| `prompt-loader` | `.opencode/tools/prompt-loader.ts` | `src/tools/prompt_loader.py` | `PromptLoader` — template loading + variable substitution |
+| `story-state` | `.opencode/tools/story-state.ts` | `src/tools/story_state.py` | Direct filesystem — atomic writes with `fcntl` locking |
+| `savepoint-mgr` | `.opencode/tools/savepoint-mgr.ts` | `src/tools/savepoint_manager.py` | `FilesystemSavepointRepository` — checkpoint save/load/list/clear |
+
+Pattern: `.opencode/tools/*.ts` (Zod schema + execFileSync) → `src/tools/*.py` (argparse + domain logic) → `src/infrastructure/` or `src/domain/`.
 
 See [Tools Reference](docs/tools.md) for full documentation.
 

--- a/.github/notes/reflections/archive/issue-7-documenter-verification-gap-2026-04-13.md
+++ b/.github/notes/reflections/archive/issue-7-documenter-verification-gap-2026-04-13.md
@@ -1,0 +1,35 @@
+---
+date: "2026-04-13"
+issue: 7
+pr: 34
+category: agent
+targets:
+  - ".github/agents/documenter.agent.md"
+severity: minor
+status: archived
+---
+
+## Documenter produces inaccurate output formats and file extensions
+
+### Finding
+
+During issue #7 (Build savepoint-mgr Tool), the Documenter wrote documentation with `.json` file extensions and array output format for the `list` subcommand, when the actual implementation uses `.md` files and returns a dict. Both inaccuracies were caught by all three reviewers unanimously (U-W-01, U-W-02).
+
+### Observation
+
+The Documenter agent's verification checklist already covers route tables, method signatures, DB schema, directory trees, file paths, and links. However, it does not explicitly cover **output format/structure** (what the code actually returns) or **file extensions used by the implementation** (what files the code creates on disk). These are the exact two things the Documenter got wrong.
+
+This is the first Documenter inaccuracy finding — not yet a recurring pattern — but the fix is trivial: add two bullet points to the existing verification checklist.
+
+### Suggested Improvement
+
+Add to the Documenter agent's verification checklist (the blockquote in "### 3. Write Documentation"):
+
+```markdown
+> - For tool output formats: read the Python tool's `cmd_*` functions to verify the exact JSON structure returned (dict vs array, field names, status codes).
+> - For file extensions: check the Python tool's save/load logic to verify the actual file format used on disk — do not infer from the domain name.
+```
+
+### Action Taken
+
+Applied: added two verification bullet points to `.github/agents/documenter.agent.md`.

--- a/.github/notes/reflections/archive/issue-7-system-health-2026-04-13.md
+++ b/.github/notes/reflections/archive/issue-7-system-health-2026-04-13.md
@@ -1,0 +1,34 @@
+---
+date: "2026-04-13"
+issue: 7
+pr: 34
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: archived
+---
+
+## Positive signals: testing catches bug, security patterns followed, review catches consistency gap
+
+### Finding
+
+During issue #7 (Build savepoint-mgr Tool), three positive signals observed:
+
+1. **Bug found by tests, not review.** A dict round-trip bug in `FilesystemSavepointRepository.load_savepoint()` was caught by the Test Writer's tests — the method returned body text "Data saved in YAML frontmatter above." instead of the frontmatter dict. The Synthesized Review did not flag this. This validates the test-first verification approach: tests probe runtime behaviour that static review misses.
+
+2. **Security patterns followed.** The Coder used `execFileSync` with argument arrays (not `execSync` with string concatenation) and `is_relative_to()` for path validation. This confirms the Rule 9 addition from issue #3 reflection is established practice — second consecutive tool (after issue #8) to follow it correctly.
+
+3. **Review catches consistency gap.** `cmd_clear` lacked a story existence check, unlike save/load/has/list. All three reviewers flagged it (U-W-03). The plan explicitly said to make clear idempotent, but `_make_repo()` would silently create directories — a side effect inconsistent with the other subcommands. This is the review system working as designed.
+
+### Observation
+
+No agent rule changes needed. The testing and review layers are functioning correctly and complementing each other — tests catch runtime bugs, reviews catch design consistency issues.
+
+### Suggested Improvement
+
+No changes. Recorded as positive signal for system health tracking.
+
+### Action Taken
+
+Recorded. No agent changes applied.

--- a/.github/notes/reflections/archive/issue-8-2026-04-13.md
+++ b/.github/notes/reflections/archive/issue-8-2026-04-13.md
@@ -6,7 +6,7 @@ category: agent
 targets:
   - ".github/agents/coder.agent.md"
 severity: minor
-status: active
+status: archived
 ---
 
 ## Synthesized Review catches TOCTOU, temp file leak, and missing assertion — system working correctly

--- a/.github/notes/reflections/issue-7-conventions-collection-missing.md
+++ b/.github/notes/reflections/issue-7-conventions-collection-missing.md
@@ -1,0 +1,40 @@
+---
+date: "2026-04-13"
+issue: 7
+pr: 34
+category: instruction
+targets:
+  - ".github/instructions/chromadb.instructions.md"
+  - ".github/agents/coder.agent.md"
+severity: major
+status: active
+---
+
+## ChromaDB `conventions` collection referenced but does not exist
+
+### Finding
+
+During issue #7 planning, the Orchestrator queried the `conventions` ChromaDB collection for relevant gotchas and patterns. The collection does not exist — only `tests`, `reflections`, and `codebase` are present. The Coder agent explicitly references this collection in its "Conventions & Gotchas" section: "query the ChromaDB `conventions` collection for gotchas relevant to the task domain."
+
+The `chromadb.instructions.md` file lists `conventions` as a collection with a full metadata schema, sourced from `gotchas.md`, `patterns.md`, `architecture.md`, and `domain.md`. Of these source files, only `architecture.md` exists in `.github/notes/`. The other three (`gotchas.md`, `patterns.md`, `domain.md`) have never been created.
+
+### Observation
+
+This creates a silent failure: agents attempt to query a collection that doesn't exist, get no results or an error, and continue without the context they were supposed to have. The `conventions` collection was designed to provide gotchas, patterns, and architectural context for planning and implementation — its absence means agents are flying blind on accumulated project knowledge.
+
+Two options:
+1. **Create the collection and seed files.** Create `gotchas.md`, `patterns.md`, `domain.md` in `.github/notes/` with content extracted from existing reflections and architecture notes, then embed into a new `conventions` collection.
+2. **Remove references until content exists.** Strip the `conventions` references from `chromadb.instructions.md` and `coder.agent.md`, and add it back when source content is ready.
+
+Option 1 is preferred — there's enough accumulated knowledge from 7 issues of reflections to seed meaningful gotchas and patterns.
+
+### Suggested Improvement
+
+1. Create `.github/notes/gotchas.md` with entries extracted from reflection archive (security patterns from issue #3, stale doc patterns from issues #4/#5/#30, role boundary from issue #8).
+2. Create `.github/notes/patterns.md` with tool implementation patterns (TypeScript wrapper → Python script, execFileSync, is_relative_to, etc.).
+3. Create the `conventions` ChromaDB collection and embed the seed documents.
+4. Verify the Coder agent's `conventions` query works end-to-end.
+
+### Action Taken
+
+Proposed for approval — this creates new knowledge base files and a new ChromaDB collection.

--- a/.github/notes/reviews/2026-04-13-pr34-synthesis.md
+++ b/.github/notes/reviews/2026-04-13-pr34-synthesis.md
@@ -1,0 +1,36 @@
+## Synthesized Code Review — 2026-04-13
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-7-savepoint-mgr-tool
+**PR:** #34
+**Issue:** #7 — Build savepoint-mgr Tool
+**Model Agreement Score:** 9/10
+**Overall Assessment:** Needs Fixes (documentation inaccuracies + minor correctness gap)
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 3       | 1          |
+| ★★☆ Majority      | 0        | 0       | 3          |
+| ★☆☆ Singular      | 0        | 0       | 1          |
+
+### Key Findings
+
+- [U-W-01] Docs claim `.json` extension but code stores `.md` (★★★)
+- [U-W-02] list output documented as array but code returns dict (★★★)
+- [U-W-03] cmd_clear creates directories for non-existent stories (★★★)
+- [U-S-01] `_make_repo` return type is `object` instead of concrete type (★★★)
+- [M-S-01] `list_savepoints` loads full data — performance concern (★★☆)
+- [M-S-02] Bug fix should be separate commit from feature/formatting (★★☆)
+- [M-S-03] No test for `clear` on non-existent story (★★☆)
+- [S-S-01] No regression test for `load_savepoint` bug fix (★☆☆)
+
+### Divergences
+
+- [D-01] `_make_repo` return type severity — Claude/GPT say Suggestion, Gemini says Warning
+
+### Actions Required
+
+- Findings requiring fixes: 3 (U-W-01, U-W-02, U-W-03)
+- Findings deferred: 5 (suggestions — non-blocking)

--- a/.opencode/tools/savepoint-mgr.ts
+++ b/.opencode/tools/savepoint-mgr.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "savepoint-mgr",
+  description:
+    "Manage story savepoints: save, load, has, list, or clear. Supports hierarchical step paths like chapter_1/scene_2.",
+  parameters: z.object({
+    operation: z
+      .enum(["save", "load", "has", "list", "clear"])
+      .describe("Operation to perform"),
+    name: z.string().describe("Story name"),
+    step: z
+      .string()
+      .optional()
+      .describe(
+        "Step name (required for save/load/has). Supports hierarchical paths like chapter_1/scene_2"
+      ),
+    data: z
+      .string()
+      .optional()
+      .describe("Data to save (JSON string, required for save operation)"),
+  }),
+  execute: async ({
+    operation,
+    name,
+    step,
+    data,
+  }: {
+    operation: "save" | "load" | "has" | "list" | "clear";
+    name: string;
+    step?: string;
+    data?: string;
+  }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = [
+      "src/tools/savepoint_manager.py",
+      "--operation",
+      operation,
+      "--name",
+      name,
+    ];
+
+    if (step) {
+      args.push("--step", step);
+    }
+    if (data !== undefined) {
+      args.push("--data", data);
+    }
+
+    try {
+      const stdout = execFileSync("python3", args, {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message =
+        execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 ## Tools
 
-- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader and story-state tools, guide for adding new tools
+- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader, story-state, and savepoint-mgr tools, guide for adding new tools
 
 ## Planning
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -199,6 +199,107 @@ For non-dict values (scalars, arrays), the new value replaces the old one entire
 
 ---
 
+## savepoint-mgr
+
+Manages story savepoints — save, load, check, list, and clear checkpoint data used to resume story generation from intermediate steps.
+
+**Source files:**
+- `.opencode/tools/savepoint-mgr.ts` — TypeScript wrapper
+- `src/tools/savepoint_manager.py` — Python CLI script
+- `src/infrastructure/storage/savepoint_repository.py` — Underlying `FilesystemSavepointRepository` class
+
+### Purpose
+
+During story generation, intermediate results (outlines, character sheets, chapter recaps, etc.) are saved as savepoints under `stories/<name>/savepoints/`. This tool provides CLI access to the `FilesystemSavepointRepository` so agents can checkpoint and resume multi-step generation pipelines without re-running expensive LLM calls.
+
+Savepoints support **hierarchical step names** (e.g., `chapter_1/scene_2`) for organising checkpoints by phase and sub-step.
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `operation` | `"save" \| "load" \| "has" \| "list" \| "clear"` | Yes | Operation to perform |
+| `name` | string | Yes | Story name (maps to directory under `stories/`) |
+| `step` | string | For `save`, `load`, `has` | Step name, supports hierarchical paths like `chapter_1/scene_2` |
+| `data` | string | For `save` | JSON string of the data to save |
+
+### CLI Interface (Python script)
+
+```bash
+python3 src/tools/savepoint_manager.py --operation <op> --name <name> [--step <step>] [--data '<json>']
+```
+
+**Examples:**
+
+```bash
+# Save a chapter outline checkpoint
+python3 src/tools/savepoint_manager.py --operation save --name my-story \
+  --step chapter_1/outline --data '{"title": "The Beginning", "scenes": 3}'
+
+# Load a savepoint
+python3 src/tools/savepoint_manager.py --operation load --name my-story \
+  --step chapter_1/outline
+
+# Check if a savepoint exists
+python3 src/tools/savepoint_manager.py --operation has --name my-story \
+  --step chapter_1/outline
+
+# List all savepoints for a story
+python3 src/tools/savepoint_manager.py --operation list --name my-story
+
+# Clear all savepoints for a story
+python3 src/tools/savepoint_manager.py --operation clear --name my-story
+```
+
+### Operations
+
+| Operation | Effect | Output |
+|-----------|--------|--------|
+| `save` | Serialises `--data` as a savepoint file under `savepoints/<step>.json` | `{"status": "saved", "step": "<step>"}` |
+| `load` | Reads and deserialises a savepoint file | `{"step": "<step>", "data": <value>}` |
+| `has` | Checks whether a savepoint file exists for the given step | `{"step": "<step>", "exists": true/false}` |
+| `list` | Scans the `savepoints/` directory for all saved steps | `{"savepoints": ["step_1", "step_2", ...]}` |
+| `clear` | Removes all savepoint files for the story | `{"status": "cleared"}` |
+
+### Hierarchical Step Names
+
+Step names can contain `/` separators to create a hierarchy:
+
+```
+savepoints/
+├── chapter_1/
+│   ├── outline.json
+│   ├── scene_1.json
+│   └── scene_2.json
+├── chapter_2/
+│   └── outline.json
+└── characters.json
+```
+
+This maps naturally to the story generation pipeline phases (outline, character sheets, per-chapter scenes, recaps).
+
+### Backward Compatibility
+
+The tool handles legacy savepoint files that use **Markdown with YAML frontmatter** format (from the original codebase). The `FilesystemSavepointRepository.load_savepoint()` method detects frontmatter-formatted files and parses them correctly, while new saves always use JSON format.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — result printed to stdout as JSON |
+| 1 | Domain error — story not found, savepoint not found |
+| 2 | Argument error — missing required `--step` or `--data` flag for the chosen operation |
+
+### Security
+
+- **Path traversal prevention (story name)** — story names are validated with `Path.is_relative_to()` to ensure they cannot escape the `stories/` directory
+- **Path traversal prevention (step name)** — step names are checked for `..` segments and validated with `is_relative_to()` to prevent escaping the `savepoints/` directory
+- **Shell injection prevention** — the TypeScript wrapper uses `execFileSync` with an argument array, never shell interpolation
+- **Async bridging** — the Python script bridges from sync CLI to async repository methods using `asyncio.run()`
+- **Test isolation** — the `STORIES_DIR` environment variable overrides the default stories directory, ensuring tests never touch production data
+
+---
+
 ## Adding a New Tool
 
 Follow this pattern to add tools to the system:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -255,10 +255,10 @@ python3 src/tools/savepoint_manager.py --operation clear --name my-story
 
 | Operation | Effect | Output |
 |-----------|--------|--------|
-| `save` | Serialises `--data` as a savepoint file under `savepoints/<step>.json` | `{"status": "saved", "step": "<step>"}` |
+| `save` | Serialises `--data` as a savepoint file under `savepoints/<step>.md` | `{"status": "saved", "step": "<step>"}` |
 | `load` | Reads and deserialises a savepoint file | `{"step": "<step>", "data": <value>}` |
 | `has` | Checks whether a savepoint file exists for the given step | `{"step": "<step>", "exists": true/false}` |
-| `list` | Scans the `savepoints/` directory for all saved steps | `{"savepoints": ["step_1", "step_2", ...]}` |
+| `list` | Scans the `savepoints/` directory for all saved steps | `{"savepoints": {"step_1": <data>, "step_2": <data>, ...}}` |
 | `clear` | Removes all savepoint files for the story | `{"status": "cleared"}` |
 
 ### Hierarchical Step Names
@@ -268,19 +268,19 @@ Step names can contain `/` separators to create a hierarchy:
 ```
 savepoints/
 ├── chapter_1/
-│   ├── outline.json
-│   ├── scene_1.json
-│   └── scene_2.json
+│   ├── outline.md
+│   ├── scene_1.md
+│   └── scene_2.md
 ├── chapter_2/
-│   └── outline.json
-└── characters.json
+│   └── outline.md
+└── characters.md
 ```
 
 This maps naturally to the story generation pipeline phases (outline, character sheets, per-chapter scenes, recaps).
 
 ### Backward Compatibility
 
-The tool handles legacy savepoint files that use **Markdown with YAML frontmatter** format (from the original codebase). The `FilesystemSavepointRepository.load_savepoint()` method detects frontmatter-formatted files and parses them correctly, while new saves always use JSON format.
+Savepoint files use **Markdown with YAML frontmatter** format. The `FilesystemSavepointRepository` reads and writes `.md` files with YAML frontmatter containing the serialised data.
 
 ### Exit Codes
 

--- a/src/infrastructure/storage/savepoint_repository.py
+++ b/src/infrastructure/storage/savepoint_repository.py
@@ -11,51 +11,53 @@ from domain.exceptions import StorageError
 
 class FilesystemSavepointRepository(SavepointRepository):
     """Filesystem-based savepoint repository implementation."""
-    
+
     def __init__(self, base_path: Path = Path("SavePoints")):
         self.base_path = Path(base_path)
         self.base_path.mkdir(exist_ok=True)
         self._current_story_dir: Optional[Path] = None
-    
+
     def set_story_directory(self, prompt_filename: str) -> None:
         """Set the savepoint directory for the current story based on prompt filename."""
         # Remove extension and create directory name
         story_name = Path(prompt_filename).stem
         self._current_story_dir = self.base_path / story_name
         self._current_story_dir.mkdir(exist_ok=True)
-    
+
     def _get_savepoint_path(self, step_name: str) -> Path:
         """Get the full path for a savepoint."""
         if not self._current_story_dir:
-            raise StorageError("Story directory not set. Call set_story_directory() first.")
-        
+            raise StorageError(
+                "Story directory not set. Call set_story_directory() first."
+            )
+
         # Handle subpath in step_name (e.g., 'some/handle' -> subfolder structure)
-        if '/' in step_name or '\\' in step_name:
+        if "/" in step_name or "\\" in step_name:
             # Split the step_name into path components
-            path_parts = step_name.replace('\\', '/').split('/')
+            path_parts = step_name.replace("\\", "/").split("/")
             # The last part is the filename, the rest are subdirectories
             filename = path_parts[-1]
             subdirs = path_parts[:-1]
-            
+
             # Create the full path with subdirectories
             savepoint_path = self._current_story_dir
             for subdir in subdirs:
                 savepoint_path = savepoint_path / subdir
-            
+
             # Ensure the directory exists
             savepoint_path.mkdir(parents=True, exist_ok=True)
-            
+
             # Return the full path with .md extension
             return savepoint_path / f"{filename}.md"
         else:
             # Simple case - just sanitize the step name
             safe_step_name = step_name.replace("/", "_").replace("\\", "_")
             return self._current_story_dir / f"{safe_step_name}.md"
-    
+
     def _is_scalar(self, data: Any) -> bool:
         """Check if data is a scalar value that can be stored as markdown."""
         return isinstance(data, (str, int, float, bool)) or data is None
-    
+
     def _is_supported_type(self, data: Any) -> bool:
         """Check if data is a supported type for savepoint storage."""
         if self._is_scalar(data):
@@ -63,15 +65,15 @@ class FilesystemSavepointRepository(SavepointRepository):
         if isinstance(data, (dict, list)):
             return True
         return False
-    
+
     def _extract_content_from_markdown(self, content: str) -> Any:
         """Extract the original value from markdown content."""
-        lines = content.split('\n')
-        
+        lines = content.split("\n")
+
         # Skip the header line
         if len(lines) < 2:
             return None
-        
+
         # Extract the value based on the type information
         if "**Type:** Boolean" in content:
             # Extract boolean value
@@ -97,8 +99,8 @@ class FilesystemSavepointRepository(SavepointRepository):
         else:
             # Extract string value (everything after the header)
             # Remove the first line (header) and join the rest
-            return '\n'.join(lines[1:]).strip()
-    
+            return "\n".join(lines[1:]).strip()
+
     async def save_savepoint(self, step_name: str, data: Any) -> None:
         """Save data to a savepoint."""
         try:
@@ -108,9 +110,9 @@ class FilesystemSavepointRepository(SavepointRepository):
                     f"Cannot save data of type {type(data).__name__}. "
                     f"Only str, int, float, bool, dict, list, and None are supported."
                 )
-            
+
             savepoint_path = self._get_savepoint_path(step_name)
-            
+
             # Handle different data types
             if data is None:
                 content = "# Savepoint: None\n\nThis savepoint contains no data."
@@ -124,195 +126,219 @@ class FilesystemSavepointRepository(SavepointRepository):
                     content = f"# Savepoint: {step_name}\n\n{data}"
             else:
                 # Handle complex data types (dict, list) with YAML frontmatter
-                if isinstance(data, dict) and "_frontmatter" in data and "_body" in data:
+                if (
+                    isinstance(data, dict)
+                    and "_frontmatter" in data
+                    and "_body" in data
+                ):
                     # Handle our new savepoint data structure
                     frontmatter = data["_frontmatter"]
                     body = data["_body"]
-                    
+
                     # Convert frontmatter to YAML
-                    yaml_frontmatter = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True)
-                    
+                    yaml_frontmatter = yaml.dump(
+                        frontmatter, default_flow_style=False, allow_unicode=True
+                    )
+
                     # Format the body content
                     if isinstance(body, str):
                         body_content = body
                     else:
-                        body_content = yaml.dump(body, default_flow_style=False, allow_unicode=True)
-                    
+                        body_content = yaml.dump(
+                            body, default_flow_style=False, allow_unicode=True
+                        )
+
                     content = f"---\n{yaml_frontmatter}---\n\n# Savepoint: {step_name}\n\n{body_content}"
                 else:
                     # Handle regular complex data types
-                    yaml_data = yaml.dump(data, default_flow_style=False, allow_unicode=True)
+                    yaml_data = yaml.dump(
+                        data, default_flow_style=False, allow_unicode=True
+                    )
                     content = f"---\n{yaml_data}---\n\n# Savepoint: {step_name}\n\nData saved in YAML frontmatter above."
-            
+
             # Save as markdown
             await asyncio.to_thread(
-                savepoint_path.write_text,
-                content,
-                encoding='utf-8'
+                savepoint_path.write_text, content, encoding="utf-8"
             )
         except Exception as e:
             raise StorageError(f"Failed to save savepoint {step_name}: {e}") from e
-    
+
     async def load_savepoint(self, step_name: str) -> Optional[Any]:
         """Load data from a savepoint."""
         try:
             savepoint_path = self._get_savepoint_path(step_name)
-            
+
             if not await asyncio.to_thread(savepoint_path.exists):
                 return None
-            
+
             # Load markdown content
             content = await asyncio.to_thread(
-                savepoint_path.read_text,
-                encoding='utf-8'
+                savepoint_path.read_text, encoding="utf-8"
             )
-            
+
             # Check if content has YAML frontmatter
-            if content.startswith('---'):
+            if content.startswith("---"):
                 # Extract YAML frontmatter
-                frontmatter_match = re.search(r'^---\s*\n(.*?)\n---\s*\n', content, re.DOTALL)
+                frontmatter_match = re.search(
+                    r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL
+                )
                 if frontmatter_match:
                     yaml_content = frontmatter_match.group(1)
                     try:
                         frontmatter_data = yaml.safe_load(yaml_content)
-                        
+
                         # Check if this is our new savepoint structure with _frontmatter and _body
-                        if isinstance(frontmatter_data, dict) and "_frontmatter" in frontmatter_data and "_body" in frontmatter_data:
+                        if (
+                            isinstance(frontmatter_data, dict)
+                            and "_frontmatter" in frontmatter_data
+                            and "_body" in frontmatter_data
+                        ):
                             # Return only the body content for backward compatibility
                             return frontmatter_data["_body"]
                         else:
-                            # Handle legacy format - extract content from markdown body
-                            # Remove the frontmatter and extract the actual content
-                            body_content = content[frontmatter_match.end():].strip()
-                            # Parse the markdown to extract the original value
-                            return self._extract_content_from_markdown(body_content)
+                            # Frontmatter IS the data (dict or list saved as YAML)
+                            return frontmatter_data
                     except yaml.YAMLError as e:
-                        raise StorageError(f"Failed to parse YAML frontmatter in savepoint {step_name}: {e}") from e
-            
+                        raise StorageError(
+                            f"Failed to parse YAML frontmatter in savepoint {step_name}: {e}"
+                        ) from e
+
             # Parse the markdown to extract the original value (legacy format)
             return self._extract_content_from_markdown(content)
-                
+
         except Exception as e:
             raise StorageError(f"Failed to load savepoint {step_name}: {e}") from e
-    
-    async def load_savepoint_with_metadata(self, step_name: str) -> Optional[Dict[str, Any]]:
+
+    async def load_savepoint_with_metadata(
+        self, step_name: str
+    ) -> Optional[Dict[str, Any]]:
         """Load savepoint with full metadata including frontmatter and body."""
         try:
             savepoint_path = self._get_savepoint_path(step_name)
-            
+
             if not await asyncio.to_thread(savepoint_path.exists):
                 return None
-            
+
             # Load markdown content
             content = await asyncio.to_thread(
-                savepoint_path.read_text,
-                encoding='utf-8'
+                savepoint_path.read_text, encoding="utf-8"
             )
-            
+
             # Check if content has YAML frontmatter
-            if content.startswith('---'):
+            if content.startswith("---"):
                 # Extract YAML frontmatter
-                frontmatter_match = re.search(r'^---\s*\n(.*?)\n---\s*\n', content, re.DOTALL)
+                frontmatter_match = re.search(
+                    r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL
+                )
                 if frontmatter_match:
                     yaml_content = frontmatter_match.group(1)
                     try:
                         frontmatter_data = yaml.safe_load(yaml_content)
-                        
+
                         # Check if this is our new savepoint structure with _frontmatter and _body
-                        if isinstance(frontmatter_data, dict) and "_frontmatter" in frontmatter_data and "_body" in frontmatter_data:
+                        if (
+                            isinstance(frontmatter_data, dict)
+                            and "_frontmatter" in frontmatter_data
+                            and "_body" in frontmatter_data
+                        ):
                             # Return the full structure
                             return frontmatter_data
                         else:
                             # This is our new savepoint structure where frontmatter contains metadata
                             # and the body content is in the markdown after the frontmatter
-                            body_content = content[frontmatter_match.end():].strip()
+                            body_content = content[frontmatter_match.end() :].strip()
                             # Extract the actual content from the markdown body
-                            actual_body = self._extract_content_from_markdown(body_content)
-                            
+                            actual_body = self._extract_content_from_markdown(
+                                body_content
+                            )
+
                             return {
                                 "_frontmatter": frontmatter_data,
-                                "_body": actual_body
+                                "_body": actual_body,
                             }
                     except yaml.YAMLError as e:
-                        raise StorageError(f"Failed to parse YAML frontmatter in savepoint {step_name}: {e}") from e
-            
+                        raise StorageError(
+                            f"Failed to parse YAML frontmatter in savepoint {step_name}: {e}"
+                        ) from e
+
             # For legacy format without frontmatter, wrap the content
             body_content = await self.load_savepoint(step_name)
-            return {
-                "_frontmatter": {"legacy_data": True},
-                "_body": body_content
-            }
-                
+            return {"_frontmatter": {"legacy_data": True}, "_body": body_content}
+
         except Exception as e:
-            raise StorageError(f"Failed to load savepoint with metadata {step_name}: {e}") from e
-    
+            raise StorageError(
+                f"Failed to load savepoint with metadata {step_name}: {e}"
+            ) from e
+
     async def has_savepoint(self, step_name: str) -> bool:
         """Check if a savepoint exists."""
         try:
             savepoint_path = self._get_savepoint_path(step_name)
             return await asyncio.to_thread(savepoint_path.exists)
         except Exception as e:
-            raise StorageError(f"Failed to check savepoint existence {step_name}: {e}") from e
-    
+            raise StorageError(
+                f"Failed to check savepoint existence {step_name}: {e}"
+            ) from e
+
     async def delete_savepoint(self, step_name: str) -> bool:
         """Delete a savepoint."""
         try:
             savepoint_path = self._get_savepoint_path(step_name)
-            
+
             if not await asyncio.to_thread(savepoint_path.exists):
                 return False
-            
+
             await asyncio.to_thread(savepoint_path.unlink)
             return True
         except Exception as e:
             raise StorageError(f"Failed to delete savepoint {step_name}: {e}") from e
-    
+
     async def list_savepoints(self) -> Dict[str, Any]:
         """List all available savepoints for the current story."""
         try:
             if not self._current_story_dir:
                 return {}
-            
+
             savepoints = {}
-            
+
             # Recursively find all .md files
             for file_path in await asyncio.to_thread(
                 self._current_story_dir.rglob, "*.md"
             ):
                 # Calculate the relative path from the story directory
                 relative_path = file_path.relative_to(self._current_story_dir)
-                
+
                 # Convert the file path back to the step name
                 # Remove .md extension and convert path separators
-                step_name = str(relative_path.with_suffix('')).replace('\\', '/')
-                
+                step_name = str(relative_path.with_suffix("")).replace("\\", "/")
+
                 try:
                     data = await self.load_savepoint(step_name)
                     savepoints[step_name] = data
                 except Exception:
                     # Skip corrupted savepoints
                     continue
-            
+
             return savepoints
         except Exception as e:
             raise StorageError(f"Failed to list savepoints: {e}") from e
-    
+
     async def clear_all_savepoints(self) -> None:
         """Clear all savepoints for the current story."""
         try:
             if not self._current_story_dir:
                 return
-            
+
             # Recursively remove all .md files
             for file_path in await asyncio.to_thread(
                 self._current_story_dir.rglob, "*.md"
             ):
                 await asyncio.to_thread(file_path.unlink)
-            
+
             # Remove empty directories
-            for dir_path in reversed(list(await asyncio.to_thread(
-                self._current_story_dir.rglob, "*"
-            ))):
+            for dir_path in reversed(
+                list(await asyncio.to_thread(self._current_story_dir.rglob, "*"))
+            ):
                 if dir_path.is_dir() and dir_path != self._current_story_dir:
                     try:
                         await asyncio.to_thread(dir_path.rmdir)
@@ -320,4 +346,4 @@ class FilesystemSavepointRepository(SavepointRepository):
                         # Directory not empty, skip
                         pass
         except Exception as e:
-            raise StorageError(f"Failed to clear savepoints: {e}") from e 
+            raise StorageError(f"Failed to clear savepoints: {e}") from e

--- a/src/tools/savepoint_manager.py
+++ b/src/tools/savepoint_manager.py
@@ -1,0 +1,171 @@
+"""CLI tool for managing story savepoints (save, load, has, list, clear)."""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+STORIES_DIR = Path(os.environ.get("STORIES_DIR", str(PROJECT_ROOT / "stories")))
+
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _validate_story_name(name: str) -> Path:
+    """Validate story name does not escape the stories directory."""
+    story_dir = (STORIES_DIR / name).resolve()
+    if not story_dir.is_relative_to(STORIES_DIR.resolve()):
+        print(
+            f"Error: story name escapes stories directory: {name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return story_dir
+
+
+def _validate_step(step: str, savepoints_dir: Path) -> None:
+    """Validate step name does not contain path traversal."""
+    if ".." in step:
+        print(
+            f"Error: step name must not contain '..': {step}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    resolved = (savepoints_dir / step).resolve()
+    if not resolved.is_relative_to(savepoints_dir.resolve()):
+        print(
+            f"Error: step name escapes savepoints directory: {step}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _make_repo(name: str) -> object:
+    """Create a FilesystemSavepointRepository for the given story."""
+    from infrastructure.storage.savepoint_repository import (
+        FilesystemSavepointRepository,
+    )
+
+    repo = FilesystemSavepointRepository(base_path=STORIES_DIR / name)
+    repo.set_story_directory("savepoints")
+    return repo
+
+
+def cmd_save(name: str, step: str, data_str: str) -> None:
+    """Save data to a savepoint."""
+    story_dir = _validate_story_name(name)
+    if not story_dir.exists():
+        print(f"Error: story not found: {name}", file=sys.stderr)
+        sys.exit(1)
+    _validate_step(step, story_dir / "savepoints")
+
+    try:
+        data = json.loads(data_str)
+    except json.JSONDecodeError:
+        data = data_str
+
+    repo = _make_repo(name)
+    asyncio.run(repo.save_savepoint(step, data))
+    print(json.dumps({"status": "saved", "step": step}, indent=2, default=str))
+
+
+def cmd_load(name: str, step: str) -> None:
+    """Load data from a savepoint."""
+    story_dir = _validate_story_name(name)
+    if not story_dir.exists():
+        print(f"Error: story not found: {name}", file=sys.stderr)
+        sys.exit(1)
+    _validate_step(step, story_dir / "savepoints")
+
+    repo = _make_repo(name)
+    data = asyncio.run(repo.load_savepoint(step))
+    print(json.dumps({"step": step, "data": data}, indent=2, default=str))
+
+
+def cmd_has(name: str, step: str) -> None:
+    """Check if a savepoint exists."""
+    story_dir = _validate_story_name(name)
+    if not story_dir.exists():
+        print(f"Error: story not found: {name}", file=sys.stderr)
+        sys.exit(1)
+    _validate_step(step, story_dir / "savepoints")
+
+    repo = _make_repo(name)
+    exists = asyncio.run(repo.has_savepoint(step))
+    print(json.dumps({"step": step, "exists": exists}, indent=2, default=str))
+
+
+def cmd_list(name: str) -> None:
+    """List all savepoints for a story."""
+    story_dir = _validate_story_name(name)
+    if not story_dir.exists():
+        print(f"Error: story not found: {name}", file=sys.stderr)
+        sys.exit(1)
+
+    repo = _make_repo(name)
+    savepoints = asyncio.run(repo.list_savepoints())
+    print(json.dumps({"savepoints": savepoints}, indent=2, default=str))
+
+
+def cmd_clear(name: str) -> None:
+    """Clear all savepoints for a story."""
+    _validate_story_name(name)
+
+    repo = _make_repo(name)
+    asyncio.run(repo.clear_all_savepoints())
+    print(json.dumps({"status": "cleared"}, indent=2, default=str))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage story savepoints.")
+    parser.add_argument(
+        "--operation",
+        required=True,
+        choices=["save", "load", "has", "list", "clear"],
+        help="Operation to perform",
+    )
+    parser.add_argument("--name", required=True, help="Story name")
+    parser.add_argument(
+        "--step",
+        default=None,
+        help="Step name (required for save/load/has)",
+    )
+    parser.add_argument(
+        "--data",
+        default=None,
+        help="Data to save (JSON string, required for save)",
+    )
+    args = parser.parse_args()
+
+    if args.operation == "save":
+        if not args.step:
+            print("Error: --step is required for save", file=sys.stderr)
+            sys.exit(2)
+        if args.data is None:
+            print("Error: --data is required for save", file=sys.stderr)
+            sys.exit(2)
+        cmd_save(args.name, args.step, args.data)
+
+    elif args.operation == "load":
+        if not args.step:
+            print("Error: --step is required for load", file=sys.stderr)
+            sys.exit(2)
+        cmd_load(args.name, args.step)
+
+    elif args.operation == "has":
+        if not args.step:
+            print("Error: --step is required for has", file=sys.stderr)
+            sys.exit(2)
+        cmd_has(args.name, args.step)
+
+    elif args.operation == "list":
+        cmd_list(args.name)
+
+    elif args.operation == "clear":
+        cmd_clear(args.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/savepoint_manager.py
+++ b/src/tools/savepoint_manager.py
@@ -1,11 +1,19 @@
 """CLI tool for managing story savepoints (save, load, has, list, clear)."""
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import json
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from infrastructure.storage.savepoint_repository import (
+        FilesystemSavepointRepository,
+    )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 STORIES_DIR = Path(os.environ.get("STORIES_DIR", str(PROJECT_ROOT / "stories")))
@@ -42,7 +50,7 @@ def _validate_step(step: str, savepoints_dir: Path) -> None:
         sys.exit(1)
 
 
-def _make_repo(name: str) -> object:
+def _make_repo(name: str) -> FilesystemSavepointRepository:
     """Create a FilesystemSavepointRepository for the given story."""
     from infrastructure.storage.savepoint_repository import (
         FilesystemSavepointRepository,
@@ -111,7 +119,10 @@ def cmd_list(name: str) -> None:
 
 def cmd_clear(name: str) -> None:
     """Clear all savepoints for a story."""
-    _validate_story_name(name)
+    story_dir = _validate_story_name(name)
+    if not story_dir.exists():
+        print(f"Error: story not found: {name}", file=sys.stderr)
+        sys.exit(1)
 
     repo = _make_repo(name)
     asyncio.run(repo.clear_all_savepoints())

--- a/tests/unit/test_savepoint_manager_tool.py
+++ b/tests/unit/test_savepoint_manager_tool.py
@@ -305,3 +305,17 @@ def test_missing_data_for_save(story_env: tuple[Path, str]) -> None:
         stories_dir=stories_dir,
     )
     assert result.returncode == 2
+
+
+def test_clear_nonexistent_story(tmp_path: Path) -> None:
+    stories_dir = tmp_path / "stories"
+    stories_dir.mkdir()
+    result = _run_tool(
+        "--operation",
+        "clear",
+        "--name",
+        "no-such-story",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1
+    assert "story not found" in result.stderr

--- a/tests/unit/test_savepoint_manager_tool.py
+++ b/tests/unit/test_savepoint_manager_tool.py
@@ -1,0 +1,307 @@
+"""Verification tests for Issue #7 — savepoint-mgr Tool.
+
+Confirms the CLI tool (src/tools/savepoint_manager.py) correctly manages
+story savepoints: save, load, has, list, and clear operations.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOL_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "savepoint_manager.py")
+
+
+@pytest.fixture()
+def story_env(tmp_path: Path) -> tuple[Path, str]:
+    """Provide a temp stories directory with a pre-created story."""
+    stories_dir = tmp_path / "stories"
+    story_name = "test-story"
+    (stories_dir / story_name / "savepoints").mkdir(parents=True)
+    return stories_dir, story_name
+
+
+def _run_tool(
+    *args: str, stories_dir: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    if stories_dir is not None:
+        env["STORIES_DIR"] = str(stories_dir)
+    return subprocess.run(
+        [sys.executable, TOOL_SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_save_and_load_string(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    save_result = _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        "--step",
+        "greeting",
+        "--data",
+        '"hello world"',
+        stories_dir=stories_dir,
+    )
+    assert save_result.returncode == 0, f"stderr: {save_result.stderr}"
+    save_out = json.loads(save_result.stdout)
+    assert save_out["status"] == "saved"
+
+    load_result = _run_tool(
+        "--operation",
+        "load",
+        "--name",
+        name,
+        "--step",
+        "greeting",
+        stories_dir=stories_dir,
+    )
+    assert load_result.returncode == 0, f"stderr: {load_result.stderr}"
+    load_out = json.loads(load_result.stdout)
+    assert load_out["step"] == "greeting"
+    assert load_out["data"] == "hello world"
+
+
+def test_save_and_load_dict(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    payload = {"title": "Chapter One", "word_count": 500}
+    save_result = _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        "--step",
+        "chapter_meta",
+        "--data",
+        json.dumps(payload),
+        stories_dir=stories_dir,
+    )
+    assert save_result.returncode == 0, f"stderr: {save_result.stderr}"
+
+    load_result = _run_tool(
+        "--operation",
+        "load",
+        "--name",
+        name,
+        "--step",
+        "chapter_meta",
+        stories_dir=stories_dir,
+    )
+    assert load_result.returncode == 0, f"stderr: {load_result.stderr}"
+    load_out = json.loads(load_result.stdout)
+    assert load_out["step"] == "chapter_meta"
+    assert load_out["data"] == payload
+
+
+def test_has_existing_step(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        "--step",
+        "chapter_1",
+        "--data",
+        '"some data"',
+        stories_dir=stories_dir,
+    )
+    result = _run_tool(
+        "--operation",
+        "has",
+        "--name",
+        name,
+        "--step",
+        "chapter_1",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["exists"] is True
+
+
+def test_has_missing_step(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    result = _run_tool(
+        "--operation",
+        "has",
+        "--name",
+        name,
+        "--step",
+        "nonexistent",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["exists"] is False
+
+
+def test_list_savepoints(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    for step in ("step_a", "step_b", "step_c"):
+        _run_tool(
+            "--operation",
+            "save",
+            "--name",
+            name,
+            "--step",
+            step,
+            "--data",
+            f'"{step} data"',
+            stories_dir=stories_dir,
+        )
+    result = _run_tool(
+        "--operation",
+        "list",
+        "--name",
+        name,
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    out = json.loads(result.stdout)
+    assert set(out["savepoints"].keys()) == {"step_a", "step_b", "step_c"}
+
+
+def test_clear_savepoints(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    for step in ("s1", "s2"):
+        _run_tool(
+            "--operation",
+            "save",
+            "--name",
+            name,
+            "--step",
+            step,
+            "--data",
+            '"x"',
+            stories_dir=stories_dir,
+        )
+    clear_result = _run_tool(
+        "--operation",
+        "clear",
+        "--name",
+        name,
+        stories_dir=stories_dir,
+    )
+    assert clear_result.returncode == 0, f"stderr: {clear_result.stderr}"
+    assert json.loads(clear_result.stdout)["status"] == "cleared"
+
+    list_result = _run_tool(
+        "--operation",
+        "list",
+        "--name",
+        name,
+        stories_dir=stories_dir,
+    )
+    assert list_result.returncode == 0
+    out = json.loads(list_result.stdout)
+    assert out["savepoints"] == {}
+
+
+def test_hierarchical_step_names(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    save_result = _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        "--step",
+        "chapter_1/scene_2",
+        "--data",
+        '"scene content"',
+        stories_dir=stories_dir,
+    )
+    assert save_result.returncode == 0, f"stderr: {save_result.stderr}"
+
+    load_result = _run_tool(
+        "--operation",
+        "load",
+        "--name",
+        name,
+        "--step",
+        "chapter_1/scene_2",
+        stories_dir=stories_dir,
+    )
+    assert load_result.returncode == 0, f"stderr: {load_result.stderr}"
+    load_out = json.loads(load_result.stdout)
+    assert load_out["step"] == "chapter_1/scene_2"
+    assert load_out["data"] == "scene content"
+
+
+def test_load_missing_step(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    result = _run_tool(
+        "--operation",
+        "load",
+        "--name",
+        name,
+        "--step",
+        "does_not_exist",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["data"] is None
+
+
+def test_path_traversal_blocked_name(story_env: tuple[Path, str]) -> None:
+    stories_dir, _ = story_env
+    result = _run_tool(
+        "--operation",
+        "list",
+        "--name",
+        "../etc/passwd",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1
+    assert "escapes stories directory" in result.stderr
+
+
+def test_path_traversal_blocked_step(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    result = _run_tool(
+        "--operation",
+        "has",
+        "--name",
+        name,
+        "--step",
+        "../../etc/passwd",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1
+    assert "must not contain '..'" in result.stderr
+
+
+def test_missing_step_for_save(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    result = _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 2
+
+
+def test_missing_data_for_save(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    result = _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        "--step",
+        "some_step",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary
Build the savepoint-mgr tool wrapping existing FilesystemSavepointRepository for CLI access to story savepoints (save/load/has/list/clear operations). Also fixes a dict round-trip bug in `FilesystemSavepointRepository.load_savepoint()`.

## Closes
Closes #7

## Changes
- [x] Implementation complete
- [x] All tests passing (verified)
- [x] Linting clean

## Plan
1. Python tool: `src/tools/savepoint_manager.py` — argparse CLI wrapping FilesystemSavepointRepository
2. TypeScript wrapper: `.opencode/tools/savepoint-mgr.ts` — Zod schema + execFileSync
3. Tests: `tests/unit/test_savepoint_manager_tool.py` — 12 test methods
4. Bug fix: `src/infrastructure/storage/savepoint_repository.py` — dict data round-trip in load_savepoint()

## Files Changed
- `.opencode/tools/savepoint-mgr.ts` — TypeScript tool definition
- `src/tools/savepoint_manager.py` — Python CLI implementation
- `tests/unit/test_savepoint_manager_tool.py` — 12 verification tests
- `src/infrastructure/storage/savepoint_repository.py` — Bug fix for dict data round-trip