### PR TITLE
Follow-up: outline-generator tool improvements from PR #45 review

### DIFF
--- a/.github/notes/reflections/issue-10-semantic-correctness-gap.md
+++ b/.github/notes/reflections/issue-10-semantic-correctness-gap.md
@@ -37,6 +37,10 @@ N. **Before handing off a multi-operation tool**, trace the data flow of each op
 
 This is complementary to existing rules: Rule 9 ensures secure patterns, proposed Rule 10 ensures established patterns carry forward, and this new rule ensures semantic correctness of the implemented logic.
 
+### Supporting Evidence
+
+- **Issue #46 (PR #47):** Coder applied savepoint-before-prompt ordering correctly in `cmd_expand_chapter()` but incorrectly in `cmd_generate_outline()` — same file, same dispatch. Intra-task variant of pattern inconsistency that data-flow tracing would catch. See `issue-46-intra-task-ordering-consistency.md`. Suggests the proposed rule should explicitly mention intra-tool consistency between similar operations.
+
 ### Action Taken
 
 Proposed for approval — this adds a new numbered rule to the Coder agent addressing a class of defect not covered by pattern-matching rules.

--- a/.github/notes/reflections/issue-10-system-health.md
+++ b/.github/notes/reflections/issue-10-system-health.md
@@ -1,0 +1,41 @@
+---
+date: "2026-04-14"
+issue: 10
+pr: 45
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+  - ".github/agents/orchestrator-v3.agent.md"
+severity: minor
+status: active
+---
+
+## Seventh tool implementation — most complex yet, pattern maturity continues
+
+### Finding
+
+Issue #10 (Build outline-generator Tool) was the most complex tool implementation to date: 5 operations (generate, review, refine, status, export), multi-turn conversation support via `generate_text_messages()`, and a resumable pipeline using savepoints. Positive signals:
+
+1. **All established patterns applied on first pass.** Path validation, savepoint usage, error handling to stderr, JSON output, `sys.path` guards — all correct without review-fix cycles. Seventh consecutive tool confirming pattern carry-forward.
+
+2. **`_llm.py` extended cleanly.** New `generate_text_messages()` function for conversation history, with `generate_text()` refactored to delegate to it (DRY improvement, M-W-02 review finding). Shared module pattern (`src/tools/_*.py`) continues to work well.
+
+3. **Test Writer produced 10 tests passing in one shot.** Continues the trend from issues #9 and #11 — the Test Writer's pattern-following is reliable.
+
+4. **Synthesized Review caught a genuine correctness bug** (U-C-01: feedback parameter ignored in refine). All three models flagged it. This validates the multi-model review approach — the bug was semantically invisible (no lint errors, no type errors, correct argument parsing) but functionally critical.
+
+5. **Code duplication in `_llm.py` caught and cleaned.** `generate_text()` was refactored to delegate to `generate_text_messages()` rather than duplicating the HTTP call logic (M-W-02). Clean DRY improvement.
+
+### Observation
+
+The tool implementation pipeline is now highly mature for pattern compliance, but issue #10 revealed a gap in semantic verification (separate reflection: issue-10-semantic-correctness-gap.md). The system reliably catches and fixes these via review, but pre-handoff self-verification would save a review-fix cycle.
+
+The pre-existing uncommitted changes observed in the working tree (agent files from prior sessions) reinforce the pending proposal from issue #11 (reflection file leakage to Step 5d).
+
+### Suggested Improvement
+
+No agent/skill/instruction changes needed. Positive signals recorded. The semantic correctness gap is tracked in the companion reflection note.
+
+### Action Taken
+
+No action needed — positive signal recorded.

--- a/.github/notes/reflections/issue-46-intra-task-ordering-consistency.md
+++ b/.github/notes/reflections/issue-46-intra-task-ordering-consistency.md
@@ -1,0 +1,41 @@
+---
+date: "2026-04-14"
+issue: 46
+pr: 47
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Coder applies operation ordering inconsistently between similar functions in the same tool
+
+### Finding
+
+During issue #46 (outline-generator improvements from PR #45 review), the Coder added savepoint resumability to two operations in `src/tools/outline_generator.py`. In `cmd_expand_chapter()`, the savepoint existence check was correctly placed before `_load_prompt()` — so if a savepoint already existed, the function would return early without incurring a prompt template load. In `cmd_generate_outline()`, the savepoint check was placed *after* `_load_prompt()`, inside the try/except block — meaning a prompt template failure would bypass the savepoint check entirely, and a valid savepoint would still trigger a redundant prompt load.
+
+The Synthesized Review caught this unanimously (Warning severity), and the Coder fixed it in one dispatch by moving the savepoint check before `_load_prompt()` in `cmd_generate_outline()`.
+
+### Observation
+
+This is an **intra-task** variant of the cross-task pattern amnesia documented in issue #6. Prior pattern amnesia observations involved the Coder failing to carry patterns between different tool implementations (issue #3: security patterns, issue #6: atomic writes). This instance is different — the Coder implemented the same pattern (savepoint resumability) in two functions *within the same file, in the same dispatch*, and got the ordering right in one but wrong in the other.
+
+Critically, the pending proposals from prior reflections would not have prevented this:
+
+- **Proposed Rule 10 (prior-tool review):** Addresses cross-tool pattern carry-forward — would not trigger for consistency within a single tool.
+- **Existing Rule 9 (security validation):** Covers subprocess/path/input validation patterns, not operation ordering.
+
+The proposed **semantic verification rule** from issue #10 (data-flow tracing before handoff) *would* catch this — if the Coder traces each operation's flow and compares similar operations for consistency, the ordering discrepancy becomes visible. This observation strengthens the case for that proposal and suggests it should explicitly mention intra-tool consistency: when multiple operations share a common pattern (e.g., savepoint resumability, state validation, prompt loading), verify the pattern implementation is consistent across all operations.
+
+### Suggested Improvement
+
+When the issue #10 semantic verification rule is approved and applied to the Coder agent, add explicit guidance about intra-tool consistency. Suggested wording for the rule (extending the proposed text):
+
+> ...Pay special attention to operations that accept user input — confirm the input reaches the LLM prompt or processing logic. **For tools with multiple operations sharing a common pattern (savepoint checks, input validation, prompt loading), verify the pattern is applied consistently across all operations — check ordering, error handling, and early-return conditions.**
+
+No standalone rule change is needed. This observation refines the existing pending proposal from issue #10.
+
+### Action Taken
+
+No immediate action needed — observation recorded to refine the pending semantic verification rule proposal (issue #10, `issue-10-semantic-correctness-gap.md`). Cross-reference added to that note.

--- a/.github/notes/reviews/2026-04-14-pr47-synthesis.md
+++ b/.github/notes/reviews/2026-04-14-pr47-synthesis.md
@@ -1,0 +1,33 @@
+## Synthesized Code Review — 2026-04-14
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-46-outline-generator-improvements
+**PR:** #47 | **Issue:** #46
+**Model Agreement Score:** 8/10
+**Overall Assessment:** Needs Fixes
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 1       | 1          |
+| ★★☆ Majority      | 0        | 0       | 0          |
+| ★☆☆ Singular      | 0        | 0       | 3          |
+
+### Key Findings
+
+- [U-W-01] Savepoint check after _load_prompt in cmd_generate_outline breaks resumability guarantee (★★★)
+- [U-S-01] Zod cross-field validation gap — no .refine() for relational constraints (★★★)
+- [S-S-01] Missing test for analyze-prompt resumability (★☆☆)
+- [S-S-02] Private _extract_json_block listed in docs public API description (★☆☆)
+- [S-S-03] Missing negative-value test case for numeric validation (★☆☆)
+
+### Divergences
+
+- [D-01] Severity of savepoint ordering issue — Claude: Critical, GPT: Warning, Gemini: Suggestion → resolved as Warning (correctness gap, but low-probability trigger)
+- [D-02] Severity of Zod cross-field gap — Claude: Warning, GPT: Suggestion, Gemini: Warning → resolved as Suggestion (Python layer catches all cases, docs are accurate)
+
+### Actions Required
+
+- Findings requiring fixes: 1 (U-W-01)
+- Findings deferred: 4 (suggestions — address at discretion)

--- a/.opencode/tools/outline-generator.ts
+++ b/.opencode/tools/outline-generator.ts
@@ -25,18 +25,26 @@ export default {
       ),
     desiredChapters: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe("Number of desired chapters (required for generate-outline)"),
     chunkStart: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe("Start chapter for chunk expansion (required for expand-chapter)"),
     chunkEnd: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe("End chapter for chunk expansion (required for expand-chapter)"),
     totalChapters: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe(
         "Total chapters in story (required for expand-chapter)"

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -667,7 +667,7 @@ Multi-step outline generation pipeline: analyses a story prompt via an 8-chunk L
 **Source files:**
 - `.opencode/tools/outline-generator.ts` — TypeScript wrapper
 - `src/tools/outline_generator.py` — Python CLI script
-- `src/tools/_llm.py` — LLM access layer (`generate_text`, `generate_text_messages`)
+- `src/tools/_llm.py` — Shared LLM client (`generate_text`, `generate_text_messages`, `_extract_json_block`)
 - `src/infrastructure/prompts/prompt_loader.py` — Prompt template loading
 - `src/infrastructure/storage/savepoint_repository.py` — Savepoint persistence
 
@@ -684,10 +684,10 @@ The tool uses `generate_text_messages()` from `src/tools/_llm.py` to maintain mu
 | `operation` | `"analyze-prompt" \| "generate-elements" \| "generate-outline" \| "expand-chapter" \| "refine"` | Yes | Operation to perform |
 | `name` | string | Yes | Story name (directory under `stories/`) |
 | `prompt` | string | For `analyze-prompt`; optional for `generate-outline` | Story prompt text |
-| `desiredChapters` | number | For `generate-outline` | Number of desired chapters |
-| `chunkStart` | number | For `expand-chapter` | Start chapter for chunk expansion |
-| `chunkEnd` | number | For `expand-chapter` | End chapter for chunk expansion |
-| `totalChapters` | number | For `expand-chapter` | Total chapters in the story |
+| `desiredChapters` | integer | For `generate-outline` | Number of desired chapters (must be ≥ 1) |
+| `chunkStart` | integer | For `expand-chapter` | Start chapter for chunk expansion (must be ≥ 1) |
+| `chunkEnd` | integer | For `expand-chapter` | End chapter for chunk expansion (must be ≥ `chunkStart`) |
+| `totalChapters` | integer | For `expand-chapter` | Total chapters in the story (must be ≥ `chunkEnd`) |
 | `previousChunks` | string | No | Previous chunk outlines text (for `expand-chapter` continuity) |
 | `continuitySummary` | string | No | Continuity summary from prior chunks (for `expand-chapter`) |
 | `feedback` | string | For `refine` | Critique/feedback text to apply |
@@ -780,9 +780,11 @@ All intermediate results are persisted under `stories/<name>/savepoints/`:
 
 ### Resumability
 
-Each sub-step checks `_has_savepoint()` before calling the LLM. If a savepoint exists, the saved result is loaded and the LLM call is skipped. This means:
+All LLM-calling operations check `_has_savepoint()` before invoking the model. If a savepoint exists, the saved result is loaded and the LLM call is skipped. This means:
 
 - If `analyze-prompt` fails on chunk 5, re-running it resumes from chunk 5 — chunks 1–4 are loaded from savepoints
+- `generate-outline` checks for an existing `initial_outline` savepoint before calling the LLM
+- `expand-chapter` checks for existing `outline_chunk_N_M` and `continuity_N_M` savepoints before calling the LLM
 - Conversation history is reconstructed from saved chunks to maintain coherent multi-turn context
 - The `generate-elements` operation is purely deterministic (no LLM) — it concatenates saved chunks
 
@@ -803,12 +805,21 @@ The tool uses `src/tools/_llm.py` for LLM access, configured via environment var
 
 The `--model` argument overrides `LLM_MODEL` for a single invocation.
 
+### Argument Validation
+
+Numeric arguments are validated at both layers:
+
+- **TypeScript (Zod)** — `desiredChapters`, `chunkStart`, `chunkEnd`, and `totalChapters` are validated as positive integers (`.int().min(1)`)
+- **Python (argparse)** — `--desired-chapters` must be ≥ 1; `--chunk-start` must be ≥ 1; `--chunk-end` must be ≥ `--chunk-start`; `--total-chapters` must be ≥ `--chunk-end`
+
+Invalid values produce exit code 1 with a descriptive error message.
+
 ### Exit Codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success — result printed to stdout as JSON |
-| 1 | Domain error — missing prerequisite savepoints, LLM failure |
+| 1 | Domain error — missing prerequisite savepoints, LLM failure, invalid numeric arguments |
 | 2 | Argument error — missing required flag for the chosen operation |
 
 ### Security

--- a/src/tools/_llm.py
+++ b/src/tools/_llm.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import re
 
@@ -145,29 +144,3 @@ def _extract_json_block(text: str) -> str:
 
     # Fallback — return from start to end
     return text[start:]
-
-
-def generate_json(
-    prompt: str,
-    *,
-    system_message: str | None = None,
-    model: str | None = None,
-) -> dict | list:
-    """Call LLM, extract JSON from response, parse and return.
-
-    Raises ``RuntimeError`` on API errors; ``ValueError`` on parse errors.
-    """
-    raw = generate_text(prompt, system_message=system_message, model=model)
-    json_str = _extract_json_block(raw)
-
-    try:
-        result = json.loads(json_str)
-    except json.JSONDecodeError as exc:
-        raise ValueError(
-            f"Failed to parse JSON from LLM response: {exc}\n"
-            f"Extracted text: {json_str[:500]}"
-        ) from exc
-
-    if not isinstance(result, (dict, list)):
-        raise ValueError(f"Expected JSON object or array, got {type(result).__name__}")
-    return result

--- a/src/tools/outline_generator.py
+++ b/src/tools/outline_generator.py
@@ -306,26 +306,26 @@ def cmd_generate_outline(
         _error("--prompt is required when understand_prompt savepoint missing")
         return  # unreachable
 
-    try:
-        outline_prompt = _load_prompt(
-            "outline/create",
-            {
-                "prompt": prompt_text,
-                "story_elements": story_elements,
-                "base_context": base_context,
-                "desired_chapters": str(desired_chapters),
-            },
-        )
-        if _has_savepoint(repo, "initial_outline"):
-            outline_text = _load_savepoint(repo, "initial_outline")
-            if not isinstance(outline_text, str):
-                outline_text = json.dumps(outline_text, default=str)
-        else:
+    if _has_savepoint(repo, "initial_outline"):
+        outline_text = _load_savepoint(repo, "initial_outline")
+        if not isinstance(outline_text, str):
+            outline_text = json.dumps(outline_text, default=str)
+    else:
+        try:
+            outline_prompt = _load_prompt(
+                "outline/create",
+                {
+                    "prompt": prompt_text,
+                    "story_elements": story_elements,
+                    "base_context": base_context,
+                    "desired_chapters": str(desired_chapters),
+                },
+            )
             outline_text = _call_llm(outline_prompt, model=model)
             _save_savepoint(repo, "initial_outline", outline_text)
-        _success("generate-outline", {"outline": outline_text})
-    except Exception as exc:
-        _error(f"outline generation failed: {exc}")
+        except Exception as exc:
+            _error(f"outline generation failed: {exc}")
+    _success("generate-outline", {"outline": outline_text})
 
 
 def cmd_expand_chapter(

--- a/src/tools/outline_generator.py
+++ b/src/tools/outline_generator.py
@@ -316,8 +316,13 @@ def cmd_generate_outline(
                 "desired_chapters": str(desired_chapters),
             },
         )
-        outline_text = _call_llm(outline_prompt, model=model)
-        _save_savepoint(repo, "initial_outline", outline_text)
+        if _has_savepoint(repo, "initial_outline"):
+            outline_text = _load_savepoint(repo, "initial_outline")
+            if not isinstance(outline_text, str):
+                outline_text = json.dumps(outline_text, default=str)
+        else:
+            outline_text = _call_llm(outline_prompt, model=model)
+            _save_savepoint(repo, "initial_outline", outline_text)
         _success("generate-outline", {"outline": outline_text})
     except Exception as exc:
         _error(f"outline generation failed: {exc}")
@@ -352,76 +357,85 @@ def cmd_expand_chapter(
 
     # --- Generate chunk outline ---
     chunk_step = f"outline_chunk_{chunk_start}_{chunk_end}"
-    try:
-        chunk_prompt = _load_prompt(
-            "outline/create_chunk",
-            {
-                "story_elements": story_elements,
-                "base_context": base_context,
-                "chunk_start": str(chunk_start),
-                "chunk_end": str(chunk_end),
-                "total_chapters": str(total_chapters),
-                "previous_chunks": previous_chunks,
-                "continuity_summary": continuity_summary,
-            },
-        )
-        chunk_text = _call_llm(chunk_prompt, model=model)
-        _save_savepoint(repo, chunk_step, chunk_text)
-    except Exception as exc:
-        _error(f"chunk expansion failed: {exc}")
-        return  # unreachable
+    if _has_savepoint(repo, chunk_step):
+        chunk_text = _load_savepoint(repo, chunk_step)
+        if not isinstance(chunk_text, str):
+            chunk_text = json.dumps(chunk_text, default=str)
+    else:
+        try:
+            chunk_prompt = _load_prompt(
+                "outline/create_chunk",
+                {
+                    "story_elements": story_elements,
+                    "base_context": base_context,
+                    "chunk_start": str(chunk_start),
+                    "chunk_end": str(chunk_end),
+                    "total_chapters": str(total_chapters),
+                    "previous_chunks": previous_chunks,
+                    "continuity_summary": continuity_summary,
+                },
+            )
+            chunk_text = _call_llm(chunk_prompt, model=model)
+            _save_savepoint(repo, chunk_step, chunk_text)
+        except Exception as exc:
+            _error(f"chunk expansion failed: {exc}")
+            return  # unreachable
 
     # --- Analyze continuity ---
-    continuity_analysis = ""
-    try:  # noqa: SIM105
-        # Determine last chapter in previous chunks
-        last_prev = str(chunk_start - 1) if chunk_start > 1 else "0"
+    continuity_step = f"continuity_{chunk_start}_{chunk_end}"
+    if _has_savepoint(repo, continuity_step):
+        continuity_analysis = _load_savepoint(repo, continuity_step)
+        if not isinstance(continuity_analysis, str):
+            continuity_analysis = json.dumps(continuity_analysis, default=str)
+    else:
+        continuity_analysis = ""
+        try:
+            # Determine last chapter in previous chunks
+            last_prev = str(chunk_start - 1) if chunk_start > 1 else "0"
 
-        # Load enrichment suggestions if available
-        enrichment = ""
-        if _has_savepoint(repo, "enrichment_suggestions"):
-            enr_data = _load_savepoint(repo, "enrichment_suggestions")
-            enrichment = (
-                enr_data
-                if isinstance(enr_data, str)
-                else json.dumps(enr_data, default=str)
+            # Load enrichment suggestions if available
+            enrichment = ""
+            if _has_savepoint(repo, "enrichment_suggestions"):
+                enr_data = _load_savepoint(repo, "enrichment_suggestions")
+                enrichment = (
+                    enr_data
+                    if isinstance(enr_data, str)
+                    else json.dumps(enr_data, default=str)
+                )
+
+            # Build combined previous chunks text including this new chunk
+            all_previous = previous_chunks
+            if all_previous:
+                all_previous += "\n\n"
+            all_previous += chunk_text
+
+            continuity_prompt = _load_prompt(
+                "outline/analyze_continuity",
+                {
+                    "story_elements": story_elements,
+                    "base_context": base_context,
+                    "enrichment_suggestions": enrichment,
+                    "previous_chunks": all_previous,
+                    "chunk_start": str(chunk_end + 1),
+                    "chunk_end": str(
+                        min(chunk_end + (chunk_end - chunk_start + 1), total_chapters)
+                    ),
+                    "total_chapters": str(total_chapters),
+                    "last_chapter_in_previous": last_prev,
+                },
             )
-
-        # Build combined previous chunks text including this new chunk
-        all_previous = previous_chunks
-        if all_previous:
-            all_previous += "\n\n"
-        all_previous += chunk_text
-
-        continuity_prompt = _load_prompt(
-            "outline/analyze_continuity",
-            {
-                "story_elements": story_elements,
-                "base_context": base_context,
-                "enrichment_suggestions": enrichment,
-                "previous_chunks": all_previous,
-                "chunk_start": str(chunk_end + 1),
-                "chunk_end": str(
-                    min(chunk_end + (chunk_end - chunk_start + 1), total_chapters)
-                ),
-                "total_chapters": str(total_chapters),
-                "last_chapter_in_previous": last_prev,
-            },
-        )
-        continuity_analysis = _call_llm(continuity_prompt, model=model)
-        _save_savepoint(
-            repo, f"continuity_{chunk_start}_{chunk_end}", continuity_analysis
-        )
-    except Exception as exc:
-        print(
-            f"Warning: continuity analysis failed: {exc}",
-            file=sys.stderr,
-        )
+            continuity_analysis = _call_llm(continuity_prompt, model=model)
+            _save_savepoint(repo, continuity_step, continuity_analysis)
+        except Exception as exc:
+            print(
+                f"Warning: continuity analysis failed: {exc}",
+                file=sys.stderr,
+            )
 
     _success(
         "expand-chapter",
         {
-            "chunk_outline": chunk_text,  # bound in try above; _error exits on failure
+            "chunk_outline": chunk_text,
             "continuity_analysis": continuity_analysis,
         },
     )
@@ -585,6 +599,8 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(2)
+        if args.desired_chapters < 1:
+            _error("--desired-chapters must be >= 1")
         cmd_generate_outline(
             args.name,
             args.desired_chapters,
@@ -603,6 +619,12 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(2)
+        if args.chunk_start < 1:
+            _error("--chunk-start must be >= 1")
+        if args.chunk_end < args.chunk_start:
+            _error("--chunk-end must be >= --chunk-start")
+        if args.total_chapters < args.chunk_end:
+            _error("--total-chapters must be >= --chunk-end")
         cmd_expand_chapter(
             args.name,
             args.chunk_start,

--- a/tests/unit/test_outline_generator_tool.py
+++ b/tests/unit/test_outline_generator_tool.py
@@ -1,7 +1,8 @@
-"""Verification tests for Issue #10 — outline-generator Tool.
+"""Verification tests for outline-generator Tool.
 
 Confirms the CLI tool (src/tools/outline_generator.py) correctly handles
-error paths, input validation, and the non-LLM generate-elements operation.
+error paths, input validation, the non-LLM generate-elements operation,
+savepoint resumability, and numeric argument validation.
 """
 
 import json
@@ -11,6 +12,8 @@ import sys
 from pathlib import Path
 
 import pytest
+
+import src.tools.outline_generator as og
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "outline_generator.py")
@@ -260,3 +263,331 @@ def test_invalid_operation(story_env: tuple[Path, str]) -> None:
         stories_dir=stories_dir,
     )
     assert result.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Fixture: monkeypatched environment for direct function calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def patched_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    """Redirect STORIES_DIR and stub _load_prompt for direct function calls."""
+    stories_dir = tmp_path / "stories"
+    story_name = "test-story"
+    (stories_dir / story_name / "savepoints").mkdir(parents=True)
+
+    monkeypatch.setattr(og, "STORIES_DIR", stories_dir)
+    monkeypatch.setattr(og, "_load_prompt", lambda *_a, **_kw: "mock prompt text")
+
+    return stories_dir, story_name
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze-prompt happy path (monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_prompt_happy_path(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Monkeypatch LLM calls; verify all savepoints created by analyze-prompt."""
+    stories_dir, name = patched_env
+
+    call_count: dict[str, int] = {"llm": 0, "messages": 0}
+
+    def fake_call_llm(prompt: str, *, model: str | None = None) -> str:
+        call_count["llm"] += 1
+        return "Fake LLM single response"
+
+    def fake_call_llm_messages(
+        messages: list[dict[str, str]], *, model: str | None = None
+    ) -> str:
+        call_count["messages"] += 1
+        return f"Fake LLM message response #{call_count['messages']}"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+    monkeypatch.setattr(og, "_call_llm_messages", fake_call_llm_messages)
+
+    og.cmd_analyze_prompt(name, "Write a story about dragons", model="test-model")
+
+    repo = og._make_repo(name)
+    # understand_prompt savepoint
+    assert og._has_savepoint(repo, "understand_prompt")
+    # 8 analysis chunk savepoints
+    for chunk_type in CHUNK_TYPES:
+        assert og._has_savepoint(repo, f"story_analysis/{chunk_type}_chunk")
+    # story_start_date and base_context
+    assert og._has_savepoint(repo, "story_start_date")
+    assert og._has_savepoint(repo, "base_context")
+
+    # Verify success JSON on stdout
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "analyze-prompt"
+    assert out["data"]["chunks_generated"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Test: generate-outline happy path (monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_outline_happy_path(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate prerequisites; verify initial_outline savepoint created."""
+    stories_dir, name = patched_env
+
+    # Pre-populate required savepoints
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+
+    def fake_call_llm(prompt: str, *, model: str | None = None) -> str:
+        return "Chapter 1: The Beginning\nChapter 2: The Middle"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+
+    og.cmd_generate_outline(
+        name, 10, prompt="Write a story about dragons", model="test-model"
+    )
+
+    repo = og._make_repo(name)
+    assert og._has_savepoint(repo, "initial_outline")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "generate-outline"
+    assert "outline" in out["data"]
+
+
+# ---------------------------------------------------------------------------
+# Test: generate-outline resumable (cached savepoint skips LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_outline_resumable(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate initial_outline; LLM should NOT be called."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+    _write_savepoint(stories_dir, name, "initial_outline", "Cached outline")
+
+    def llm_should_not_be_called(prompt: str, *, model: str | None = None) -> str:
+        raise AssertionError("_call_llm should not be called when savepoint exists")
+
+    monkeypatch.setattr(og, "_call_llm", llm_should_not_be_called)
+
+    og.cmd_generate_outline(
+        name, 10, prompt="Write a story about dragons", model="test-model"
+    )
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert "Cached outline" in out["data"]["outline"]
+
+
+# ---------------------------------------------------------------------------
+# Test: expand-chapter happy path (monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_expand_chapter_happy_path(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate prerequisites; verify outline_chunk and continuity savepoints."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+
+    call_count = 0
+
+    def fake_call_llm(prompt: str, *, model: str | None = None) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return "Expanded chapters 1-3 outline"
+        return "Continuity analysis for chapters 1-3"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+
+    og.cmd_expand_chapter(name, 1, 3, 10, model="test-model")
+
+    repo = og._make_repo(name)
+    assert og._has_savepoint(repo, "outline_chunk_1_3")
+    assert og._has_savepoint(repo, "continuity_1_3")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "expand-chapter"
+    assert "chunk_outline" in out["data"]
+    assert "continuity_analysis" in out["data"]
+
+
+# ---------------------------------------------------------------------------
+# Test: expand-chapter resumable (cached savepoints skip LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_expand_chapter_resumable(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate chunk + continuity savepoints; LLM should NOT be called."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+    _write_savepoint(stories_dir, name, "outline_chunk_1_3", "Cached chunk")
+    _write_savepoint(stories_dir, name, "continuity_1_3", "Cached continuity")
+
+    def llm_should_not_be_called(prompt: str, *, model: str | None = None) -> str:
+        raise AssertionError("_call_llm should not be called when savepoints exist")
+
+    monkeypatch.setattr(og, "_call_llm", llm_should_not_be_called)
+
+    og.cmd_expand_chapter(name, 1, 3, 10, model="test-model")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert "Cached chunk" in out["data"]["chunk_outline"]
+    assert "Cached continuity" in out["data"]["continuity_analysis"]
+
+
+# ---------------------------------------------------------------------------
+# Test: refine happy path (monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_refine_happy_path(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate prerequisites; verify refined_outline savepoint and feedback included."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "initial_outline", "Original outline")
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+
+    received_prompts: list[str] = []
+
+    def fake_call_llm(prompt: str, *, model: str | None = None) -> str:
+        received_prompts.append(prompt)
+        return "Refined outline with stronger ending"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+
+    og.cmd_refine(name, "Make the ending stronger", model="test-model")
+
+    repo = og._make_repo(name)
+    assert og._has_savepoint(repo, "refined_outline")
+
+    # Verify feedback was incorporated into the prompt
+    assert len(received_prompts) == 1
+    assert "Make the ending stronger" in received_prompts[0]
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "refine"
+    assert "Refined outline with stronger ending" in out["data"]["refined_outline"]
+
+
+# ---------------------------------------------------------------------------
+# Test: numeric argument validation (subprocess, matching existing pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "extra_args,expected_err",
+    [
+        # --desired-chapters must be >= 1
+        (
+            ["--operation", "generate-outline", "--desired-chapters", "0"],
+            "desired-chapters must be >= 1",
+        ),
+        # --chunk-start must be >= 1
+        (
+            [
+                "--operation",
+                "expand-chapter",
+                "--chunk-start",
+                "0",
+                "--chunk-end",
+                "3",
+                "--total-chapters",
+                "10",
+            ],
+            "chunk-start must be >= 1",
+        ),
+        # --chunk-end must be >= --chunk-start
+        (
+            [
+                "--operation",
+                "expand-chapter",
+                "--chunk-start",
+                "5",
+                "--chunk-end",
+                "3",
+                "--total-chapters",
+                "10",
+            ],
+            "chunk-end must be >= --chunk-start",
+        ),
+        # --total-chapters must be >= --chunk-end
+        (
+            [
+                "--operation",
+                "expand-chapter",
+                "--chunk-start",
+                "1",
+                "--chunk-end",
+                "5",
+                "--total-chapters",
+                "3",
+            ],
+            "total-chapters must be >= --chunk-end",
+        ),
+    ],
+    ids=[
+        "desired_chapters_zero",
+        "chunk_start_zero",
+        "chunk_end_lt_start",
+        "total_lt_chunk_end",
+    ],
+)
+def test_numeric_validation_errors(
+    story_env: tuple[Path, str],
+    extra_args: list[str],
+    expected_err: str,
+) -> None:
+    """Numeric boundary violations exit with error containing expected message."""
+    stories_dir, name = story_env
+    result = _run_tool(
+        *extra_args,
+        "--name",
+        name,
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1
+    assert expected_err in result.stderr


### PR DESCRIPTION
## Summary
Addresses four follow-up findings from the PR #45 synthesized review:
1. Mock-based happy-path tests for LLM-calling operations
2. Savepoint-based resumability for generate-outline and expand-chapter
3. Dead code removal (generate_json)
4. Numeric argument validation

## Closes
Closes #46

## Changes
- [x] Remove `generate_json()` from `_llm.py` [S-W-02]
- [x] Add savepoint resumability to `cmd_generate_outline()` [S-W-01]
- [x] Add savepoint resumability to `cmd_expand_chapter()` [S-W-01]
- [x] Numeric argument validation in Python CLI [S-I-01]
- [x] Zod `.int().min(1)` validation in TypeScript wrapper [S-I-01]
- [x] Mock-based happy-path tests for all 4 LLM operations [M-W-04]
- [x] Numeric validation error tests [S-I-01]
- [x] All tests passing (verified)
- [x] Linting clean