### PR TITLE
Build scene-writer Tool

### DIFF
--- a/.github/notes/reflections/issue-12-dead-code-template-residue.md
+++ b/.github/notes/reflections/issue-12-dead-code-template-residue.md
@@ -1,0 +1,38 @@
+---
+date: "2026-04-14"
+issue: 12
+pr: 48
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Dead code from template-copying persists despite Rule 7
+
+### Finding
+
+During issue #12 (Build scene-writer Tool), the Coder copied the outline-generator as a template and left behind: (1) `_call_llm_messages()` — a function defined but never called by any scene-writer operation, and (2) a dead `scenes` list variable in the assemble-chapter loop. Both caught by the Synthesized Review (U-W-01, unanimous).
+
+### Observation
+
+This is the third occurrence of dead code slipping through after Rule 7 was expanded to include dead code sweeps (issue #9):
+
+| Issue | Dead Code | Rule 7 status |
+| ----- | --------- | ------------- |
+| #9 | `_call_llm_json()` in `_llm.py` | Pre-expansion (prompted the rule change) |
+| #10 | None flagged | Rule 7 working |
+| #12 | `_call_llm_messages()`, dead `scenes` variable | Rule 7 not applied |
+
+The Rule 7 text is clear: "sweep newly created or heavily modified files for dead code — unused functions, unreachable branches, abandoned helpers — especially in shared modules where iterative development leaves artifacts." The issue is intermittent compliance, not insufficient rule text.
+
+Template-copying is a specific trigger: when the Coder uses an existing tool as a starting template, functions from the template that aren't needed by the new tool persist as dead code. This is distinct from iterative development artifacts (abandoned approaches within the current task).
+
+### Suggested Improvement
+
+No rule text change. The rule is clear and comprehensive. Adding more sub-clauses to a rule that's already intermittently applied won't improve compliance. The pending semantic verification rule (issue #10 proposal) would catch these as part of data-flow tracing — a function defined but never called is immediately visible when tracing operation flows.
+
+### Action Taken
+
+No action needed — observation recorded. Pattern reinforces the case for the pending semantic verification rule (issue #10).

--- a/.github/notes/reflections/issue-12-system-health.md
+++ b/.github/notes/reflections/issue-12-system-health.md
@@ -1,0 +1,41 @@
+---
+date: "2026-04-14"
+issue: 12
+pr: 48
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+  - ".github/agents/orchestrator-v3.agent.md"
+severity: minor
+status: active
+---
+
+## Eighth tool implementation — clean pattern adherence, stale count recurrence
+
+### Finding
+
+Issue #12 (Build scene-writer Tool) was the eighth tool implementation: 4 operations (parse-definitions, generate, revise, assemble-chapter), with multi-scene assembly and definitions-driven generation. Positive signals:
+
+1. **Implementation followed outline-generator pattern well.** Clean copy-and-adapt approach. Path validation, savepoint usage, error handling to stderr, JSON output — all applied on first pass.
+
+2. **Synthesized Review found no critical issues.** Three warnings (all fixable), one suggestion. Model agreement score 9/10 — highest consistency yet for a tool review.
+
+3. **All fixes applied cleanly in one dispatch.** 136 tests pass, lint clean. No regression from review fixes.
+
+4. **Stale prompt count recurrence.** `docs/tools.md` said "131 prompt templates" when the correct count was 132 (U-W-03). This is the fifth occurrence of the stale-docs pattern (issues #4, #5, #11, #30, #12). Rule 6 already covers this explicitly: "when adding or removing an item from a set that may be counted or inventoried in documentation, grep for the old count." The Coder is not consistently running this check.
+
+5. **Pre-existing mypy issues with `sys.path`-based imports.** Systemic issue across all tools in `src/tools/` — `sys.path.insert(0, ...)` prevents mypy from resolving imports. Not an agent system issue; needs a structural fix (e.g., proper packaging or mypy path configuration).
+
+### Observation
+
+The tool implementation pipeline continues to mature. Pattern carry-forward for security (Rule 9) and structural patterns is reliable. The remaining recurring issues — dead code (Rule 7) and stale counts (Rule 6) — are _compliance gaps_ rather than rule gaps. The rules exist and are clear; they're just not consistently executed.
+
+This suggests the value of the pending semantic verification rule (issue #10) is high: it forces the Coder to trace through each operation systematically, which would naturally surface both dead code and count mismatches as side effects of a thorough pre-handoff review.
+
+### Suggested Improvement
+
+No agent/skill/instruction changes needed. Positive signals and recurring patterns recorded.
+
+### Action Taken
+
+No action needed — positive signal recorded.

--- a/.github/notes/reviews/2026-04-14-pr48-synthesis.md
+++ b/.github/notes/reviews/2026-04-14-pr48-synthesis.md
@@ -1,0 +1,35 @@
+## Synthesized Code Review — 2026-04-14
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-12-scene-writer-tool
+**PR:** #48 (Issue #12 — Build scene-writer Tool)
+**Model Agreement Score:** 9/10
+**Overall Assessment:** Needs Minor Fixes
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 3       | 1          |
+| ★★☆ Majority      | 0        | 0       | 1          |
+| ★☆☆ Singular      | 0        | 0       | 5          |
+
+### Key Findings
+
+- [U-W-01] Dead code: `_call_llm_messages` defined but never used (★★★)
+- [U-W-02] Repeated definitions savepoint loading inside assemble-chapter loop (★★★)
+- [U-W-03] Stale prompt template count "131" in docs/tools.md — should be 132 (★★★)
+- [U-S-01] `count_tokens` added to `_llm.py` but unused by any production code (★★★)
+- [M-S-01] `_error()` return type should be `NoReturn` instead of `None` (★★☆)
+
+### Divergences
+
+- [D-01] Stale prompt count severity: Claude=Suggestion, GPT/Gemini=Warning → resolved as Warning (majority)
+- [D-02] count_tokens unused severity: Claude=Warning, GPT/Gemini=Suggestion → resolved as Suggestion (majority)
+- [D-03] `_error()` NoReturn: Claude=Suggestion, GPT=not flagged, Gemini=Warning → resolved as Suggestion (majority flags, lower severity chosen)
+
+### Actions Required
+
+- Findings requiring fixes: 3 (U-W-01, U-W-02, U-W-03)
+- Findings recommended: 2 (U-S-01, M-S-01)
+- Findings deferred: 5 (singular suggestions — no action needed for merge)

--- a/.opencode/tools/scene-writer.ts
+++ b/.opencode/tools/scene-writer.ts
@@ -1,0 +1,205 @@
+import { z } from "zod";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "scene-writer",
+  description:
+    "Scene writing pipeline: parse chapter outline into scene definitions, generate individual scenes, revise scenes with feedback, or assemble scenes into a chapter.",
+  parameters: z.object({
+    operation: z
+      .enum(["parse-definitions", "generate", "revise", "assemble-chapter"])
+      .describe("Operation to perform"),
+    name: z.string().describe("Story name (directory under stories/)"),
+    chapterNum: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Chapter number"),
+    sceneNum: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Scene number within the chapter"),
+    sceneCount: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Total number of scenes in the chapter (assemble-chapter)"),
+    chapterOutline: z
+      .string()
+      .optional()
+      .describe("Chapter outline text"),
+    sceneDefinition: z
+      .string()
+      .optional()
+      .describe("Scene definition as JSON string"),
+    sceneContent: z
+      .string()
+      .optional()
+      .describe("Current scene content (required for revise)"),
+    feedback: z
+      .string()
+      .optional()
+      .describe("Revision feedback (required for revise)"),
+    chapterTitle: z
+      .string()
+      .optional()
+      .describe("Chapter title (assemble-chapter, defaults to 'Chapter N')"),
+    baseContext: z
+      .string()
+      .optional()
+      .describe("Base story context"),
+    storyElements: z
+      .string()
+      .optional()
+      .describe("Story elements text"),
+    characterSheets: z
+      .string()
+      .optional()
+      .describe("Character sheets"),
+    settingSheets: z
+      .string()
+      .optional()
+      .describe("Setting sheets"),
+    previousRecap: z
+      .string()
+      .optional()
+      .describe("Previous chapter recap"),
+    previousScene: z
+      .string()
+      .optional()
+      .describe("Previous scene content"),
+    nextSceneDefinition: z
+      .string()
+      .optional()
+      .describe("Next scene definition"),
+    nextChapterSynopsis: z
+      .string()
+      .optional()
+      .describe("Next chapter synopsis"),
+    model: z
+      .string()
+      .optional()
+      .describe("Override LLM model identifier"),
+  }),
+  execute: async ({
+    operation,
+    name,
+    chapterNum,
+    sceneNum,
+    sceneCount,
+    chapterOutline,
+    sceneDefinition,
+    sceneContent,
+    feedback,
+    chapterTitle,
+    baseContext,
+    storyElements,
+    characterSheets,
+    settingSheets,
+    previousRecap,
+    previousScene,
+    nextSceneDefinition,
+    nextChapterSynopsis,
+    model,
+  }: {
+    operation: string;
+    name: string;
+    chapterNum?: number;
+    sceneNum?: number;
+    sceneCount?: number;
+    chapterOutline?: string;
+    sceneDefinition?: string;
+    sceneContent?: string;
+    feedback?: string;
+    chapterTitle?: string;
+    baseContext?: string;
+    storyElements?: string;
+    characterSheets?: string;
+    settingSheets?: string;
+    previousRecap?: string;
+    previousScene?: string;
+    nextSceneDefinition?: string;
+    nextChapterSynopsis?: string;
+    model?: string;
+  }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = [
+      "src/tools/scene_writer.py",
+      "--operation",
+      operation,
+      "--name",
+      name,
+    ];
+
+    if (chapterNum !== undefined) {
+      args.push("--chapter-num", String(chapterNum));
+    }
+    if (sceneNum !== undefined) {
+      args.push("--scene-num", String(sceneNum));
+    }
+    if (sceneCount !== undefined) {
+      args.push("--scene-count", String(sceneCount));
+    }
+    if (chapterOutline) {
+      args.push("--chapter-outline", chapterOutline);
+    }
+    if (sceneDefinition) {
+      args.push("--scene-definition", sceneDefinition);
+    }
+    if (sceneContent) {
+      args.push("--scene-content", sceneContent);
+    }
+    if (feedback) {
+      args.push("--feedback", feedback);
+    }
+    if (chapterTitle) {
+      args.push("--chapter-title", chapterTitle);
+    }
+    if (baseContext) {
+      args.push("--base-context", baseContext);
+    }
+    if (storyElements) {
+      args.push("--story-elements", storyElements);
+    }
+    if (characterSheets) {
+      args.push("--character-sheets", characterSheets);
+    }
+    if (settingSheets) {
+      args.push("--setting-sheets", settingSheets);
+    }
+    if (previousRecap) {
+      args.push("--previous-recap", previousRecap);
+    }
+    if (previousScene) {
+      args.push("--previous-scene", previousScene);
+    }
+    if (nextSceneDefinition) {
+      args.push("--next-scene-definition", nextSceneDefinition);
+    }
+    if (nextChapterSynopsis) {
+      args.push("--next-chapter-synopsis", nextChapterSynopsis);
+    }
+    if (model) {
+      args.push("--model", model);
+    }
+
+    try {
+      const stdout = execFileSync("python3", args, {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message =
+        execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 ## Tools
 
-- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader, story-state, savepoint-mgr, character-mgr, setting-mgr, recap-manager, and outline-generator tools, guide for adding new tools
+- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader, story-state, savepoint-mgr, character-mgr, setting-mgr, recap-manager, outline-generator, and scene-writer tools, guide for adding new tools
 
 ## Planning
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -830,6 +830,173 @@ Invalid values produce exit code 1 with a descriptive error message.
 
 ---
 
+## scene-writer
+
+Scene writing pipeline: parse a chapter outline into scene definitions, generate individual scenes, revise scenes with feedback, or assemble scenes into a chapter.
+
+**Source files:**
+- `.opencode/tools/scene-writer.ts` — TypeScript wrapper
+- `src/tools/scene_writer.py` — Python CLI script
+- `src/tools/_llm.py` — Shared LLM client (`generate_text`, `_extract_json_block`, `count_tokens`)
+- `src/infrastructure/prompts/prompt_loader.py` — Prompt template loading
+- `src/infrastructure/storage/savepoint_repository.py` — Savepoint persistence
+
+### Purpose
+
+The scene writer breaks chapter-level generation into finer-grained scene units. A chapter outline is first parsed into individual scene definitions (structured JSON), then each scene is generated independently. Scenes can be revised with targeted feedback, and once all scenes in a chapter are complete they are assembled into a single chapter document with section headers and separators.
+
+All LLM-backed operations save their results to savepoints, making the pipeline fully resumable if interrupted.
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `operation` | `"parse-definitions" \| "generate" \| "revise" \| "assemble-chapter"` | Yes | Operation to perform |
+| `name` | string | Yes | Story name (directory under `stories/`) |
+| `chapterNum` | integer | For all except as noted | Chapter number (must be ≥ 1) |
+| `sceneNum` | integer | For `generate`, `revise` | Scene number within the chapter (must be ≥ 1) |
+| `sceneCount` | integer | For `assemble-chapter` | Total number of scenes in the chapter (must be ≥ 1) |
+| `chapterOutline` | string | For `parse-definitions`, `generate`; optional for `revise` | Chapter outline text |
+| `sceneDefinition` | string | For `generate`; optional for `revise` | Scene definition as JSON string |
+| `sceneContent` | string | For `revise` | Current scene content to revise |
+| `feedback` | string | For `revise` | Revision feedback describing what to improve |
+| `chapterTitle` | string | No | Chapter title for `assemble-chapter` (defaults to `"Chapter N"`) |
+| `baseContext` | string | No | Base story context (for `generate`) |
+| `storyElements` | string | No | Story elements text (for `generate`) |
+| `characterSheets` | string | No | Character sheets (for `generate`) |
+| `settingSheets` | string | No | Setting sheets (for `generate`) |
+| `previousRecap` | string | No | Previous chapter recap (for `generate`) |
+| `previousScene` | string | No | Previous scene content (for `generate`) |
+| `nextSceneDefinition` | string | No | Next scene definition (for `generate`) |
+| `nextChapterSynopsis` | string | No | Next chapter synopsis (for `generate`) |
+| `model` | string | No | Override LLM model identifier |
+
+### CLI Interface (Python script)
+
+```bash
+python3 src/tools/scene_writer.py --operation <op> --name <name> [options]
+```
+
+**Examples:**
+
+```bash
+# Parse chapter outline into scene definitions
+python3 src/tools/scene_writer.py --operation parse-definitions \
+  --name my-story --chapter-num 3 \
+  --chapter-outline "Elena arrives at the ancient city..."
+
+# Generate a single scene
+python3 src/tools/scene_writer.py --operation generate \
+  --name my-story --chapter-num 3 --scene-num 1 \
+  --scene-definition '{"title": "The Arrival", "description": "Elena enters the gate"}' \
+  --chapter-outline "Chapter 3 outline text" \
+  --base-context "Fantasy world context" \
+  --previous-scene "Previous scene text"
+
+# Revise a scene with feedback
+python3 src/tools/scene_writer.py --operation revise \
+  --name my-story --chapter-num 3 --scene-num 1 \
+  --scene-content "The sun set over the city..." \
+  --feedback "Add more tension in the dialogue" \
+  --scene-definition '{"title": "The Arrival"}' \
+  --chapter-outline "Chapter 3 outline"
+
+# Assemble all scenes into a chapter
+python3 src/tools/scene_writer.py --operation assemble-chapter \
+  --name my-story --chapter-num 3 --scene-count 4 \
+  --chapter-title "The Ancient City"
+```
+
+### Operations
+
+| Operation | Effect | Output |
+|-----------|--------|--------|
+| `parse-definitions` | Sends chapter outline through `scenes/parse_definitions` prompt; LLM returns a JSON array of scene objects. Falls back to a single scene if JSON parsing fails. Saves to savepoint. | `{"status": "success", "operation": "parse-definitions", "data": [{"title": "...", "description": "..."}, ...]}` |
+| `generate` | Renders `scenes/create_content` prompt with scene definition and full story context, calls LLM, saves result to savepoint | `{"status": "success", "operation": "generate", "data": "<scene text>"}` |
+| `revise` | Renders `scenes/revise_content` prompt with current content, feedback, and optional context, calls LLM, overwrites the scene savepoint | `{"status": "success", "operation": "revise", "data": "<revised text>"}` |
+| `assemble-chapter` | Loads all scene savepoints for the chapter, retrieves scene titles from definitions savepoint, concatenates with `## <title>` headers and `---` separators | `{"status": "success", "operation": "assemble-chapter", "data": "# <title>\n\n## Scene 1\n\n..."}` |
+
+### Scene Definition Format
+
+The `parse-definitions` operation produces (and `generate` consumes) scene definition objects:
+
+```json
+[
+  {
+    "title": "The Arrival",
+    "description": "Elena steps through the city gate for the first time",
+    "characters": ["Elena", "Guard Captain"],
+    "setting": "City Gate",
+    "conflict": "Elena must prove her identity",
+    "tone": "Tense, anticipatory",
+    "key_events": ["Elena presents her papers", "Guard recognises the seal"],
+    "dialogue": "Sample dialogue snippet",
+    "ending": "Elena is admitted to the city",
+    "lead_in_to_next_scene": "As Elena enters, she notices...",
+    "literary_devices": "Foreshadowing of the seal's significance"
+  }
+]
+```
+
+### Prompt Templates
+
+The tool uses three prompt templates from the `prompts/scenes/` directory:
+
+| Template | Used By | Purpose |
+|----------|---------|---------|
+| `scenes/parse_definitions` | `parse-definitions` | Analyse a chapter outline and extract scene objects as JSON |
+| `scenes/create_content` | `generate` | Generate 750–1500 words of scene prose from a definition and context |
+| `scenes/revise_content` | `revise` | Revise scene content based on specific feedback |
+
+### Savepoint Structure
+
+All intermediate results are persisted under `stories/<name>/savepoints/`:
+
+| Savepoint Key | Created By | Content |
+|---------------|-----------|---------|
+| `chapter_N/scene_definitions` | `parse-definitions` | JSON array of scene definition objects |
+| `chapter_N/scene_M` | `generate`, `revise` | Scene prose text |
+
+### Resumability
+
+The `parse-definitions` and `generate` operations check for existing savepoints before calling the LLM. If a savepoint exists, the saved result is returned immediately and the LLM call is skipped. This means:
+
+- If `parse-definitions` has already run for a chapter, re-running returns the cached definitions
+- If a scene has already been generated, re-running `generate` returns the cached content
+- The `revise` operation always calls the LLM and overwrites the scene savepoint, since revisions are intentional changes
+- `assemble-chapter` is purely deterministic (no LLM) — it reads scene savepoints and concatenates them
+
+### Fallback Behaviour
+
+If the LLM response from `parse-definitions` cannot be parsed as valid JSON, or the parsed result is not a list of dictionaries, the tool falls back to a single scene definition containing the chapter number and the full chapter outline text as description.
+
+### LLM Configuration
+
+The tool uses `src/tools/_llm.py` for LLM access, configured via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_API_BASE` | `http://localhost:11434/v1` | OpenAI-compatible API base URL |
+| `LLM_MODEL` | `huihui_ai/magistral-abliterated:24b` | Default model identifier |
+
+The `--model` argument overrides `LLM_MODEL` for a single invocation.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — result printed to stdout as JSON |
+| 1 | Domain error — missing scenes for assembly, LLM failure, path traversal detected, invalid arguments |
+| 2 | Argument error — missing required flag for the chosen operation |
+
+### Security
+
+- **Path traversal prevention** — story names are validated with `Path.is_relative_to()` to ensure they cannot escape the `stories/` directory
+- **Shell injection prevention** — the TypeScript wrapper uses `execFileSync` with an argument array, never shell interpolation
+- **Test isolation** — the `STORIES_DIR` environment variable overrides the default stories directory, ensuring tests never touch production data
+
+---
+
 ## Adding a New Tool
 
 Follow this pattern to add tools to the system:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,7 +42,7 @@ Loads a prompt template by ID and substitutes variables, returning the rendered 
 
 ### Purpose
 
-Prompt templates are Markdown files in the `prompts/` directory (131 templates across 10 categories). This tool provides deterministic template loading and variable substitution so agents can retrieve rendered prompts without managing file paths or parsing logic.
+Prompt templates are Markdown files in the `prompts/` directory (132 templates across 10 categories). This tool provides deterministic template loading and variable substitution so agents can retrieve rendered prompts without managing file paths or parsing logic.
 
 ### Arguments
 

--- a/prompts/scenes/revise_content.md
+++ b/prompts/scenes/revise_content.md
@@ -1,0 +1,48 @@
+# Scene Revision
+
+## Your Task
+Revise the following scene content based on the feedback provided. Produce a complete, improved version of the scene.
+
+## Current Scene Content
+<SCENE_CONTENT>
+{scene_content}
+</SCENE_CONTENT>
+
+## Feedback to Address
+<FEEDBACK>
+{feedback}
+</FEEDBACK>
+
+## Scene Definition
+<SCENE_DEFINITION>
+{scene_definition}
+</SCENE_DEFINITION>
+
+## Chapter Outline
+<CHAPTER_OUTLINE>
+{chapter_outline}
+</CHAPTER_OUTLINE>
+
+## Revision Guidelines
+
+### Requirements
+- Address ALL points raised in the feedback
+- Maintain consistency with the scene definition and chapter outline
+- Preserve the core events and plot points of the scene
+- Improve quality based on the specific feedback given
+
+### What to Include
+- Rich sensory details and vivid descriptions
+- Natural, character-appropriate dialogue
+- Internal thoughts and emotional depth
+- Character development and voice consistency
+- Smooth transitions and logical flow
+
+### What NOT to Include
+- Commentary about the revision process
+- Meta-text about what was changed
+- Events beyond the scene definition
+- Working notes or thought process
+
+### Output
+Return ONLY the revised scene content. No explanations, no commentary, no before/after comparisons.

--- a/src/tools/_llm.py
+++ b/src/tools/_llm.py
@@ -85,6 +85,11 @@ def generate_text_messages(
         raise RuntimeError(f"Unexpected LLM API response structure: {exc}") from exc
 
 
+def count_tokens(text: str) -> int:
+    """Estimate token count using word-based approximation."""
+    return int(len(text.split()) * 1.33)
+
+
 def _strip_markdown_fences(text: str) -> str:
     """Remove markdown code fences from text and extract JSON content."""
     text = text.strip()

--- a/src/tools/scene_writer.py
+++ b/src/tools/scene_writer.py
@@ -79,15 +79,6 @@ def _call_llm(prompt: str, *, model: str | None = None) -> str:
     return generate_text(prompt, model=model)
 
 
-def _call_llm_messages(
-    messages: list[dict[str, str]], *, model: str | None = None
-) -> str:
-    """Call LLM with full conversation history and return text response."""
-    from src.tools._llm import generate_text_messages
-
-    return generate_text_messages(messages, model=model)
-
-
 def _success(operation: str, data: Any) -> None:
     """Print success response and exit."""
     print(
@@ -265,18 +256,23 @@ def cmd_assemble_chapter(
 
     title = chapter_title or f"Chapter {chapter_num}"
     missing: list[int] = []
-    scenes: list[str] = []
 
     for i in range(1, scene_count + 1):
         step = f"chapter_{chapter_num}/scene_{i}"
         if not _has_savepoint(repo, step):
             missing.append(i)
-        else:
-            scenes.append("")  # placeholder
 
     if missing:
         _error(f"missing scenes: {missing}")
         return  # unreachable
+
+    # Load scene definitions once for title lookup
+    defs_step = f"chapter_{chapter_num}/scene_definitions"
+    defs: list[Any] | None = None
+    if _has_savepoint(repo, defs_step):
+        loaded = _load_savepoint(repo, defs_step)
+        if isinstance(loaded, list):
+            defs = loaded
 
     parts: list[str] = []
     for i in range(1, scene_count + 1):
@@ -285,15 +281,12 @@ def cmd_assemble_chapter(
         if not isinstance(content, str):
             content = json.dumps(content, default=str)
 
-        # Try to get scene title from definitions savepoint
+        # Try to get scene title from definitions
         scene_title = f"Scene {i}"
-        defs_step = f"chapter_{chapter_num}/scene_definitions"
-        if _has_savepoint(repo, defs_step):
-            defs = _load_savepoint(repo, defs_step)
-            if isinstance(defs, list) and len(defs) >= i:
-                entry = defs[i - 1]
-                if isinstance(entry, dict) and "title" in entry:
-                    scene_title = entry["title"]
+        if defs is not None and len(defs) >= i:
+            entry = defs[i - 1]
+            if isinstance(entry, dict) and "title" in entry:
+                scene_title = entry["title"]
 
         parts.append(f"## {scene_title}\n\n{content}")
 

--- a/src/tools/scene_writer.py
+++ b/src/tools/scene_writer.py
@@ -1,0 +1,434 @@
+"""CLI tool for scene writing pipeline (parse-definitions, generate, revise, assemble-chapter)."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from infrastructure.storage.savepoint_repository import (
+        FilesystemSavepointRepository,
+    )
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+STORIES_DIR = Path(os.environ.get("STORIES_DIR", str(PROJECT_ROOT / "stories")))
+
+_src_path = str(PROJECT_ROOT / "src")
+_root_path = str(PROJECT_ROOT)
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+if _root_path not in sys.path:
+    sys.path.insert(0, _root_path)
+
+
+def _validate_story_name(name: str) -> Path:
+    """Validate story name does not escape the stories directory."""
+    story_dir = (STORIES_DIR / name).resolve()
+    if not story_dir.is_relative_to(STORIES_DIR.resolve()):
+        print(
+            f"Error: story name escapes stories directory: {name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return story_dir
+
+
+def _make_repo(name: str) -> FilesystemSavepointRepository:
+    """Create a FilesystemSavepointRepository for the given story."""
+    from infrastructure.storage.savepoint_repository import (
+        FilesystemSavepointRepository,
+    )
+
+    repo = FilesystemSavepointRepository(base_path=STORIES_DIR / name)
+    repo.set_story_directory("savepoints")
+    return repo
+
+
+def _load_savepoint(repo: FilesystemSavepointRepository, step: str) -> Any:
+    """Load a savepoint, returning its data."""
+    return asyncio.run(repo.load_savepoint(step))
+
+
+def _save_savepoint(repo: FilesystemSavepointRepository, step: str, data: Any) -> None:
+    """Save data to a savepoint."""
+    asyncio.run(repo.save_savepoint(step, data))
+
+
+def _has_savepoint(repo: FilesystemSavepointRepository, step: str) -> bool:
+    """Check if a savepoint exists."""
+    return asyncio.run(repo.has_savepoint(step))
+
+
+def _load_prompt(prompt_id: str, variables: dict[str, Any] | None = None) -> str:
+    """Load and render a prompt template."""
+    from infrastructure.prompts.prompt_loader import PromptLoader
+
+    loader = PromptLoader(prompts_dir=str(PROJECT_ROOT / "prompts"))
+    return loader.load_prompt(prompt_id, variables)
+
+
+def _call_llm(prompt: str, *, model: str | None = None) -> str:
+    """Call LLM with a single prompt and return text response."""
+    from src.tools._llm import generate_text
+
+    return generate_text(prompt, model=model)
+
+
+def _call_llm_messages(
+    messages: list[dict[str, str]], *, model: str | None = None
+) -> str:
+    """Call LLM with full conversation history and return text response."""
+    from src.tools._llm import generate_text_messages
+
+    return generate_text_messages(messages, model=model)
+
+
+def _success(operation: str, data: Any) -> None:
+    """Print success response and exit."""
+    print(
+        json.dumps(
+            {"status": "success", "operation": operation, "data": data},
+            indent=2,
+            default=str,
+        )
+    )
+
+
+def _error(message: str, exit_code: int = 1) -> None:
+    """Print error to stderr and exit."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Operations
+# ---------------------------------------------------------------------------
+
+
+def cmd_parse_definitions(
+    name: str,
+    chapter_num: int,
+    chapter_outline: str,
+    *,
+    model: str | None = None,
+) -> None:
+    """Parse a chapter outline into individual scene definitions."""
+    _validate_story_name(name)
+    repo = _make_repo(name)
+    step = f"chapter_{chapter_num}/scene_definitions"
+
+    if _has_savepoint(repo, step):
+        definitions = _load_savepoint(repo, step)
+        _success("parse-definitions", definitions)
+        return
+
+    prompt_text = _load_prompt(
+        "scenes/parse_definitions", {"chapter_outline": chapter_outline}
+    )
+
+    try:
+        from src.tools._llm import _extract_json_block
+
+        raw = _call_llm(prompt_text, model=model)
+        json_str = _extract_json_block(raw)
+        definitions = json.loads(json_str)
+    except (json.JSONDecodeError, RuntimeError) as exc:
+        print(
+            f"Warning: scene parse failed ({exc}), falling back to single scene",
+            file=sys.stderr,
+        )
+        definitions = [
+            {"title": f"Chapter {chapter_num} Scene", "description": chapter_outline}
+        ]
+
+    if not isinstance(definitions, list) or not all(
+        isinstance(d, dict) for d in definitions
+    ):
+        print(
+            "Warning: invalid definitions structure, falling back to single scene",
+            file=sys.stderr,
+        )
+        definitions = [
+            {"title": f"Chapter {chapter_num} Scene", "description": chapter_outline}
+        ]
+
+    _save_savepoint(repo, step, definitions)
+    _success("parse-definitions", definitions)
+
+
+def cmd_generate(
+    name: str,
+    chapter_num: int,
+    scene_num: int,
+    scene_definition: str,
+    chapter_outline: str,
+    *,
+    base_context: str | None = None,
+    story_elements: str | None = None,
+    character_sheets: str | None = None,
+    setting_sheets: str | None = None,
+    previous_recap: str | None = None,
+    previous_scene: str | None = None,
+    next_scene_definition: str | None = None,
+    next_chapter_synopsis: str | None = None,
+    model: str | None = None,
+) -> None:
+    """Generate content for a single scene."""
+    _validate_story_name(name)
+    repo = _make_repo(name)
+    step = f"chapter_{chapter_num}/scene_{scene_num}"
+
+    if _has_savepoint(repo, step):
+        content = _load_savepoint(repo, step)
+        _success("generate", content)
+        return
+
+    prompt_text = _load_prompt(
+        "scenes/create_content",
+        {
+            "chapter_num": str(chapter_num),
+            "scene_num": str(scene_num),
+            "scene_definition": scene_definition,
+            "chapter_outline": chapter_outline,
+            "base_context": base_context or "",
+            "story_elements": story_elements or "",
+            "character_sheets": character_sheets or "",
+            "setting_sheets": setting_sheets or "",
+            "previous_recap": previous_recap or "",
+            "previous_scene": previous_scene or "",
+            "next_scene_definition": next_scene_definition or "",
+            "next_chapter_synopsis": next_chapter_synopsis or "",
+        },
+    )
+
+    try:
+        content = _call_llm(prompt_text, model=model)
+    except RuntimeError as exc:
+        _error(f"scene generation failed: {exc}")
+        return  # unreachable
+
+    _save_savepoint(repo, step, content)
+    _success("generate", content)
+
+
+def cmd_revise(
+    name: str,
+    chapter_num: int,
+    scene_num: int,
+    scene_content: str,
+    feedback: str,
+    *,
+    scene_definition: str | None = None,
+    chapter_outline: str | None = None,
+    model: str | None = None,
+) -> None:
+    """Revise scene content based on feedback."""
+    _validate_story_name(name)
+    repo = _make_repo(name)
+    step = f"chapter_{chapter_num}/scene_{scene_num}"
+
+    prompt_text = _load_prompt(
+        "scenes/revise_content",
+        {
+            "scene_content": scene_content,
+            "feedback": feedback,
+            "scene_definition": scene_definition or "",
+            "chapter_outline": chapter_outline or "",
+        },
+    )
+
+    try:
+        revised = _call_llm(prompt_text, model=model)
+    except RuntimeError as exc:
+        _error(f"scene revision failed: {exc}")
+        return  # unreachable
+
+    _save_savepoint(repo, step, revised)
+    _success("revise", revised)
+
+
+def cmd_assemble_chapter(
+    name: str,
+    chapter_num: int,
+    scene_count: int,
+    *,
+    chapter_title: str | None = None,
+) -> None:
+    """Assemble all scenes into a single chapter."""
+    _validate_story_name(name)
+    repo = _make_repo(name)
+
+    title = chapter_title or f"Chapter {chapter_num}"
+    missing: list[int] = []
+    scenes: list[str] = []
+
+    for i in range(1, scene_count + 1):
+        step = f"chapter_{chapter_num}/scene_{i}"
+        if not _has_savepoint(repo, step):
+            missing.append(i)
+        else:
+            scenes.append("")  # placeholder
+
+    if missing:
+        _error(f"missing scenes: {missing}")
+        return  # unreachable
+
+    parts: list[str] = []
+    for i in range(1, scene_count + 1):
+        step = f"chapter_{chapter_num}/scene_{i}"
+        content = _load_savepoint(repo, step)
+        if not isinstance(content, str):
+            content = json.dumps(content, default=str)
+
+        # Try to get scene title from definitions savepoint
+        scene_title = f"Scene {i}"
+        defs_step = f"chapter_{chapter_num}/scene_definitions"
+        if _has_savepoint(repo, defs_step):
+            defs = _load_savepoint(repo, defs_step)
+            if isinstance(defs, list) and len(defs) >= i:
+                entry = defs[i - 1]
+                if isinstance(entry, dict) and "title" in entry:
+                    scene_title = entry["title"]
+
+        parts.append(f"## {scene_title}\n\n{content}")
+
+    assembled = f"# {title}\n\n" + "\n\n---\n\n".join(parts)
+    _success("assemble-chapter", assembled)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scene writer tool")
+    parser.add_argument(
+        "--operation",
+        required=True,
+        choices=["parse-definitions", "generate", "revise", "assemble-chapter"],
+        help="Operation to perform",
+    )
+    parser.add_argument("--name", required=True, help="Story name")
+    parser.add_argument("--chapter-num", type=int, default=None, help="Chapter number")
+    parser.add_argument("--scene-num", type=int, default=None, help="Scene number")
+    parser.add_argument(
+        "--scene-count", type=int, default=None, help="Total scenes in chapter"
+    )
+    parser.add_argument("--chapter-outline", default=None, help="Chapter outline text")
+    parser.add_argument(
+        "--scene-definition", default=None, help="Scene definition JSON"
+    )
+    parser.add_argument("--scene-content", default=None, help="Current scene content")
+    parser.add_argument("--feedback", default=None, help="Revision feedback")
+    parser.add_argument("--chapter-title", default=None, help="Chapter title")
+    parser.add_argument("--base-context", default=None, help="Base story context")
+    parser.add_argument("--story-elements", default=None, help="Story elements text")
+    parser.add_argument("--character-sheets", default=None, help="Character sheets")
+    parser.add_argument("--setting-sheets", default=None, help="Setting sheets")
+    parser.add_argument("--previous-recap", default=None, help="Previous chapter recap")
+    parser.add_argument("--previous-scene", default=None, help="Previous scene content")
+    parser.add_argument(
+        "--next-scene-definition", default=None, help="Next scene definition"
+    )
+    parser.add_argument(
+        "--next-chapter-synopsis", default=None, help="Next chapter synopsis"
+    )
+    parser.add_argument("--model", default=None, help="Override LLM model identifier")
+    args = parser.parse_args()
+
+    # --- Dispatch ---
+    op = args.operation
+
+    if op == "parse-definitions":
+        if args.chapter_num is None:
+            _error("--chapter-num is required for parse-definitions")
+        if args.chapter_num < 1:
+            _error("--chapter-num must be >= 1")
+        if not args.chapter_outline:
+            _error("--chapter-outline is required for parse-definitions")
+        cmd_parse_definitions(
+            args.name,
+            args.chapter_num,
+            args.chapter_outline,
+            model=args.model,
+        )
+
+    elif op == "generate":
+        if args.chapter_num is None:
+            _error("--chapter-num is required for generate")
+        if args.chapter_num < 1:
+            _error("--chapter-num must be >= 1")
+        if args.scene_num is None:
+            _error("--scene-num is required for generate")
+        if args.scene_num < 1:
+            _error("--scene-num must be >= 1")
+        if not args.scene_definition:
+            _error("--scene-definition is required for generate")
+        if not args.chapter_outline:
+            _error("--chapter-outline is required for generate")
+        cmd_generate(
+            args.name,
+            args.chapter_num,
+            args.scene_num,
+            args.scene_definition,
+            args.chapter_outline,
+            base_context=args.base_context,
+            story_elements=args.story_elements,
+            character_sheets=args.character_sheets,
+            setting_sheets=args.setting_sheets,
+            previous_recap=args.previous_recap,
+            previous_scene=args.previous_scene,
+            next_scene_definition=args.next_scene_definition,
+            next_chapter_synopsis=args.next_chapter_synopsis,
+            model=args.model,
+        )
+
+    elif op == "revise":
+        if args.chapter_num is None:
+            _error("--chapter-num is required for revise")
+        if args.chapter_num < 1:
+            _error("--chapter-num must be >= 1")
+        if args.scene_num is None:
+            _error("--scene-num is required for revise")
+        if args.scene_num < 1:
+            _error("--scene-num must be >= 1")
+        if not args.scene_content:
+            _error("--scene-content is required for revise")
+        if not args.feedback:
+            _error("--feedback is required for revise")
+        cmd_revise(
+            args.name,
+            args.chapter_num,
+            args.scene_num,
+            args.scene_content,
+            args.feedback,
+            scene_definition=args.scene_definition,
+            chapter_outline=args.chapter_outline,
+            model=args.model,
+        )
+
+    elif op == "assemble-chapter":
+        if args.chapter_num is None:
+            _error("--chapter-num is required for assemble-chapter")
+        if args.chapter_num < 1:
+            _error("--chapter-num must be >= 1")
+        if args.scene_count is None:
+            _error("--scene-count is required for assemble-chapter")
+        if args.scene_count < 1:
+            _error("--scene-count must be >= 1")
+        cmd_assemble_chapter(
+            args.name,
+            args.chapter_num,
+            args.scene_count,
+            chapter_title=args.chapter_title,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_prompt_relocation.py
+++ b/tests/unit/test_prompt_relocation.py
@@ -105,9 +105,9 @@ def test_outline_chapter_prompt_directory():
 
 
 def test_prompt_file_count():
-    """Count all .md files under prompts/ and verify there are 131."""
+    """Count all .md files under prompts/ and verify there are 132."""
     prompts_dir = PROJECT_ROOT / "prompts"
     md_files = list(prompts_dir.rglob("*.md"))
-    assert len(md_files) == 131, (
-        f"Expected 131 .md files under prompts/, found {len(md_files)}"
+    assert len(md_files) == 132, (
+        f"Expected 132 .md files under prompts/, found {len(md_files)}"
     )

--- a/tests/unit/test_scene_writer.py
+++ b/tests/unit/test_scene_writer.py
@@ -1,0 +1,390 @@
+"""Verification tests for Issue #12 — scene-writer Tool.
+
+Confirms the CLI tool (src/tools/scene_writer.py) correctly handles
+parse-definitions, generate, revise, and assemble-chapter operations —
+including savepoint resumability, LLM mocking, fallback paths, and
+input validation.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import src.tools.scene_writer as sw
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOL_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "scene_writer.py")
+
+
+@pytest.fixture()
+def story_env(tmp_path: Path) -> tuple[Path, str]:
+    """Provide a temp stories directory with a pre-created story."""
+    stories_dir = tmp_path / "stories"
+    story_name = "test-story"
+    (stories_dir / story_name / "savepoints").mkdir(parents=True)
+    return stories_dir, story_name
+
+
+@pytest.fixture()
+def patched_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    """Redirect STORIES_DIR and stub _load_prompt for direct function calls."""
+    stories_dir = tmp_path / "stories"
+    story_name = "test-story"
+    (stories_dir / story_name / "savepoints").mkdir(parents=True)
+
+    monkeypatch.setattr(sw, "STORIES_DIR", stories_dir)
+    monkeypatch.setattr(sw, "_load_prompt", lambda *_a, **_kw: "mock prompt text")
+
+    return stories_dir, story_name
+
+
+def _run_tool(
+    *args: str, stories_dir: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    if stories_dir is not None:
+        env["STORIES_DIR"] = str(stories_dir)
+    return subprocess.run(
+        [sys.executable, TOOL_SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. test_parse_definitions_success
+# ---------------------------------------------------------------------------
+
+
+def test_parse_definitions_success(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock LLM to return valid JSON scene definitions. Verify parse + savepoint."""
+    stories_dir, name = patched_env
+
+    definitions = [
+        {"title": "Opening", "description": "The hero arrives"},
+        {"title": "Confrontation", "description": "The villain appears"},
+    ]
+    raw_llm = f"```json\n{json.dumps(definitions)}\n```"
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: raw_llm)
+
+    sw.cmd_parse_definitions(name, 1, "Chapter outline text", model="test")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "parse-definitions"
+    assert out["data"] == definitions
+
+    # Verify savepoint written
+    repo = sw._make_repo(name)
+    assert sw._has_savepoint(repo, "chapter_1/scene_definitions")
+    saved = sw._load_savepoint(repo, "chapter_1/scene_definitions")
+    assert saved == definitions
+
+
+# ---------------------------------------------------------------------------
+# 2. test_parse_definitions_fallback
+# ---------------------------------------------------------------------------
+
+
+def test_parse_definitions_fallback(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock LLM to return unparseable response. Verify fallback single-scene definition."""
+    _stories_dir, name = patched_env
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: "not valid json at all")
+
+    sw.cmd_parse_definitions(name, 3, "My chapter outline", model="test")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "parse-definitions"
+    assert len(out["data"]) == 1
+    assert out["data"][0]["title"] == "Chapter 3 Scene"
+    assert out["data"][0]["description"] == "My chapter outline"
+
+
+# ---------------------------------------------------------------------------
+# 3. test_parse_definitions_savepoint_resume
+# ---------------------------------------------------------------------------
+
+
+def test_parse_definitions_savepoint_resume(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate savepoint. Verify returns cached data without LLM call."""
+    stories_dir, name = patched_env
+
+    cached_defs = [{"title": "Cached Scene", "description": "Already done"}]
+    repo = sw._make_repo(name)
+    sw._save_savepoint(repo, "chapter_1/scene_definitions", cached_defs)
+
+    def llm_should_not_be_called(*_a: object, **_kw: object) -> str:
+        raise AssertionError("_call_llm should not be called when savepoint exists")
+
+    monkeypatch.setattr(sw, "_call_llm", llm_should_not_be_called)
+
+    sw.cmd_parse_definitions(name, 1, "Ignored outline", model="test")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["data"] == cached_defs
+
+
+# ---------------------------------------------------------------------------
+# 4. test_generate_scene_success
+# ---------------------------------------------------------------------------
+
+
+def test_generate_scene_success(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock LLM to return scene content. Verify generate with full context params."""
+    _stories_dir, name = patched_env
+
+    scene_text = "The sun set over the ancient city as Elena stepped through the gate."
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: scene_text)
+
+    sw.cmd_generate(
+        name,
+        chapter_num=2,
+        scene_num=1,
+        scene_definition="Elena arrives at the city",
+        chapter_outline="Chapter 2 outline",
+        base_context="Fantasy world context",
+        story_elements="Key story elements",
+        character_sheets="Elena: protagonist",
+        setting_sheets="Ancient city setting",
+        previous_recap="Chapter 1 recap",
+        previous_scene="Previous scene text",
+        next_scene_definition="Next scene def",
+        next_chapter_synopsis="Chapter 3 synopsis",
+        model="test",
+    )
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "generate"
+    assert out["data"] == scene_text
+
+    # Verify savepoint
+    repo = sw._make_repo(name)
+    assert sw._has_savepoint(repo, "chapter_2/scene_1")
+    saved = sw._load_savepoint(repo, "chapter_2/scene_1")
+    assert scene_text in str(saved)
+
+
+# ---------------------------------------------------------------------------
+# 5. test_generate_scene_savepoint_resume
+# ---------------------------------------------------------------------------
+
+
+def test_generate_scene_savepoint_resume(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate savepoint for scene. Verify returns cached content without LLM call."""
+    _stories_dir, name = patched_env
+
+    cached_content = "Cached scene content from previous run."
+    repo = sw._make_repo(name)
+    sw._save_savepoint(repo, "chapter_1/scene_2", cached_content)
+
+    def llm_should_not_be_called(*_a: object, **_kw: object) -> str:
+        raise AssertionError("_call_llm should not be called when savepoint exists")
+
+    monkeypatch.setattr(sw, "_call_llm", llm_should_not_be_called)
+
+    sw.cmd_generate(
+        name,
+        chapter_num=1,
+        scene_num=2,
+        scene_definition="Some definition",
+        chapter_outline="Some outline",
+        model="test",
+    )
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "generate"
+    assert "Cached scene content" in str(out["data"])
+
+
+# ---------------------------------------------------------------------------
+# 6. test_revise_scene_success
+# ---------------------------------------------------------------------------
+
+
+def test_revise_scene_success(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock LLM to return revised content. Verify feedback appears in prompt."""
+    _stories_dir, name = patched_env
+
+    revised_text = "The revised scene with more tension."
+    captured_prompts: list[str] = []
+
+    def mock_load_prompt(prompt_id: str, variables: dict | None = None) -> str:
+        # Build a fake prompt that includes the variable values so we can verify
+        rendered = f"prompt:{prompt_id}"
+        if variables:
+            for k, v in variables.items():
+                rendered += f" {k}={v}"
+        captured_prompts.append(rendered)
+        return rendered
+
+    monkeypatch.setattr(sw, "_load_prompt", mock_load_prompt)
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: revised_text)
+
+    feedback_text = "Add more tension in the dialogue"
+    sw.cmd_revise(
+        name,
+        chapter_num=1,
+        scene_num=1,
+        scene_content="Original scene text",
+        feedback=feedback_text,
+        scene_definition="Scene def",
+        chapter_outline="Chapter outline",
+        model="test",
+    )
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "revise"
+    assert out["data"] == revised_text
+
+    # CRITICAL: Verify feedback text appears in the LLM call arguments
+    assert len(captured_prompts) == 1
+    assert feedback_text in captured_prompts[0]
+
+    # Verify savepoint overwritten
+    repo = sw._make_repo(name)
+    assert sw._has_savepoint(repo, "chapter_1/scene_1")
+
+
+# ---------------------------------------------------------------------------
+# 7. test_assemble_chapter_success
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_chapter_success(
+    patched_env: tuple[Path, str],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-populate scene savepoints. Verify assembly concatenates with headers."""
+    _stories_dir, name = patched_env
+    repo = sw._make_repo(name)
+
+    # Save scene definitions with titles
+    defs = [
+        {"title": "The Arrival", "description": "Scene 1 desc"},
+        {"title": "The Battle", "description": "Scene 2 desc"},
+        {"title": "The Aftermath", "description": "Scene 3 desc"},
+    ]
+    sw._save_savepoint(repo, "chapter_1/scene_definitions", defs)
+
+    # Save scene content
+    sw._save_savepoint(repo, "chapter_1/scene_1", "Content of scene one.")
+    sw._save_savepoint(repo, "chapter_1/scene_2", "Content of scene two.")
+    sw._save_savepoint(repo, "chapter_1/scene_3", "Content of scene three.")
+
+    sw.cmd_assemble_chapter(name, 1, 3, chapter_title="The Beginning")
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["status"] == "success"
+    assert out["operation"] == "assemble-chapter"
+
+    assembled = out["data"]
+    assert "# The Beginning" in assembled
+    assert "## The Arrival" in assembled
+    assert "## The Battle" in assembled
+    assert "## The Aftermath" in assembled
+    assert "Content of scene one." in assembled
+    assert "Content of scene two." in assembled
+    assert "Content of scene three." in assembled
+    assert "---" in assembled
+
+
+# ---------------------------------------------------------------------------
+# 8. test_assemble_chapter_missing_scenes
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_chapter_missing_scenes(story_env: tuple[Path, str]) -> None:
+    """Don't populate all savepoints. Verify error for missing scenes."""
+    stories_dir, name = story_env
+    result = _run_tool(
+        "--operation",
+        "assemble-chapter",
+        "--name",
+        name,
+        "--chapter-num",
+        "1",
+        "--scene-count",
+        "3",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1
+    assert "missing scenes" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# 9. test_count_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_count_tokens() -> None:
+    """Verify count_tokens: 'hello world' -> int(2*1.33)=2, empty string -> 0."""
+    from src.tools._llm import count_tokens
+
+    assert count_tokens("hello world") == 2
+    assert count_tokens("") == 0
+
+
+# ---------------------------------------------------------------------------
+# 10. test_invalid_story_name
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_story_name(story_env: tuple[Path, str]) -> None:
+    """Pass path traversal name (../hack). Verify error raised."""
+    stories_dir, _ = story_env
+    result = _run_tool(
+        "--operation",
+        "parse-definitions",
+        "--name",
+        "../hack",
+        "--chapter-num",
+        "1",
+        "--chapter-outline",
+        "Some outline",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1
+    assert "escapes" in result.stderr.lower()


### PR DESCRIPTION
## Summary
Build the scene-writer tool wrapping SceneGenerator logic with four operations: parse-definitions, generate, revise, and assemble-chapter. Adds token counting to _llm.py and a new revision prompt template.

## Closes
Closes #12

## Changes
- [x] Implementation complete
- [x] All tests passing (verified)
- [x] Linting clean

## Plan
- [x] Add count_tokens to _llm.py
- [x] Create scenes/revise_content.md prompt
- [x] Create src/tools/scene_writer.py (4 operations)
- [x] Create .opencode/tools/scene-writer.ts wrapper
- [x] Write verification tests (10 tests, all passing)
- [x] Update prompt file count in test_prompt_relocation.py (131 → 132)