### PR TITLE
Refactor: Use NoReturn type annotation for _error() across all tools

### DIFF
--- a/.github/notes/reflections/archive/issue-50-noreturn-clean-refactor-2026-04-14.md
+++ b/.github/notes/reflections/archive/issue-50-noreturn-clean-refactor-2026-04-14.md
@@ -1,0 +1,29 @@
+---
+date: "2026-04-14"
+issue: 50
+pr: 51
+category: agent
+targets: []
+severity: minor
+status: archived
+---
+
+## Clean refactor with minor issue-scoping overestimation
+
+### Finding
+
+Issue #50 (Refactor: Use `NoReturn` type annotation for `_error()` across all tools) listed 9 files as affected but only 4 contained `_error()`. The other 5 use inline error patterns (`sys.exit()` directly without a helper function). The Coder correctly identified and changed only the 4 relevant files. Synthesized Review was unanimous 10/10 with zero issues. 146 tests passing, zero regressions.
+
+### Observation
+
+The issue scope overestimation is a minor triage accuracy gap — the Contemplator (or issue author) listed all files containing `-> None` on error-adjacent functions without verifying each file actually uses the `_error()` helper pattern. No downstream impact: the Coder scoped correctly at implementation time, and no wasted effort resulted.
+
+This is the first refactor-only issue processed through the pipeline. The clean pass confirms the Synthesized Review and Coder workflows handle non-feature work (type annotation changes, dead code removal) without friction.
+
+### Suggested Improvement
+
+No agent changes needed. The mismatch between issue scope and implementation scope is a natural consequence of triage being done without full code analysis. The Coder self-corrected at implementation time, which is the expected behaviour.
+
+### Action Taken
+
+No action needed — recorded as positive signal. Archived immediately.

--- a/.github/notes/reviews/2026-04-14-pr51-synthesis.md
+++ b/.github/notes/reviews/2026-04-14-pr51-synthesis.md
@@ -1,0 +1,28 @@
+## Synthesized Code Review — 2026-04-14 (PR #51)
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** refactor/issue-50-noreturn-error-annotation
+**PR:** #51 — Refactor: Use NoReturn type annotation for _error() across all tools
+**Model Agreement Score:** 10/10
+**Overall Assessment:** Clean
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 0          |
+| ★★☆ Majority      | 0        | 0       | 0          |
+| ★☆☆ Singular      | 0        | 0       | 1          |
+
+### Key Findings
+
+- [S-S-01] Consider standardising `_error()` pattern across remaining 5 tool files (★☆☆)
+
+### Divergences
+
+None — all three models reached identical conclusions.
+
+### Actions Required
+
+- Findings requiring fixes: 0
+- Findings deferred: 1 (follow-up suggestion, out of scope)

--- a/src/tools/critique_runner.py
+++ b/src/tools/critique_runner.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
     from infrastructure.storage.savepoint_repository import (
@@ -101,7 +101,7 @@ def _success(operation: str, data: Any) -> None:
     )
 
 
-def _error(message: str, exit_code: int = 1) -> None:
+def _error(message: str, exit_code: int = 1) -> NoReturn:
     """Print error to stderr and exit."""
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(exit_code)
@@ -161,7 +161,6 @@ def cmd_run_critics(
             outline = data if isinstance(data, str) else json.dumps(data, default=str)
         else:
             _error("no outline content provided and no outline savepoint found")
-            return  # unreachable
 
     parser = CritiqueParser()
     critique_results = []
@@ -237,7 +236,6 @@ def cmd_should_refine(
     data = _load_savepoint(repo, step)
     if not isinstance(data, dict):
         _error("invalid critique results format")
-        return  # unreachable
 
     average_scores: dict[str, float] = data.get("average_scores", {})
     overall_average: float = data.get("overall_average", 0.0)
@@ -281,12 +279,10 @@ def cmd_generate_feedback(name: str, iteration: int) -> None:
     data = _load_savepoint(repo, step)
     if not isinstance(data, dict):
         _error("invalid critique results format")
-        return  # unreachable
 
     raw_results = data.get("critic_results", [])
     if not isinstance(raw_results, list):
         _error("invalid critic_results format: expected list")
-        return  # unreachable
 
     # Reconstruct CritiqueResult objects from serialized data
     critique_results: list[CritiqueResult] = []

--- a/src/tools/outline_generator.py
+++ b/src/tools/outline_generator.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
     from infrastructure.storage.savepoint_repository import (
@@ -111,7 +111,7 @@ def _success(operation: str, data: Any) -> None:
     )
 
 
-def _error(message: str, exit_code: int = 1) -> None:
+def _error(message: str, exit_code: int = 1) -> NoReturn:
     """Print error to stderr and exit."""
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(exit_code)
@@ -151,7 +151,6 @@ def cmd_analyze_prompt(
             _save_savepoint(repo, "understand_prompt", understand_response)
         except Exception as exc:
             _error(f"understand prompt failed: {exc}")
-            return  # unreachable
 
     # Rebuild conversation history with understand step
     if not conversation:
@@ -194,7 +193,6 @@ def cmd_analyze_prompt(
             conversation.append({"role": "assistant", "content": chunk_response})
         except Exception as exc:
             _error(f"chunk generation failed ({chunk_type}): {exc}")
-            return  # unreachable
 
     # --- Step 3: Extract story start date from core_story_foundation ---
     if _has_savepoint(repo, "story_start_date"):
@@ -304,7 +302,6 @@ def cmd_generate_outline(
             prompt_text = json.dumps(prompt_text, default=str)
     else:
         _error("--prompt is required when understand_prompt savepoint missing")
-        return  # unreachable
 
     if _has_savepoint(repo, "initial_outline"):
         outline_text = _load_savepoint(repo, "initial_outline")
@@ -379,7 +376,6 @@ def cmd_expand_chapter(
             _save_savepoint(repo, chunk_step, chunk_text)
         except Exception as exc:
             _error(f"chunk expansion failed: {exc}")
-            return  # unreachable
 
     # --- Analyze continuity ---
     continuity_step = f"continuity_{chunk_start}_{chunk_end}"

--- a/src/tools/recap_manager.py
+++ b/src/tools/recap_manager.py
@@ -9,7 +9,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
     from infrastructure.storage.savepoint_repository import (
@@ -105,7 +105,7 @@ def _success(operation: str, data: Any) -> None:
     )
 
 
-def _error(message: str, exit_code: int = 1) -> None:
+def _error(message: str, exit_code: int = 1) -> NoReturn:
     """Print error to stderr and exit."""
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(exit_code)
@@ -370,7 +370,6 @@ def cmd_sanitize(
         sanitized = _extract_json_from_response(sanitized_raw)
     except Exception as exc:
         _error(f"sanitize LLM call failed: {exc}")
-        return  # unreachable but keeps type checker happy
 
     # Optional: programmatic recency classification
     if enable_programmatic_classification:
@@ -492,7 +491,6 @@ def cmd_compact(
         compacted = _extract_json_from_response(compacted_raw)
     except Exception as exc:
         _error(f"compact LLM call failed: {exc}")
-        return  # unreachable
 
     # Save compacted recap
     _save_savepoint(repo, f"chapter_{chapter}/compacted_recap", compacted)

--- a/src/tools/scene_writer.py
+++ b/src/tools/scene_writer.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
     from infrastructure.storage.savepoint_repository import (
@@ -90,7 +90,7 @@ def _success(operation: str, data: Any) -> None:
     )
 
 
-def _error(message: str, exit_code: int = 1) -> None:
+def _error(message: str, exit_code: int = 1) -> NoReturn:
     """Print error to stderr and exit."""
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(exit_code)
@@ -201,7 +201,6 @@ def cmd_generate(
         content = _call_llm(prompt_text, model=model)
     except RuntimeError as exc:
         _error(f"scene generation failed: {exc}")
-        return  # unreachable
 
     _save_savepoint(repo, step, content)
     _success("generate", content)
@@ -237,7 +236,6 @@ def cmd_revise(
         revised = _call_llm(prompt_text, model=model)
     except RuntimeError as exc:
         _error(f"scene revision failed: {exc}")
-        return  # unreachable
 
     _save_savepoint(repo, step, revised)
     _success("revise", revised)
@@ -264,7 +262,6 @@ def cmd_assemble_chapter(
 
     if missing:
         _error(f"missing scenes: {missing}")
-        return  # unreachable
 
     # Load scene definitions once for title lookup
     defs_step = f"chapter_{chapter_num}/scene_definitions"


### PR DESCRIPTION
## Summary

Refactors the `_error()` helper function across all tool scripts that define it, changing the return type annotation from `-> None` to `-> NoReturn` from `typing`. Since `_error()` always calls `sys.exit()` and never returns, `NoReturn` lets mypy understand that code after `_error()` is unreachable — eliminating the need for `return  # unreachable` comments.

## Closes

Closes #50

## Changes

- [x] Implementation complete
- [x] All tests passing (146 passed, 0 failed)
- [x] Linting clean

## Plan

### Affected Files (4 files with `_error()`)

| File | Import Added | Annotation Changed | Unreachable Comments Removed |
|------|:---:|:---:|:---:|
| `src/tools/critique_runner.py` | `NoReturn` | `-> NoReturn` | 4 |
| `src/tools/scene_writer.py` | `NoReturn` | `-> NoReturn` | 3 |
| `src/tools/outline_generator.py` | `NoReturn` | `-> NoReturn` | 4 |
| `src/tools/recap_manager.py` | `NoReturn` | `-> NoReturn` | 2 |

**Total:** 4 files modified, 13 `return  # unreachable` comments removed.

### Note on Scope

The issue listed 9 files, but only 4 have the `_error()` helper function. The remaining 5 files (`character_manager.py`, `setting_manager.py`, `savepoint_manager.py`, `story_state.py`, `prompt_loader.py`) use inline `print(…, stderr) + sys.exit()` instead — they don't have an `_error()` function to annotate. Extracting `_error()` into those files would be a separate concern.