### PR TITLE
Add backslash rejection to _validate_slug()

### DIFF
--- a/.github/notes/reviews/2026-04-14-pr58-synthesis.md
+++ b/.github/notes/reviews/2026-04-14-pr58-synthesis.md
@@ -1,0 +1,33 @@
+## Synthesized Code Review — 2026-04-14
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** fix/issue-57-validate-slug-backslash
+**PR:** #58 (logicalor/llm-story-writer)
+**Model Agreement Score:** 9/10
+**Overall Assessment:** Clean
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 0          |
+| ★★☆ Majority      | 0        | 0       | 2          |
+| ★☆☆ Singular      | 0        | 1       | 2          |
+
+### Key Findings
+
+- [M-S-01] Add combined Windows-style traversal unit test (★★☆)
+- [M-S-02] Extend `_validate_glob_pattern` with backslash rejection for consistency (★★☆)
+- [S-W-01] Add integration-level backslash traversal test (★☆☆)
+- [S-S-01] Consider null byte rejection as defence-in-depth (★☆☆)
+- [S-S-02] Private function import style acknowledged as acceptable (★☆☆)
+
+### Divergences
+
+- [D-01] Test level for backslash coverage: Claude/GPT suggest a combined unit test; Gemini suggests an integration-level test at Warning severity. Both are valid — unit test is higher priority since it targets the function directly. Integration test is a nice-to-have.
+
+### Actions Required
+
+- Findings requiring fixes: 0
+- Findings deferred as follow-up suggestions: 4
+- Non-actionable observations: 1

--- a/src/tools/_wiki.py
+++ b/src/tools/_wiki.py
@@ -170,10 +170,10 @@ _TYPE_TO_DIR = {
 
 
 def _validate_slug(slug: str) -> None:
-    """Reject slugs containing path traversal sequences."""
-    if ".." in slug or "/" in slug:
+    """Reject slugs containing path traversal sequences or backslashes."""
+    if ".." in slug or "/" in slug or "\\" in slug:
         print(
-            f"Error: invalid slug (contains '..' or '/'): {slug}",
+            f"Error: invalid slug (contains '..', '/' or '\\'): {slug}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/unit/test_wiki_shared.py
+++ b/tests/unit/test_wiki_shared.py
@@ -28,6 +28,11 @@ class TestValidateSlug:
             _validate_slug("path/slug")
         assert exc_info.value.code == 1
 
+    def test_validate_slug_rejects_windows_traversal(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_slug("..\\..\\etc\\passwd")
+        assert exc_info.value.code == 1
+
     def test_validate_slug_accepts_valid_slug(self) -> None:
         # Should not raise or exit
         _validate_slug("valid-slug")

--- a/tests/unit/test_wiki_shared.py
+++ b/tests/unit/test_wiki_shared.py
@@ -1,0 +1,33 @@
+"""Verification tests for shared wiki utilities (src/tools/_wiki.py).
+
+Covers _validate_slug path-traversal rejection (Issue #57).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tools._wiki import _validate_slug
+
+
+class TestValidateSlug:
+    """Tests for _validate_slug path-traversal guard."""
+
+    def test_validate_slug_rejects_backslash(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_slug("some\\slug")
+        assert exc_info.value.code == 1
+
+    def test_validate_slug_rejects_dotdot(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_slug("..secret")
+        assert exc_info.value.code == 1
+
+    def test_validate_slug_rejects_forward_slash(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_slug("path/slug")
+        assert exc_info.value.code == 1
+
+    def test_validate_slug_accepts_valid_slug(self) -> None:
+        # Should not raise or exit
+        _validate_slug("valid-slug")


### PR DESCRIPTION
## Summary

Add backslash (`\`) rejection to `_validate_slug()` in `src/tools/_wiki.py`. The function previously rejected `..` and `/` but allowed backslashes, which could cause issues when slugs are used as ChromaDB document IDs, file path components, or wikilink references.

## Closes

Closes #57

## Changes

- [x] Implementation complete — added `"\\" in slug` check to `_validate_slug()`
- [x] All tests passing (verified — 217 passed, 0 failed)
- [x] Linting clean

## Plan

- **Implementation**: Add backslash to the existing validation condition, update error message and docstring
- **Verification tests**: `tests/unit/test_wiki_shared.py` — 4 test methods covering backslash, `..`, `/` rejection and valid slug acceptance

## Test Results

| Test | Status |
|------|--------|
| `test_validate_slug_rejects_backslash` | ✅ PASS |
| `test_validate_slug_rejects_dotdot` | ✅ PASS |
| `test_validate_slug_rejects_forward_slash` | ✅ PASS |
| `test_validate_slug_accepts_valid_slug` | ✅ PASS |