### PR TITLE
Add backslash and slash rejection to _validate_glob_pattern() for consistency

### DIFF
--- a/.github/notes/reflections/issue-59.md
+++ b/.github/notes/reflections/issue-59.md
@@ -1,0 +1,35 @@
+---
+date: "2026-04-14"
+issue: 59
+pr: 60
+category: agent
+targets:
+  - ".github/agents/orchestrator-v3.agent.md"
+  - ".github/notes/deferred.md"
+severity: minor
+status: active
+---
+
+## Review-to-issue pipeline validated; git-safe-publish.sh recurrence (6th)
+
+### Finding
+
+Two observations from issue #59 (defence-in-depth `/`/`\` rejection in `_validate_glob_pattern()`):
+
+1. **Positive signal — review-to-issue pipeline works.** This issue originated from Synthesized Review finding M-S-02 on PR #58, where reviewers flagged that `_validate_glob_pattern()` lacked the slash rejection already present in `_validate_slug()`. The finding was filed as issue #59 and resolved cleanly: 2-file change, 222 tests pass, 9/10 model agreement on the synthesized review. This validates the review pipeline's ability to spawn targeted follow-up issues for real security gaps.
+
+2. **Recurring friction — `scripts/git-safe-publish.sh` still missing.** The Orchestrator's Steps 5d, 7, and 8 reference this script. It does not exist (tracked since issue #1 in `deferred.md`). This is at least the 6th issue where manual `git add && git commit && git push` was required as a workaround. Issues #1, #4, #11, #16, and now #59 have all encountered this.
+
+### Observation
+
+The review-to-issue pipeline is working as designed — synthesized reviews catch genuine security consistency gaps and the resulting issues are well-scoped and quick to resolve. No agent changes needed for this path.
+
+The `git-safe-publish.sh` gap continues to accumulate friction but is already tracked in `deferred.md`. Each occurrence costs a few minutes of manual git commands. The script remains blocked on being prioritised as a migration task.
+
+### Suggested Improvement
+
+No new agent or instruction changes needed. The positive review-to-issue signal confirms the current process works. The `git-safe-publish.sh` gap is already tracked — recording the recurrence here for future prioritisation evidence.
+
+### Action Taken
+
+No action needed — positive validation of existing pipeline. Recurrence of known deferred item recorded for prioritisation evidence.

--- a/.github/notes/reviews/2026-04-14-pr60-synthesis.md
+++ b/.github/notes/reviews/2026-04-14-pr60-synthesis.md
@@ -1,0 +1,135 @@
+# Synthesized Code Review — PR #60
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**PR:** #60 — Add backslash and slash rejection to `_validate_glob_pattern()` for consistency
+**Issue:** #59 — Defence-in-depth improvement
+**Branch:** `fix/issue-59-glob-pattern-slash-rejection`
+**Base:** `development`
+**Model Agreement Score:** 9/10
+**Overall Assessment:** Clean
+
+---
+
+## Synthesis Overview
+
+This PR adds forward-slash (`/`) and backslash (`\`) rejection to `_validate_glob_pattern()` in `src/tools/_wiki.py`, bringing it to parity with the sibling `_validate_slug()` function. Four new unit tests cover each rejection path and the valid-pattern happy path. All three models unanimously assessed this PR as ready to merge with no critical or warning findings. The only divergence was minor — two models suggested an additional combined traversal test for symmetry, while the third explicitly noted this was unnecessary since individual vectors are already covered.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- |
+| Claude | Ready to merge — clean, minimal fix | Detailed security analysis of which attack patterns are now blocked; noted the M-S-02 provenance | 0 | 0 |
+| GPT    | Ready to merge — well-scoped | Suggested parametrized valid-pattern test for broader coverage | 0 | 0 |
+| Gemini | Ready to merge — no findings | Most thorough phase-by-phase structural audit; explicitly reasoned that combined traversal test is implicitly covered | 0 | 0 |
+
+**Claude** provided a focused review emphasizing the security rationale and the relationship to prior review finding M-S-02. Raised one suggestion for a combined traversal test.
+
+**GPT** aligned closely with Claude on the combined traversal suggestion and additionally proposed parametrizing the valid-pattern test with multiple glob patterns (`alice*`, `chapter-?`, `[a-z]*`) for broader coverage confidence.
+
+**Gemini** produced the most methodical phase-by-phase audit with explicit pass/fail tables for every checklist item. Found zero issues of any severity, explicitly noting that combined traversal is implicitly covered since individual characters are tested independently.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+None. All three models agree the PR is clean and ready to merge with no issues requiring action.
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-S-01] Consider combined traversal test for glob patterns
+Severity: Suggestion
+Category: Testing
+File: tests/unit/test_wiki_shared.py
+Lines: 42-62
+Detail: TestValidateSlug includes a combined Windows-style traversal test
+  (test_validate_slug_rejects_windows_traversal with "..\\..\\etc\\passwd")
+  that exercises multiple rejection conditions simultaneously.
+  TestValidateGlobPattern lacks an equivalent combined test. Both Claude and
+  GPT noted this as a symmetry gap — each individual vector is already tested,
+  but a combined scenario confirms short-circuit evaluation works correctly
+  when multiple violation characters are present.
+Models: Claude ✓ GPT ✓ Gemini ✗
+Dissenting view: Gemini explicitly noted that combined traversal is "already
+  covered implicitly since \ alone triggers rejection" — a technically correct
+  observation, but the symmetry argument from the majority is also valid from
+  a test-hygiene perspective.
+Suggestion: Add a test such as:
+  def test_validate_glob_pattern_rejects_combined_traversal(self) -> None:
+      with pytest.raises(SystemExit) as exc_info:
+          _validate_glob_pattern("..\\..\\etc\\passwd")
+      assert exc_info.value.code == 1
+```
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-S-01] Additional valid-pattern coverage via parametrize
+Severity: Suggestion
+Category: Testing
+File: tests/unit/test_wiki_shared.py
+Lines: 60-62
+Detail: The valid-pattern test only covers "*.md". Glob patterns legitimately
+  used in this codebase may include wildcards like "alice*" or character-class
+  patterns like "[a-z]*". GPT suggested parametrizing the test with multiple
+  valid patterns to increase confidence that the guard does not over-reject.
+Model: GPT
+Assessment: Reasonable suggestion for thoroughness, but the guard function is
+  trivially simple (three substring checks) and there is no realistic risk of
+  over-rejection. The existing "*.md" test adequately confirms the function
+  does not reject valid patterns. Low value — strictly nice-to-have.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Whether a combined traversal test is needed
+Claude says: Missing for symmetry with TestValidateSlug; minor gap.
+GPT says: Missing for symmetry; confirms short-circuit evaluation.
+Gemini says: Implicitly covered — "\ alone triggers rejection."
+Assessment: Gemini is technically correct that the combined case does not
+  exercise any new code path. However, the 2-vs-1 majority has a valid point
+  about test-suite symmetry and documentation intent. The suggestion should
+  not block merge; it is a minor enhancement that could be addressed in a
+  future housekeeping pass.
+Resolution: Classified as ★★☆ Suggestion. Does not block merge.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+No actions required before merge. The following are optional enhancements:
+
+1. [M-S-01] ★★☆ Consider: Add combined traversal test for glob pattern validation symmetry (Suggestion — 2/3 models agree)
+2. [S-S-01] ★☆☆ Consider: Parametrize valid-pattern test with additional patterns (Suggestion — 1 model only)
+
+---
+
+## Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 0          |
+| ★★☆ Majority      | 0        | 0       | 1          |
+| ★☆☆ Singular      | 0        | 0       | 1          |
+
+## Key Findings
+
+- [M-S-01] Combined traversal test for glob patterns — symmetry improvement (★★☆)
+- [S-S-01] Parametrize valid-pattern test — broader coverage (★☆☆)
+
+## Divergences
+
+- [D-01] Combined traversal test necessity — 2 models favour symmetry, 1 says implicitly covered; resolved as non-blocking suggestion
+
+## Actions Required
+
+- Findings requiring fixes: 0
+- Findings deferred: 2 (both are non-blocking suggestions)

--- a/src/tools/_wiki.py
+++ b/src/tools/_wiki.py
@@ -180,10 +180,10 @@ def _validate_slug(slug: str) -> None:
 
 
 def _validate_glob_pattern(pattern: str) -> None:
-    """Reject glob patterns containing path traversal sequences."""
-    if ".." in pattern:
+    """Reject glob patterns containing path traversal sequences or slashes."""
+    if ".." in pattern or "/" in pattern or "\\" in pattern:
         print(
-            f"Error: invalid glob pattern (contains '..'): {pattern}",
+            f"Error: invalid glob pattern (contains '..', '/' or '\\'): {pattern}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/unit/test_wiki_shared.py
+++ b/tests/unit/test_wiki_shared.py
@@ -1,13 +1,14 @@
 """Verification tests for shared wiki utilities (src/tools/_wiki.py).
 
-Covers _validate_slug path-traversal rejection (Issue #57).
+Covers _validate_slug path-traversal rejection (Issue #57) and
+_validate_glob_pattern slash/traversal rejection (Issue #59).
 """
 
 from __future__ import annotations
 
 import pytest
 
-from src.tools._wiki import _validate_slug
+from src.tools._wiki import _validate_glob_pattern, _validate_slug
 
 
 class TestValidateSlug:
@@ -36,3 +37,26 @@ class TestValidateSlug:
     def test_validate_slug_accepts_valid_slug(self) -> None:
         # Should not raise or exit
         _validate_slug("valid-slug")
+
+
+class TestValidateGlobPattern:
+    """Tests for _validate_glob_pattern path-traversal and slash guard."""
+
+    def test_validate_glob_pattern_rejects_backslash(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_glob_pattern("some\\pattern")
+        assert exc_info.value.code == 1
+
+    def test_validate_glob_pattern_rejects_forward_slash(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_glob_pattern("path/pattern")
+        assert exc_info.value.code == 1
+
+    def test_validate_glob_pattern_rejects_dotdot(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _validate_glob_pattern("..secret")
+        assert exc_info.value.code == 1
+
+    def test_validate_glob_pattern_accepts_valid_pattern(self) -> None:
+        # Should not raise or exit
+        _validate_glob_pattern("*.md")


### PR DESCRIPTION
## Summary

Add `/` and `\` character rejection to `_validate_glob_pattern()` in `src/tools/_wiki.py` for consistency with `_validate_slug()`. Defence-in-depth improvement identified during the Synthesized Review of PR #58 (finding M-S-02, majority consensus from Claude + GPT).

## Closes

Closes #59

## Changes

- [x] Implementation complete — `_validate_glob_pattern()` now rejects `..`, `/`, and `\`
- [x] All tests passing (222 passed, 0 failed)
- [x] Linting clean (changed files verified)

## Plan

**Affected Areas:** `src/tools/_wiki.py` only. No ChromaDB schema change.

**Tasks:**
1. ✅ Update `_validate_glob_pattern()` to reject `/` and `\` in addition to `..`
2. ✅ Update docstring and error message to match `_validate_slug()` style
3. ✅ Add 4 verification tests: `test_validate_glob_pattern_rejects_backslash`, `test_validate_glob_pattern_rejects_forward_slash`, `test_validate_glob_pattern_rejects_dotdot`, `test_validate_glob_pattern_accepts_valid_pattern`