### PR TITLE
Task 16: Build wiki-lint Tool

### DIFF
--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -87,6 +87,7 @@ Based on the changes, determine what documentation needs to be created or update
 > - For relative links: test they resolve from the doc's directory (e.g., from `docs/` to `.github/` requires `../`).
 > - For tool output formats: read the Python tool's `cmd_*` functions to verify the exact JSON structure returned (dict vs array, field names, status codes).
 > - For file extensions: check the Python tool's save/load logic to verify the actual file format used on disk — do not infer from the domain name.
+> - For inventory tables (tools, collections, agents, categories): cross-check table entries against the actual source of truth on disk (e.g., `ls .opencode/tools/` for tool tables, `ls src/tools/` for script tables). Verify both that every row has a matching file AND that every file has a matching row — pre-existing missing entries compound with new additions to produce wrong counts.
 > - No hardcoded URLs — reference the project's routing conventions instead.
 > - Scan the entire file for `TODO`, `[placeholder]`, `...` stubs, and trivially short sections (3 lines or fewer where substance is expected). Remove or complete them before committing.
 

--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -83,7 +83,7 @@ Prompt templates are **Markdown files** stored in the top-level `prompts/` direc
 
 ## Tools
 
-Fourteen tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
+Fifteen tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
 
 | Tool | Wrapper | Script | Infrastructure |
 |------|---------|--------|---------------|
@@ -100,6 +100,7 @@ Fourteen tools implemented following the hybrid pattern from [ADR 001](docs/plan
 | `wiki-read` | `.opencode/tools/wiki-read.ts` | `src/tools/wiki_read.py` | `_wiki.py` — page reading with detail levels, entity matching |
 | `wiki-search` | `.opencode/tools/wiki-search.ts` | `src/tools/wiki_search.py` | ChromaDB `PersistentClient` — semantic + metadata search over `wiki-<name>` collections |
 | `wiki-snapshot` | `.opencode/tools/wiki-snapshot.ts` | `src/tools/wiki_snapshot.py` | `_wiki.py` + `_llm.py` + ChromaDB — three-stage hybrid retrieval and context assembly pipeline (ADR 005) |
+| `wiki-update` | `.opencode/tools/wiki-update.ts` | `src/tools/wiki_update.py` | `_wiki.py` — page create/update/batch/timeline-append/log operations |
 | `wiki-lint` | `.opencode/tools/wiki-lint.ts` | `src/tools/wiki_lint.py` | `_wiki.py` + `_io.py` — post-chapter, full, and single-entity consistency checks with ConStory-Bench taxonomy |
 
 Pattern: `.opencode/tools/*.ts` (Zod schema + execFileSync) → `src/tools/*.py` (argparse + domain logic) → `src/infrastructure/` or `src/domain/`.

--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -83,7 +83,7 @@ Prompt templates are **Markdown files** stored in the top-level `prompts/` direc
 
 ## Tools
 
-Thirteen tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
+Fourteen tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
 
 | Tool | Wrapper | Script | Infrastructure |
 |------|---------|--------|---------------|
@@ -100,6 +100,7 @@ Thirteen tools implemented following the hybrid pattern from [ADR 001](docs/plan
 | `wiki-read` | `.opencode/tools/wiki-read.ts` | `src/tools/wiki_read.py` | `_wiki.py` — page reading with detail levels, entity matching |
 | `wiki-search` | `.opencode/tools/wiki-search.ts` | `src/tools/wiki_search.py` | ChromaDB `PersistentClient` — semantic + metadata search over `wiki-<name>` collections |
 | `wiki-snapshot` | `.opencode/tools/wiki-snapshot.ts` | `src/tools/wiki_snapshot.py` | `_wiki.py` + `_llm.py` + ChromaDB — three-stage hybrid retrieval and context assembly pipeline (ADR 005) |
+| `wiki-lint` | `.opencode/tools/wiki-lint.ts` | `src/tools/wiki_lint.py` | `_wiki.py` + `_io.py` — post-chapter, full, and single-entity consistency checks with ConStory-Bench taxonomy |
 
 Pattern: `.opencode/tools/*.ts` (Zod schema + execFileSync) → `src/tools/*.py` (argparse + domain logic) → `src/infrastructure/` or `src/domain/`.
 

--- a/.github/notes/reflections/issue-17-documenter-count-compounding.md
+++ b/.github/notes/reflections/issue-17-documenter-count-compounding.md
@@ -1,0 +1,38 @@
+---
+date: "2026-04-15"
+issue: 17
+pr: 61
+category: agent
+targets:
+  - ".github/agents/documenter.agent.md"
+severity: minor
+status: active
+---
+
+## Documenter tool count wrong AND pre-existing missing table entry — compounding errors
+
+### Finding
+
+During issue #17 (Build wiki-lint Tool), the Documenter updated the tool count in `.github/notes/architecture.md` to "Fourteen" and added wiki-lint to the table. However, wiki-update (PR #56, issue #14) was already absent from the table — the correct count should have been "Fifteen" (14 existing + 1 new). Only 1 of 3 review models (Gemini) caught the count discrepancy; Claude incorrectly assessed the count as accurate.
+
+### Observation
+
+This is the **seventh** occurrence of the stale-count pattern (issues #4, #5, #11, #12, #30, #13, #17) but introduces a new failure mode: **compounding**. Previous occurrences were simple count inaccuracies — the Coder or Documenter updated the count to the wrong number. This time, the Documenter got the count wrong because a *prior entry was missing from the table entirely*. The Documenter added its new entry and counted the table rows, but the table was already incomplete.
+
+The Documenter's verification checklist (Step 3) already covers directory trees ("re-run `ls` or `find` on the actual directory"), file paths, output formats, and file extensions. But it does not cover **inventory table completeness** — verifying that all items that should be in a table actually are, not just that the count label matches the row count.
+
+The root cause is that the Documenter trusts the existing table content as a baseline and only adds/modifies entries for the current task. It does not cross-check the table against the actual files on disk to detect pre-existing gaps.
+
+### Suggested Improvement
+
+Add a verification bullet to the Documenter's Step 3 verification checklist (`.github/agents/documenter.agent.md`):
+
+```markdown
+> - For inventory tables (tools, collections, agents, categories): cross-check table entries against the actual source of truth on disk (e.g., `ls .opencode/tools/` for tool tables, `ls src/tools/` for script tables). Verify both that every row has a matching file AND that every file has a matching row — pre-existing missing entries compound with new additions to produce wrong counts.
+```
+
+This is a clarification — adding a missing verification example to the existing checklist, same pattern as the existing directory tree and file extension bullets.
+
+### Action Taken
+
+Applied: added inventory table verification bullet to the Documenter's Step 3 verification checklist.

--- a/.github/notes/reflections/issue-17-import-pattern-deviation.md
+++ b/.github/notes/reflections/issue-17-import-pattern-deviation.md
@@ -1,0 +1,35 @@
+---
+date: "2026-04-15"
+issue: 17
+pr: 61
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Coder used `__import__("os")` instead of importing STORIES_DIR from `_io.py`
+
+### Finding
+
+During issue #17 (Build wiki-lint Tool), the Coder defined its own `STORIES_DIR` using `__import__("os").environ.get(...)` instead of importing `STORIES_DIR` from `src/tools/_io.py` like every other tool in the codebase. The `__import__("os")` pattern exists nowhere else in the codebase. The Synthesized Review caught this as a Unanimous Warning.
+
+### Observation
+
+This is the same class of defect as issue #6 (Coder pattern amnesia) — an established pattern (`from src.tools._io import STORIES_DIR`) exists across all 14 other tools but was not carried forward to the new implementation. The proposed Rule 10 (prior-tool review, still pending approval from the issue #6 reflection) would have caught this: reviewing any prior wiki tool would have shown the `_io.py` import pattern.
+
+The `_io.py` module was specifically created (issue #53, PR #55) to centralise `STORIES_DIR`, `_validate_story_name`, and `_atomic_write` — eliminating exactly this kind of drift. The Coder reimplemented what the shared module already provides.
+
+This is the third confirmed instance of the pattern-amnesia class:
+- Issue #3: subprocess injection and path traversal patterns not applied → fixed by Rule 9
+- Issue #6: atomic writes not applied → proposed Rule 10 (pending)
+- Issue #17: shared import pattern not used → additional evidence for Rule 10
+
+### Suggested Improvement
+
+No new rule needed — this is additional supporting evidence for the pending Rule 10 proposal (issue #6 reflection). The fix was applied during the review cycle.
+
+### Action Taken
+
+Recorded as supporting evidence for the pending Rule 10 proposal. No agent changes needed — the review system caught and fixed this in the current PR.

--- a/.github/notes/reflections/issue-17-reference-field-hardcoding.md
+++ b/.github/notes/reflections/issue-17-reference-field-hardcoding.md
@@ -1,0 +1,35 @@
+---
+date: "2026-04-15"
+issue: 17
+pr: 61
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Stale-claim finding message hardcoded wrong field name
+
+### Finding
+
+During issue #17 (Build wiki-lint Tool), the stale-claim check's finding message hardcoded "first_appearance" as the source field, even when the `page_chapter` value was actually sourced from the `last_updated` YAML field. Two of 3 review models caught this. The fix introduced a `reference_field` variable that tracks which field actually provided the chapter reference.
+
+### Observation
+
+This is another instance of the wiring bug / semantic correctness gap documented in the issue #10 reflection. The Coder correctly implemented the logic to check multiple YAML fields (`first_appearance`, `last_updated`) but hardcoded the diagnostic message to always reference `first_appearance`. The data flow from field detection to message composition was broken — the detection logic was correct, but the message didn't reflect which path was taken.
+
+This follows the same pattern as:
+- Issue #10: `cmd_refine()` accepted `--feedback` but never passed it to the LLM
+- Issue #15: Cache populated but never read by its consumer
+- Issue #17: Field source detected correctly but message hardcoded to wrong field
+
+The proposed semantic verification rule (issue #10, pending approval) would catch this — tracing the data flow from field detection to message composition would reveal the hardcoded string.
+
+### Suggested Improvement
+
+No new rule needed — this is additional supporting evidence for the pending issue #10 semantic verification rule proposal. The fix was applied during the review cycle.
+
+### Action Taken
+
+Recorded as supporting evidence for the pending issue-10 semantic verification rule proposal. No agent changes needed — the review system caught and fixed this in the current PR.

--- a/.github/notes/reviews/2026-04-15-synthesis.md
+++ b/.github/notes/reviews/2026-04-15-synthesis.md
@@ -1,0 +1,31 @@
+## Synthesized Code Review — 2026-04-15
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-17-wiki-lint-tool
+**Model Agreement Score:** 8/10
+**Overall Assessment:** Needs Fixes
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 1       | 0          |
+| ★★☆ Majority      | 0        | 1       | 3          |
+| ★☆☆ Singular      | 0        | 0       | 4          |
+
+### Key Findings
+
+- [U-W-01] Duplicate STORIES_DIR with non-standard `__import__("os")` (★★★)
+- [M-W-01] architecture.md tool count wrong — says 14, should be 15 (★★☆)
+- [M-S-01] Missing test coverage for check-full subtypes (★★☆)
+- [M-S-02] Misleading comment about "version field" in stale-claims logic (★★☆)
+- [M-S-03] Stale-claim message misattributes staleness baseline (★★☆)
+
+### Divergences
+
+- [D-01] architecture.md tool count accuracy — Gemini caught wiki-update missing; Claude said count was accurate (Gemini correct, verified 15 .ts wrappers on disk)
+
+### Actions Required
+
+- Findings requiring fixes: 2 (U-W-01, M-W-01)
+- Findings deferred: 5

--- a/.opencode/tools/wiki-lint.ts
+++ b/.opencode/tools/wiki-lint.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "wiki-lint",
+  description:
+    "Run consistency checks across the story wiki. Operations: check-chapter (post-chapter contradiction detection), check-full (comprehensive lint), check-entity (single entity validation).",
+  parameters: z.object({
+    operation: z
+      .enum(["check-chapter", "check-full", "check-entity"])
+      .describe("Lint operation"),
+    name: z.string().describe("Story name"),
+    chapter_number: z
+      .number()
+      .optional()
+      .describe("Chapter number (required for check-chapter)"),
+    chapter_text: z
+      .string()
+      .optional()
+      .describe("File path to chapter content (required for check-chapter)"),
+    current_chapter: z
+      .number()
+      .optional()
+      .describe("Current chapter number (required for check-full)"),
+    slug: z
+      .string()
+      .optional()
+      .describe("Entity slug (required for check-entity)"),
+  }),
+  execute: async ({
+    operation,
+    name,
+    chapter_number,
+    chapter_text,
+    current_chapter,
+    slug,
+  }: {
+    operation: string;
+    name: string;
+    chapter_number?: number;
+    chapter_text?: string;
+    current_chapter?: number;
+    slug?: string;
+  }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = [
+      "src/tools/wiki_lint.py",
+      "--operation",
+      operation,
+      "--name",
+      name,
+    ];
+
+    if (chapter_number !== undefined) {
+      args.push("--chapter-number", String(chapter_number));
+    }
+    if (chapter_text) {
+      args.push("--chapter-text", chapter_text);
+    }
+    if (current_chapter !== undefined) {
+      args.push("--current-chapter", String(current_chapter));
+    }
+    if (slug) {
+      args.push("--slug", slug);
+    }
+
+    try {
+      const stdout = execFileSync("python3", args, {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message =
+        execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 ## Tools
 
-- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader, story-state, savepoint-mgr, character-mgr, setting-mgr, recap-manager, outline-generator, scene-writer, critique-runner, wiki-init, wiki-read, wiki-search, wiki-snapshot, and wiki-update tools, guide for adding new tools
+- [Tools Reference](./tools.md) — Tool architecture pattern, prompt-loader, story-state, savepoint-mgr, character-mgr, setting-mgr, recap-manager, outline-generator, scene-writer, critique-runner, wiki-init, wiki-read, wiki-search, wiki-snapshot, wiki-update, and wiki-lint tools, guide for adding new tools
 
 ## Planning
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1713,6 +1713,173 @@ ChromaDB failures are non-fatal — the tool logs a warning to stderr and contin
 
 ---
 
+## wiki-lint
+
+Runs consistency checks across the story wiki — post-chapter contradiction detection, comprehensive periodic lint, and single entity validation. Uses the ConStory-Bench taxonomy for finding classification.
+
+**Source files:**
+- `.opencode/tools/wiki-lint.ts` — TypeScript wrapper
+- `src/tools/wiki_lint.py` — Python CLI script
+- `src/tools/_wiki.py` — Shared wiki utilities (`parse_frontmatter`, `find_pages`, `read_index`, `match_entities_in_text`, `WIKI_SUBDIRS`, `_TYPE_TO_DIR`)
+- `src/tools/_io.py` — Shared I/O utilities (`_atomic_write`, `_validate_story_name`)
+
+### Purpose
+
+As a story progresses, the wiki accumulates pages across characters, locations, events, factions, and other entity types. Inconsistencies can develop: dead characters mentioned in new chapters, broken wikilinks, orphan pages missing from the index, stale pages not updated for many chapters, or pages placed in the wrong type directory. This tool provides automated detection of these issues.
+
+All three operations produce findings in a common format with severity levels (error, warning, info), ConStory-Bench categories, and suggested fixes. Findings from `check-chapter` and `check-full` are also appended to `wiki/contradictions.md` for persistent tracking.
+
+### Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `operation` | `"check-chapter" \| "check-full" \| "check-entity"` | Yes | Lint operation to perform |
+| `name` | string | Yes | Story name (maps to directory under `stories/`) |
+| `chapter_number` | integer | For `check-chapter` | Chapter number being checked |
+| `chapter_text` | string | For `check-chapter` | File path to chapter content (must be within `stories/` directory) |
+| `current_chapter` | integer | For `check-full` | Current chapter number (used for staleness calculations) |
+| `slug` | string | For `check-entity` | Entity slug to validate |
+
+### CLI Interface (Python script)
+
+```bash
+python3 src/tools/wiki_lint.py --operation <op> --name <name> [options]
+```
+
+**Examples:**
+
+```bash
+# Check a newly written chapter for contradictions
+python3 src/tools/wiki_lint.py --operation check-chapter --name my-story \
+  --chapter-number 5 --chapter-text stories/my-story/chapters/chapter_5.md
+
+# Run a full wiki lint at chapter 12
+python3 src/tools/wiki_lint.py --operation check-full --name my-story \
+  --current-chapter 12
+
+# Validate a single entity page
+python3 src/tools/wiki_lint.py --operation check-entity --name my-story \
+  --slug elena-blackwood
+```
+
+### Operations
+
+| Operation | Effect | Output |
+|-----------|--------|--------|
+| `check-chapter` | Scans chapter text for entity mentions, broken wikilinks, and timeline ordering issues. Appends findings to `contradictions.md`. | Findings JSON (see Output Format below) |
+| `check-full` | Comprehensive lint: orphan pages, stale claims, broken wikilinks, timeline ordering, confidence downgrades, index/frontmatter mismatches, wrong directory placement. Appends findings to `contradictions.md`. | Findings JSON |
+| `check-entity` | Validates a single entity page: required frontmatter fields, detail levels, wikilink resolution, index presence, correct type directory. Appends findings to `contradictions.md`. | Findings JSON |
+
+### Output Format
+
+All operations return the same JSON structure:
+
+```json
+{
+  "status": "ok",
+  "operation": "<operation>",
+  "findings": [
+    {
+      "severity": "error",
+      "category": "characterization",
+      "subtype": "status_contradiction",
+      "pages": ["elena-blackwood"],
+      "message": "Character 'Elena Blackwood' has status 'dead' in wiki but is mentioned in chapter 5",
+      "suggested_fix": "Verify if 'Elena Blackwood' should be alive or if the mention is a flashback/memory"
+    }
+  ],
+  "summary": {
+    "errors": 1,
+    "warnings": 0,
+    "info": 0,
+    "total": 1
+  }
+}
+```
+
+### check-chapter Checks
+
+Post-chapter contradiction detection runs these checks against the chapter text:
+
+| Check | Severity | Category / Subtype | Description |
+|-------|----------|-------------------|-------------|
+| Missing entity page | warning | `factual_consistency` / `missing_entity` | Entity mentioned in chapter has no wiki page |
+| Dead character mention | error | `characterization` / `status_contradiction` | Character with `status: dead` in wiki is mentioned in the chapter |
+| Broken wikilink | warning | `factual_consistency` / `broken_wikilink` | `[[slug]]` in chapter text points to non-existent page |
+| Timeline ordering | warning | `timeline_plot_logic` / `chapter_ordering_violation` | Timeline contains entries for chapters ahead of the current one |
+
+### check-full Checks
+
+Comprehensive periodic lint runs these checks across the entire wiki:
+
+| Check | Severity | Category / Subtype | Description |
+|-------|----------|-------------------|-------------|
+| Orphan page (no index entry) | warning | `factual_consistency` / `orphan_reference` | Page exists on disk but is not listed in `index.md` |
+| Orphan index entry (no file) | warning | `factual_consistency` / `orphan_reference` | Index entry has no corresponding `.md` file |
+| Stale claim | info | `narrative_style` / `stale_claim` | Page not updated for 5+ chapters |
+| Confidence downgrade | info | `narrative_style` / `confidence_downgrade` | Page has `confidence: verified` but not updated for 10+ chapters |
+| Broken wikilink | warning | `factual_consistency` / `broken_wikilink` | Wikilink in page body points to non-existent page |
+| Timeline ordering | error | `timeline_plot_logic` / `temporal_ordering` | Timeline chapter numbers are not monotonically non-decreasing |
+| Type mismatch | warning | `factual_consistency` / `naming_inconsistency` | Index type does not match page frontmatter type |
+| Wrong directory | warning | `factual_consistency` / `naming_inconsistency` | Page is in the wrong subdirectory for its type |
+
+### check-entity Checks
+
+Single entity validation runs these checks on one page:
+
+| Check | Severity | Category / Subtype | Description |
+|-------|----------|-------------------|-------------|
+| Missing page | error | `factual_consistency` / `missing_entity` | No wiki page found for the given slug |
+| Missing required field | error | `factual_consistency` / `missing_entity` | Page is missing a required frontmatter field (`type`, `name`, `slug`, `confidence`, `first_appearance`) |
+| Missing detail level | warning | `narrative_style` / `stale_claim` | Page is missing L1, L2, or L3 in `detail_levels` |
+| Broken wikilink | warning | `factual_consistency` / `broken_wikilink` | Wikilink in page body points to non-existent page |
+| Not in index | warning | `factual_consistency` / `orphan_reference` | Page exists but is not listed in `index.md` |
+| Wrong directory | warning | `factual_consistency` / `naming_inconsistency` | Page is in the wrong subdirectory for its type |
+
+### ConStory-Bench Categories
+
+Findings are classified using categories from the ConStory-Bench contradiction taxonomy:
+
+| Category | Used For |
+|----------|----------|
+| `timeline_plot_logic` | Timeline ordering violations |
+| `characterization` | Character status contradictions (e.g., dead character mentioned) |
+| `factual_consistency` | Missing entities, broken wikilinks, orphans, type mismatches |
+| `narrative_style` | Stale claims, missing detail levels, confidence downgrades |
+| `world_building` | Reserved for future world-rule violation checks |
+
+### Contradictions Log
+
+The `check-chapter` and `check-full` operations append findings to `wiki/contradictions.md` with a timestamped header:
+
+```markdown
+## 2026-04-15T10:30:00Z — Chapter 5 check
+
+- **error** characterization/status_contradiction: Character 'Elena' has status 'dead' — Pages: elena-blackwood
+- **warning** factual_consistency/broken_wikilink: Wikilink [[old-castle]] points to non-existent page — Pages: old-castle
+```
+
+The `check-entity` operation also appends its findings to `contradictions.md`.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — result printed to stdout as JSON |
+| 1 | Domain error — story not found, chapter-text file not found, chapter-text path outside stories directory |
+| 2 | Argument error — missing required flag for the chosen operation |
+
+### Security
+
+- **Path traversal prevention (story name)** — story names are validated with `_validate_story_name()` (uses `Path.is_relative_to()`)
+- **Path traversal prevention (chapter-text)** — chapter text file paths are resolved and validated to be within the `stories/` directory
+- **Path traversal prevention (slug)** — slugs are validated with `_validate_slug()` to reject traversal patterns
+- **Shell injection prevention** — the TypeScript wrapper uses `execFileSync` with an argument array, never shell interpolation
+- **Graceful empty state** — returns `{"findings": []}` if the wiki directory does not exist
+- **Test isolation** — the `STORIES_DIR` environment variable overrides the default stories directory, ensuring tests never touch production data
+
+---
+
 ## Adding a New Tool
 
 Follow this pattern to add tools to the system:

--- a/src/tools/wiki_lint.py
+++ b/src/tools/wiki_lint.py
@@ -1,0 +1,678 @@
+"""CLI tool for running consistency checks across the story wiki."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src = str(Path(__file__).resolve().parents[1])
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from src.tools._io import _atomic_write, _validate_story_name  # noqa: E402
+from src.tools._wiki import (  # noqa: E402
+    WIKI_SUBDIRS,
+    _TYPE_TO_DIR,
+    _validate_slug,
+    find_pages,
+    get_wiki_dir,
+    match_entities_in_text,
+    parse_frontmatter,
+    read_index,
+)
+
+STORIES_DIR = Path(
+    __import__("os").environ.get("STORIES_DIR", str(PROJECT_ROOT / "stories"))
+)
+
+# Wikilink pattern: [[slug]] or [[slug|display text]]
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+
+# Timeline entry pattern: - **Chapter N** — TIME — DESCRIPTION
+_TIMELINE_RE = re.compile(r"- \*\*Chapter (\d+)\*\* — (.+?) — (.+)")
+
+# Required frontmatter fields for entity pages
+_REQUIRED_FIELDS = ("type", "name", "slug", "confidence", "first_appearance")
+
+
+# ---------------------------------------------------------------------------
+# Finding dataclass
+# ---------------------------------------------------------------------------
+
+
+def _finding(
+    severity: str,
+    category: str,
+    subtype: str,
+    pages: list[str],
+    message: str,
+    suggested_fix: str,
+) -> dict:
+    """Build a finding dict."""
+    return {
+        "severity": severity,
+        "category": category,
+        "subtype": subtype,
+        "pages": pages,
+        "message": message,
+        "suggested_fix": suggested_fix,
+    }
+
+
+def _summarise(findings: list[dict]) -> dict:
+    """Count findings by severity."""
+    errors = sum(1 for f in findings if f["severity"] == "error")
+    warnings = sum(1 for f in findings if f["severity"] == "warning")
+    info = sum(1 for f in findings if f["severity"] == "info")
+    return {
+        "errors": errors,
+        "warnings": warnings,
+        "info": info,
+        "total": len(findings),
+    }
+
+
+def _output(operation: str, findings: list[dict]) -> None:
+    """Print JSON report to stdout."""
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "operation": operation,
+                "findings": findings,
+                "summary": _summarise(findings),
+            },
+            indent=2,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contradictions.md append
+# ---------------------------------------------------------------------------
+
+
+def _append_contradictions(wiki_dir: Path, label: str, findings: list[dict]) -> None:
+    """Append new findings to wiki/contradictions.md."""
+    if not findings:
+        return
+
+    contradict_path = wiki_dir / "contradictions.md"
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    lines: list[str] = [f"\n## {ts} — {label}\n"]
+    for f in findings:
+        page_list = ", ".join(f["pages"]) if f["pages"] else "n/a"
+        lines.append(
+            f"- **{f['severity']}** {f['category']}/{f['subtype']}: "
+            f"{f['message']} — Pages: {page_list}"
+        )
+    lines.append("")
+
+    block = "\n".join(lines)
+
+    if contradict_path.exists():
+        content = contradict_path.read_text()
+    else:
+        content = "# Contradictions\n"
+
+    content = content.rstrip("\n") + "\n" + block
+    _atomic_write(contradict_path, content)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_wikilinks(text: str) -> list[str]:
+    """Extract wikilink slugs from markdown text."""
+    return _WIKILINK_RE.findall(text)
+
+
+def _all_wiki_slugs(wiki_dir: Path) -> set[str]:
+    """Return set of all slugs that have a .md page on disk."""
+    slugs: set[str] = set()
+    for subdir in WIKI_SUBDIRS:
+        subdir_path = wiki_dir / subdir
+        if not subdir_path.exists():
+            continue
+        for p in subdir_path.glob("*.md"):
+            if p.resolve().is_relative_to(wiki_dir.resolve()):
+                slugs.add(p.stem)
+    return slugs
+
+
+def _parse_timeline(wiki_dir: Path) -> list[dict]:
+    """Parse main-timeline.md and return list of {chapter, time, description}."""
+    tl_path = wiki_dir / "timeline" / "main-timeline.md"
+    if not tl_path.exists():
+        return []
+
+    entries: list[dict] = []
+    for line in tl_path.read_text().splitlines():
+        m = _TIMELINE_RE.match(line.strip())
+        if m:
+            entries.append(
+                {
+                    "chapter": int(m.group(1)),
+                    "time": m.group(2),
+                    "description": m.group(3),
+                }
+            )
+    return entries
+
+
+def _all_filesystem_pages(wiki_dir: Path) -> dict[str, Path]:
+    """Return {slug: path} for all .md pages in wiki subdirs."""
+    pages: dict[str, Path] = {}
+    for subdir in WIKI_SUBDIRS:
+        subdir_path = wiki_dir / subdir
+        if not subdir_path.exists():
+            continue
+        for p in sorted(subdir_path.glob("*.md")):
+            if p.resolve().is_relative_to(wiki_dir.resolve()):
+                pages[p.stem] = p
+    return pages
+
+
+# ---------------------------------------------------------------------------
+# Command: check-chapter
+# ---------------------------------------------------------------------------
+
+
+def cmd_check_chapter(args: argparse.Namespace) -> None:
+    """Run post-chapter contradiction detection."""
+    # Validate required args first
+    if not args.chapter_text:
+        print("Error: --chapter-text is required for check-chapter", file=sys.stderr)
+        sys.exit(2)
+    if args.chapter_number is None:
+        print("Error: --chapter-number is required for check-chapter", file=sys.stderr)
+        sys.exit(2)
+
+    story_dir = _validate_story_name(args.name)
+
+    # Validate chapter-text path before any file I/O
+    chapter_path = Path(args.chapter_text).resolve()
+    stories_resolved = STORIES_DIR.resolve()
+    if not chapter_path.is_relative_to(stories_resolved):
+        print(
+            "Error: chapter-text path must be within the stories directory",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not chapter_path.exists():
+        print(
+            f"Error: chapter-text file not found: {args.chapter_text}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    wiki_dir = get_wiki_dir(story_dir)
+
+    if not wiki_dir.exists():
+        _output("check-chapter", [])
+        return
+
+    chapter_text = chapter_path.read_text()
+    chapter_num: int = args.chapter_number
+
+    index_entries = read_index(wiki_dir)
+    all_slugs = _all_wiki_slugs(wiki_dir)
+    findings: list[dict] = []
+
+    # --- Entity mentions cross-reference ---
+    matched = match_entities_in_text(chapter_text, index_entries)
+    for entry in matched:
+        slug = entry["slug"]
+        # Check if entity has a wiki page
+        pages = find_pages(wiki_dir, slug=slug)
+        if not pages:
+            findings.append(
+                _finding(
+                    "warning",
+                    "factual_consistency",
+                    "missing_entity",
+                    [slug],
+                    f"Entity '{entry['name']}' mentioned in chapter {chapter_num} "
+                    f"but has no wiki page",
+                    f"Create a wiki page for '{entry['name']}' with slug '{slug}'",
+                )
+            )
+            continue
+
+        # Check character status contradictions
+        page_content = pages[0].read_text()
+        metadata, _body = parse_frontmatter(page_content)
+        if metadata.get("type") == "character" and metadata.get("status") == "dead":
+            findings.append(
+                _finding(
+                    "error",
+                    "characterization",
+                    "status_contradiction",
+                    [slug],
+                    f"Character '{entry['name']}' has status 'dead' in wiki "
+                    f"but is mentioned in chapter {chapter_num}",
+                    f"Verify if '{entry['name']}' should be alive or if the "
+                    f"mention is a flashback/memory",
+                )
+            )
+
+    # --- Broken wikilinks in chapter text ---
+    wikilinks = _extract_wikilinks(chapter_text)
+    for link_slug in wikilinks:
+        if link_slug not in all_slugs:
+            findings.append(
+                _finding(
+                    "warning",
+                    "factual_consistency",
+                    "broken_wikilink",
+                    [link_slug],
+                    f"Wikilink [[{link_slug}]] in chapter {chapter_num} "
+                    f"points to non-existent page",
+                    f"Create page for '{link_slug}' or fix the wikilink",
+                )
+            )
+
+    # --- Timeline ordering check ---
+    timeline = _parse_timeline(wiki_dir)
+    if timeline:
+        for entry in timeline:
+            if entry["chapter"] > chapter_num:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "timeline_plot_logic",
+                        "chapter_ordering_violation",
+                        [],
+                        f"Timeline contains entry for chapter {entry['chapter']} "
+                        f"which is ahead of current chapter {chapter_num}: "
+                        f"'{entry['description']}'",
+                        "Verify timeline entry is correct or remove future entries",
+                    )
+                )
+
+    # Append to contradictions.md
+    _append_contradictions(wiki_dir, f"Chapter {chapter_num} check", findings)
+
+    _output("check-chapter", findings)
+
+
+# ---------------------------------------------------------------------------
+# Command: check-full
+# ---------------------------------------------------------------------------
+
+
+def cmd_check_full(args: argparse.Namespace) -> None:
+    """Run comprehensive wiki lint."""
+    story_dir = _validate_story_name(args.name)
+    wiki_dir = get_wiki_dir(story_dir)
+
+    if not wiki_dir.exists():
+        _output("check-full", [])
+        return
+
+    if args.current_chapter is None:
+        print("Error: --current-chapter is required for check-full", file=sys.stderr)
+        sys.exit(2)
+
+    current_chapter: int = args.current_chapter
+    findings: list[dict] = []
+
+    index_entries = read_index(wiki_dir)
+    index_slugs = {e["slug"] for e in index_entries}
+    fs_pages = _all_filesystem_pages(wiki_dir)
+    fs_slugs = set(fs_pages.keys())
+
+    # --- Orphan detection ---
+    # Pages on disk but not in index
+    for slug in sorted(fs_slugs - index_slugs):
+        findings.append(
+            _finding(
+                "warning",
+                "factual_consistency",
+                "orphan_reference",
+                [slug],
+                f"Page '{slug}' exists on disk but is not listed in index.md",
+                f"Add '{slug}' to index.md or remove the orphan page",
+            )
+        )
+
+    # Entries in index with no file
+    for slug in sorted(index_slugs - fs_slugs):
+        findings.append(
+            _finding(
+                "warning",
+                "factual_consistency",
+                "orphan_reference",
+                [slug],
+                f"Index entry '{slug}' has no corresponding .md file on disk",
+                f"Create the page for '{slug}' or remove from index.md",
+            )
+        )
+
+    # --- Stale claims ---
+    for slug, page_path in sorted(fs_pages.items()):
+        content = page_path.read_text()
+        metadata, _body = parse_frontmatter(content)
+
+        first_app = metadata.get("first_appearance")
+        last_updated = metadata.get("last_updated")
+
+        # Try to extract a chapter number from last_updated or version
+        # Use first_appearance as the page's chapter reference
+        page_chapter = None
+        if isinstance(first_app, int):
+            page_chapter = first_app
+
+        # Check version field for a chapter-based staleness heuristic
+        # Use last_updated if it's a chapter number (int)
+        if isinstance(last_updated, int):
+            page_chapter = last_updated
+        elif isinstance(last_updated, str):
+            # last_updated is a timestamp string; check first_appearance instead
+            pass
+
+        if page_chapter is not None and current_chapter - page_chapter > 5:
+            findings.append(
+                _finding(
+                    "info",
+                    "narrative_style",
+                    "stale_claim",
+                    [slug],
+                    f"Page '{slug}' (first_appearance: {first_app}) "
+                    f"has not been updated in {current_chapter - page_chapter}+ chapters "
+                    f"(current: {current_chapter})",
+                    f"Review and update '{slug}' for current chapter relevance",
+                )
+            )
+
+        # --- Confidence downgrade candidates ---
+        if (
+            metadata.get("confidence") == "verified"
+            and page_chapter is not None
+            and current_chapter - page_chapter >= 10
+        ):
+            findings.append(
+                _finding(
+                    "info",
+                    "narrative_style",
+                    "confidence_downgrade",
+                    [slug],
+                    f"Page '{slug}' has confidence 'verified' but hasn't been "
+                    f"updated in {current_chapter - page_chapter}+ chapters — "
+                    f"may need review",
+                    f"Re-verify '{slug}' or downgrade confidence to 'speculative'",
+                )
+            )
+
+    # --- Missing cross-references (broken wikilinks) ---
+    all_slugs = _all_wiki_slugs(wiki_dir)
+    for slug, page_path in sorted(fs_pages.items()):
+        content = page_path.read_text()
+        _metadata, body = parse_frontmatter(content)
+        wikilinks = _extract_wikilinks(body)
+        for link_slug in wikilinks:
+            if link_slug not in all_slugs:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "factual_consistency",
+                        "broken_wikilink",
+                        [slug, link_slug],
+                        f"Page '{slug}' contains wikilink [[{link_slug}]] "
+                        f"pointing to non-existent page",
+                        f"Create page for '{link_slug}' or fix the wikilink in '{slug}'",
+                    )
+                )
+
+    # --- Timeline ordering ---
+    timeline = _parse_timeline(wiki_dir)
+    if timeline:
+        prev_chapter = -1
+        for entry in timeline:
+            ch = entry["chapter"]
+            if ch < prev_chapter:
+                findings.append(
+                    _finding(
+                        "error",
+                        "timeline_plot_logic",
+                        "temporal_ordering",
+                        [],
+                        f"Timeline chapter numbers are not monotonically non-decreasing: "
+                        f"chapter {ch} appears after chapter {prev_chapter}",
+                        "Re-order timeline entries so chapter numbers are non-decreasing",
+                    )
+                )
+            prev_chapter = ch
+
+    # --- Index integrity ---
+    for entry in index_entries:
+        slug = entry["slug"]
+        page_type = entry["type"]
+        if slug in fs_pages:
+            page_path = fs_pages[slug]
+            content = page_path.read_text()
+            metadata, _body = parse_frontmatter(content)
+            # Check type matches
+            fm_type = metadata.get("type", "")
+            if fm_type and fm_type != page_type:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "factual_consistency",
+                        "naming_inconsistency",
+                        [slug],
+                        f"Index lists '{slug}' as type '{page_type}' but page "
+                        f"frontmatter says '{fm_type}'",
+                        f"Update index or page frontmatter for '{slug}' to match",
+                    )
+                )
+            # Check correct directory
+            expected_dir = _TYPE_TO_DIR.get(fm_type, "")
+            if expected_dir:
+                actual_dir = page_path.parent.name
+                if actual_dir != expected_dir:
+                    findings.append(
+                        _finding(
+                            "warning",
+                            "factual_consistency",
+                            "naming_inconsistency",
+                            [slug],
+                            f"Page '{slug}' is in directory '{actual_dir}' but "
+                            f"type '{fm_type}' should be in '{expected_dir}'",
+                            f"Move '{slug}.md' to {expected_dir}/",
+                        )
+                    )
+
+    # Append to contradictions.md
+    _append_contradictions(wiki_dir, "Full lint", findings)
+
+    _output("check-full", findings)
+
+
+# ---------------------------------------------------------------------------
+# Command: check-entity
+# ---------------------------------------------------------------------------
+
+
+def cmd_check_entity(args: argparse.Namespace) -> None:
+    """Validate a single entity page."""
+    story_dir = _validate_story_name(args.name)
+    wiki_dir = get_wiki_dir(story_dir)
+
+    if not args.slug:
+        print("Error: --slug is required for check-entity", file=sys.stderr)
+        sys.exit(2)
+
+    slug = args.slug
+    _validate_slug(slug)
+
+    findings: list[dict] = []
+
+    if not wiki_dir.exists():
+        findings.append(
+            _finding(
+                "error",
+                "factual_consistency",
+                "missing_entity",
+                [slug],
+                f"Wiki directory does not exist for story '{args.name}'",
+                "Initialise the wiki with wiki-init",
+            )
+        )
+        _output("check-entity", findings)
+        return
+
+    # --- Find entity page ---
+    pages = find_pages(wiki_dir, slug=slug)
+    if not pages:
+        findings.append(
+            _finding(
+                "error",
+                "factual_consistency",
+                "missing_entity",
+                [slug],
+                f"No wiki page found for slug '{slug}'",
+                f"Create a wiki page for '{slug}'",
+            )
+        )
+        _output("check-entity", findings)
+        return
+
+    page_path = pages[0]
+    content = page_path.read_text()
+    metadata, body = parse_frontmatter(content)
+
+    # --- Required fields ---
+    for field in _REQUIRED_FIELDS:
+        if field not in metadata:
+            findings.append(
+                _finding(
+                    "error",
+                    "factual_consistency",
+                    "missing_entity",
+                    [slug],
+                    f"Page '{slug}' is missing required frontmatter field '{field}'",
+                    f"Add '{field}' to the frontmatter of '{slug}'",
+                )
+            )
+
+    # --- Detail levels ---
+    detail_levels = metadata.get("detail_levels", {})
+    if not isinstance(detail_levels, dict):
+        detail_levels = {}
+    for level in ("L1", "L2", "L3"):
+        if level not in detail_levels or not detail_levels[level]:
+            findings.append(
+                _finding(
+                    "warning",
+                    "narrative_style",
+                    "stale_claim",
+                    [slug],
+                    f"Page '{slug}' is missing detail level '{level}'",
+                    f"Add '{level}' content to detail_levels for '{slug}'",
+                )
+            )
+
+    # --- Wikilinks in body ---
+    all_slugs = _all_wiki_slugs(wiki_dir)
+    wikilinks = _extract_wikilinks(body)
+    for link_slug in wikilinks:
+        if link_slug not in all_slugs:
+            findings.append(
+                _finding(
+                    "warning",
+                    "factual_consistency",
+                    "broken_wikilink",
+                    [slug, link_slug],
+                    f"Page '{slug}' contains wikilink [[{link_slug}]] "
+                    f"pointing to non-existent page",
+                    f"Create page for '{link_slug}' or fix the wikilink",
+                )
+            )
+
+    # --- Verify entity in index ---
+    index_entries = read_index(wiki_dir)
+    index_slugs = {e["slug"] for e in index_entries}
+    if slug not in index_slugs:
+        findings.append(
+            _finding(
+                "warning",
+                "factual_consistency",
+                "orphan_reference",
+                [slug],
+                f"Page '{slug}' exists but is not listed in index.md",
+                f"Add '{slug}' to index.md",
+            )
+        )
+
+    # --- Verify correct type directory ---
+    fm_type = metadata.get("type", "")
+    expected_dir = _TYPE_TO_DIR.get(fm_type, "")  # type: ignore[arg-type]
+    if expected_dir:
+        actual_dir = page_path.parent.name
+        if actual_dir != expected_dir:
+            findings.append(
+                _finding(
+                    "warning",
+                    "factual_consistency",
+                    "naming_inconsistency",
+                    [slug],
+                    f"Page '{slug}' is in directory '{actual_dir}' but "
+                    f"type '{fm_type}' should be in '{expected_dir}'",
+                    f"Move '{slug}.md' to {expected_dir}/",
+                )
+            )
+
+    # Append to contradictions.md
+    _append_contradictions(wiki_dir, "Entity check", findings)
+
+    _output("check-entity", findings)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Parse arguments and dispatch to the appropriate command."""
+    parser = argparse.ArgumentParser(description="Wiki lint tool")
+    parser.add_argument(
+        "--operation",
+        required=True,
+        choices=["check-chapter", "check-full", "check-entity"],
+        help="Lint operation to perform",
+    )
+    parser.add_argument("--name", required=True, help="Story name")
+    parser.add_argument(
+        "--chapter-number", type=int, help="Chapter number (for check-chapter)"
+    )
+    parser.add_argument(
+        "--chapter-text",
+        help="File path to chapter content (for check-chapter)",
+    )
+    parser.add_argument(
+        "--current-chapter", type=int, help="Current chapter number (for check-full)"
+    )
+    parser.add_argument("--slug", help="Entity slug (for check-entity)")
+
+    args = parser.parse_args()
+
+    if args.operation == "check-chapter":
+        cmd_check_chapter(args)
+    elif args.operation == "check-full":
+        cmd_check_full(args)
+    elif args.operation == "check-entity":
+        cmd_check_entity(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/wiki_lint.py
+++ b/src/tools/wiki_lint.py
@@ -14,7 +14,7 @@ _src = str(Path(__file__).resolve().parents[1])
 if _src not in sys.path:
     sys.path.insert(0, _src)
 
-from src.tools._io import _atomic_write, _validate_story_name  # noqa: E402
+from src.tools._io import STORIES_DIR, _atomic_write, _validate_story_name  # noqa: E402
 from src.tools._wiki import (  # noqa: E402
     WIKI_SUBDIRS,
     _TYPE_TO_DIR,
@@ -24,10 +24,6 @@ from src.tools._wiki import (  # noqa: E402
     match_entities_in_text,
     parse_frontmatter,
     read_index,
-)
-
-STORIES_DIR = Path(
-    __import__("os").environ.get("STORIES_DIR", str(PROJECT_ROOT / "stories"))
 )
 
 # Wikilink pattern: [[slug]] or [[slug|display text]]
@@ -365,16 +361,15 @@ def cmd_check_full(args: argparse.Namespace) -> None:
         first_app = metadata.get("first_appearance")
         last_updated = metadata.get("last_updated")
 
-        # Try to extract a chapter number from last_updated or version
-        # Use first_appearance as the page's chapter reference
+        # Use last_updated if it's a chapter number (int); otherwise fall back to first_appearance
         page_chapter = None
+        reference_field = "first_appearance"
         if isinstance(first_app, int):
             page_chapter = first_app
 
-        # Check version field for a chapter-based staleness heuristic
-        # Use last_updated if it's a chapter number (int)
         if isinstance(last_updated, int):
             page_chapter = last_updated
+            reference_field = "last_updated"
         elif isinstance(last_updated, str):
             # last_updated is a timestamp string; check first_appearance instead
             pass
@@ -386,7 +381,7 @@ def cmd_check_full(args: argparse.Namespace) -> None:
                     "narrative_style",
                     "stale_claim",
                     [slug],
-                    f"Page '{slug}' (first_appearance: {first_app}) "
+                    f"Page '{slug}' ({reference_field}: {page_chapter}) "
                     f"has not been updated in {current_chapter - page_chapter}+ chapters "
                     f"(current: {current_chapter})",
                     f"Review and update '{slug}' for current chapter relevance",

--- a/tests/unit/test_wiki_lint_tool.py
+++ b/tests/unit/test_wiki_lint_tool.py
@@ -1,0 +1,587 @@
+"""Verification tests for Issue #17 — wiki-lint Tool.
+
+Confirms the CLI tool (src/tools/wiki_lint.py) correctly detects
+contradictions, orphans, broken wikilinks, and other consistency issues.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOL_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "wiki_lint.py")
+
+WIKI_SUBDIRS = [
+    "characters",
+    "locations",
+    "events",
+    "factions",
+    "items",
+    "plot-threads",
+    "world-rules",
+    "themes",
+    "relationships",
+    "timeline",
+    "chapters",
+]
+
+_TYPE_TO_DIR = {
+    "character": "characters",
+    "location": "locations",
+    "event": "events",
+    "faction": "factions",
+    "item": "items",
+    "plot_thread": "plot-threads",
+    "world_rule": "world-rules",
+    "theme": "themes",
+    "relationship": "relationships",
+    "timeline_entry": "timeline",
+    "chapter_synopsis": "chapters",
+}
+
+
+def _run_tool(
+    *args: str, stories_dir: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    if stories_dir is not None:
+        env["STORIES_DIR"] = str(stories_dir)
+    return subprocess.run(
+        [sys.executable, TOOL_SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _create_wiki(stories_dir: Path, story_name: str = "test-story") -> Path:
+    """Create a minimal wiki structure for testing."""
+    story_dir = stories_dir / story_name
+    wiki_dir = story_dir / "wiki"
+    wiki_dir.mkdir(parents=True)
+
+    for subdir in WIKI_SUBDIRS:
+        (wiki_dir / subdir).mkdir()
+
+    (wiki_dir / "index.md").write_text(
+        "# Wiki Index\n\n<!-- slug | type | name | aliases -->\n"
+    )
+    (wiki_dir / "log.md").write_text("# Wiki Log\n")
+    (wiki_dir / "contradictions.md").write_text("# Contradictions\n")
+
+    return wiki_dir
+
+
+def _create_page(
+    wiki_dir: Path,
+    page_type: str,
+    slug: str,
+    name: str,
+    extra_frontmatter: dict | None = None,
+    body: str = "",
+) -> Path:
+    """Create a wiki page with frontmatter."""
+    metadata: dict = {
+        "type": page_type,
+        "name": name,
+        "slug": slug,
+        "confidence": "verified",
+        "first_appearance": 1,
+        "aliases": [],
+        "last_updated": "2026-01-01T00:00:00Z",
+        "version": 1,
+        "detail_levels": {"L1": "Short", "L2": "Medium", "L3": "Full"},
+    }
+    if extra_frontmatter:
+        metadata.update(extra_frontmatter)
+
+    content = f"---\n{yaml.dump(metadata, default_flow_style=False)}---\n{body}"
+
+    type_dir = _TYPE_TO_DIR.get(page_type, "characters")
+    page_path = wiki_dir / type_dir / f"{slug}.md"
+    page_path.parent.mkdir(exist_ok=True)
+    page_path.write_text(content)
+    return page_path
+
+
+def _add_to_index(
+    wiki_dir: Path,
+    slug: str,
+    page_type: str,
+    name: str,
+    aliases: list[str] | None = None,
+) -> None:
+    """Add entry to index.md."""
+    aliases_str = ", ".join(aliases) if aliases else ""
+    line = f"- {slug} | {page_type} | {name} | {aliases_str}\n"
+    with open(wiki_dir / "index.md", "a") as f:
+        f.write(line)
+
+
+def _write_chapter_text(stories_dir: Path, story_name: str, text: str) -> Path:
+    """Write chapter text to a file inside the story directory."""
+    chapter_path = stories_dir / story_name / "chapter.txt"
+    chapter_path.parent.mkdir(parents=True, exist_ok=True)
+    chapter_path.write_text(text)
+    return chapter_path
+
+
+# ---------------------------------------------------------------------------
+# TestCheckChapter
+# ---------------------------------------------------------------------------
+
+
+class TestCheckChapter:
+    def test_detects_dead_character_mentioned(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(
+            wiki,
+            "character",
+            "alice",
+            "Alice",
+            extra_frontmatter={"status": "dead"},
+        )
+        _add_to_index(wiki, "alice", "character", "Alice")
+
+        chapter_path = _write_chapter_text(
+            stories, "test-story", "Alice walked into the room."
+        )
+
+        result = _run_tool(
+            "--operation",
+            "check-chapter",
+            "--name",
+            "test-story",
+            "--chapter-number",
+            "5",
+            "--chapter-text",
+            str(chapter_path),
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        findings = output["findings"]
+        status_findings = [
+            f for f in findings if f["subtype"] == "status_contradiction"
+        ]
+        assert len(status_findings) >= 1
+        assert status_findings[0]["severity"] == "error"
+        assert status_findings[0]["category"] == "characterization"
+
+    def test_detects_missing_entity_page(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        # Index entry but no page file
+        _add_to_index(wiki, "bob", "character", "Bob")
+
+        chapter_path = _write_chapter_text(
+            stories, "test-story", "Bob appeared at the gate."
+        )
+
+        result = _run_tool(
+            "--operation",
+            "check-chapter",
+            "--name",
+            "test-story",
+            "--chapter-number",
+            "3",
+            "--chapter-text",
+            str(chapter_path),
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        missing = [f for f in output["findings"] if f["subtype"] == "missing_entity"]
+        assert len(missing) >= 1
+        assert missing[0]["severity"] == "warning"
+
+    def test_detects_broken_wikilink_in_chapter(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        _create_wiki(stories)
+
+        chapter_path = _write_chapter_text(
+            stories, "test-story", "She visited [[nonexistent-place]] today."
+        )
+
+        result = _run_tool(
+            "--operation",
+            "check-chapter",
+            "--name",
+            "test-story",
+            "--chapter-number",
+            "2",
+            "--chapter-text",
+            str(chapter_path),
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        broken = [f for f in output["findings"] if f["subtype"] == "broken_wikilink"]
+        assert len(broken) >= 1
+        assert broken[0]["severity"] == "warning"
+        assert "nonexistent-place" in broken[0]["message"]
+
+    def test_clean_chapter_no_findings(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(wiki, "character", "carol", "Carol")
+        _add_to_index(wiki, "carol", "character", "Carol")
+
+        chapter_path = _write_chapter_text(
+            stories, "test-story", "Carol smiled warmly."
+        )
+
+        result = _run_tool(
+            "--operation",
+            "check-chapter",
+            "--name",
+            "test-story",
+            "--chapter-number",
+            "1",
+            "--chapter-text",
+            str(chapter_path),
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+        assert output["summary"]["total"] == 0
+        assert len(output["findings"]) == 0
+
+    def test_findings_appended_to_contradictions_md(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _add_to_index(wiki, "dan", "character", "Dan")
+        # No page for Dan → will produce a missing_entity finding
+
+        chapter_path = _write_chapter_text(stories, "test-story", "Dan rushed forward.")
+
+        result = _run_tool(
+            "--operation",
+            "check-chapter",
+            "--name",
+            "test-story",
+            "--chapter-number",
+            "4",
+            "--chapter-text",
+            str(chapter_path),
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+        contradictions = (wiki / "contradictions.md").read_text()
+        assert "Chapter 4 check" in contradictions
+        assert "missing_entity" in contradictions
+
+
+# ---------------------------------------------------------------------------
+# TestCheckFull
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFull:
+    def test_detects_orphan_page_on_disk(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        # Page on disk, not in index
+        _create_page(wiki, "character", "orphan-char", "OrphanChar")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "5",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        orphans = [f for f in output["findings"] if f["subtype"] == "orphan_reference"]
+        disk_orphans = [f for f in orphans if "exists on disk" in f["message"]]
+        assert len(disk_orphans) >= 1
+        assert disk_orphans[0]["severity"] == "warning"
+
+    def test_detects_orphan_index_entry(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        # In index but no file on disk
+        _add_to_index(wiki, "ghost", "character", "Ghost")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "5",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        orphans = [f for f in output["findings"] if f["subtype"] == "orphan_reference"]
+        index_orphans = [
+            f for f in orphans if "no corresponding .md file" in f["message"]
+        ]
+        assert len(index_orphans) >= 1
+        assert index_orphans[0]["severity"] == "warning"
+
+    def test_detects_stale_claims(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(
+            wiki,
+            "character",
+            "old-char",
+            "OldChar",
+            extra_frontmatter={"first_appearance": 1},
+        )
+        _add_to_index(wiki, "old-char", "character", "OldChar")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "10",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        stale = [f for f in output["findings"] if f["subtype"] == "stale_claim"]
+        assert len(stale) >= 1
+        assert stale[0]["severity"] == "info"
+
+    def test_detects_broken_wikilinks_in_pages(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(
+            wiki,
+            "character",
+            "eve",
+            "Eve",
+            body="Eve knows [[missing-slug]] very well.\n",
+        )
+        _add_to_index(wiki, "eve", "character", "Eve")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "3",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        broken = [f for f in output["findings"] if f["subtype"] == "broken_wikilink"]
+        assert len(broken) >= 1
+        assert "missing-slug" in broken[0]["message"]
+
+    def test_detects_timeline_ordering_violation(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+
+        # Create out-of-order timeline
+        timeline_content = (
+            "# Main Timeline\n\n"
+            "- **Chapter 3** — Morning — Something happened\n"
+            "- **Chapter 1** — Evening — Earlier event\n"
+        )
+        (wiki / "timeline" / "main-timeline.md").write_text(timeline_content)
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "5",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        temporal = [
+            f for f in output["findings"] if f["subtype"] == "temporal_ordering"
+        ]
+        assert len(temporal) >= 1
+        assert temporal[0]["severity"] == "error"
+
+    def test_clean_wiki_no_findings(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(wiki, "character", "frank", "Frank")
+        _add_to_index(wiki, "frank", "character", "Frank")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "2",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+        assert output["summary"]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestCheckEntity
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEntity:
+    def test_validates_missing_frontmatter_fields(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        # Write page with missing required fields (no confidence, no first_appearance)
+        page_path = wiki / "characters" / "incomplete.md"
+        page_path.write_text(
+            "---\ntype: character\nname: Incomplete\nslug: incomplete\n---\nBody.\n"
+        )
+        _add_to_index(wiki, "incomplete", "character", "Incomplete")
+
+        result = _run_tool(
+            "--operation",
+            "check-entity",
+            "--name",
+            "test-story",
+            "--slug",
+            "incomplete",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        missing = [f for f in output["findings"] if f["subtype"] == "missing_entity"]
+        assert len(missing) >= 1
+        # Should flag at least confidence and first_appearance
+        messages = " ".join(f["message"] for f in missing)
+        assert "confidence" in messages
+        assert "first_appearance" in messages
+
+    def test_detects_broken_wikilinks_in_body(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(
+            wiki,
+            "character",
+            "gina",
+            "Gina",
+            body="Gina visited [[missing-place]] yesterday.\n",
+        )
+        _add_to_index(wiki, "gina", "character", "Gina")
+
+        result = _run_tool(
+            "--operation",
+            "check-entity",
+            "--name",
+            "test-story",
+            "--slug",
+            "gina",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        broken = [f for f in output["findings"] if f["subtype"] == "broken_wikilink"]
+        assert len(broken) >= 1
+        assert "missing-place" in broken[0]["message"]
+
+    def test_missing_entity_returns_error(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        _create_wiki(stories)
+
+        result = _run_tool(
+            "--operation",
+            "check-entity",
+            "--name",
+            "test-story",
+            "--slug",
+            "nonexistent",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        missing = [f for f in output["findings"] if f["subtype"] == "missing_entity"]
+        assert len(missing) >= 1
+        assert missing[0]["severity"] == "error"
+
+    def test_entity_not_in_index(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        # Page exists but not in index
+        _create_page(wiki, "character", "hermit", "Hermit")
+
+        result = _run_tool(
+            "--operation",
+            "check-entity",
+            "--name",
+            "test-story",
+            "--slug",
+            "hermit",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        orphans = [f for f in output["findings"] if f["subtype"] == "orphan_reference"]
+        assert len(orphans) >= 1
+        assert orphans[0]["severity"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        _create_wiki(stories)
+
+        result = _run_tool(
+            "--operation",
+            "check-chapter",
+            "--name",
+            "test-story",
+            "--chapter-number",
+            "1",
+            "--chapter-text",
+            "../../etc/passwd",
+            stories_dir=stories,
+        )
+        assert result.returncode != 0
+        assert "stories directory" in result.stderr.lower() or result.returncode == 1

--- a/tests/unit/test_wiki_lint_tool.py
+++ b/tests/unit/test_wiki_lint_tool.py
@@ -451,6 +451,115 @@ class TestCheckFull:
         assert output["status"] == "ok"
         assert output["summary"]["total"] == 0
 
+    def test_detects_confidence_downgrade(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(
+            wiki,
+            "character",
+            "ancient-hero",
+            "AncientHero",
+            extra_frontmatter={"confidence": "verified", "first_appearance": 1},
+        )
+        _add_to_index(wiki, "ancient-hero", "character", "AncientHero")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "15",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        downgrades = [
+            f for f in output["findings"] if f["subtype"] == "confidence_downgrade"
+        ]
+        assert len(downgrades) >= 1
+        assert downgrades[0]["severity"] == "info"
+        assert downgrades[0]["category"] == "narrative_style"
+
+    def test_detects_type_mismatch(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        _create_page(wiki, "character", "mistyped", "Mistyped")
+        # Index lists it as 'location' — mismatched with frontmatter 'character'
+        _add_to_index(wiki, "mistyped", "location", "Mistyped")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "5",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        type_findings = [
+            f
+            for f in output["findings"]
+            if f["subtype"] == "naming_inconsistency" and "type" in f["message"].lower()
+        ]
+        assert len(type_findings) >= 1
+        assert type_findings[0]["severity"] == "warning"
+        assert type_findings[0]["category"] == "factual_consistency"
+        assert "character" in type_findings[0]["message"]
+        assert "location" in type_findings[0]["message"]
+
+    def test_detects_wrong_directory(self, tmp_path: Path) -> None:
+        stories = tmp_path / "stories"
+        wiki = _create_wiki(stories)
+        # Create a character page but place it in locations/ directory
+        metadata = {
+            "type": "character",
+            "name": "Misplaced",
+            "slug": "misplaced",
+            "confidence": "verified",
+            "first_appearance": 1,
+            "aliases": [],
+            "last_updated": "2026-01-01T00:00:00Z",
+            "version": 1,
+            "detail_levels": {"L1": "Short", "L2": "Medium", "L3": "Full"},
+        }
+        content = f"---\n{yaml.dump(metadata, default_flow_style=False)}---\nBody.\n"
+        page_path = wiki / "locations" / "misplaced.md"
+        page_path.write_text(content)
+        # Index type matches frontmatter (character), but file is in locations/
+        _add_to_index(wiki, "misplaced", "character", "Misplaced")
+
+        result = _run_tool(
+            "--operation",
+            "check-full",
+            "--name",
+            "test-story",
+            "--current-chapter",
+            "5",
+            stories_dir=stories,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["status"] == "ok"
+
+        dir_findings = [
+            f
+            for f in output["findings"]
+            if f["subtype"] == "naming_inconsistency"
+            and "directory" in f["message"].lower()
+        ]
+        assert len(dir_findings) >= 1
+        assert dir_findings[0]["severity"] == "warning"
+        assert dir_findings[0]["category"] == "factual_consistency"
+        assert "locations" in dir_findings[0]["message"]
+        assert "characters" in dir_findings[0]["message"]
+
 
 # ---------------------------------------------------------------------------
 # TestCheckEntity


### PR DESCRIPTION
## Summary
Build the wiki-lint tool with three consistency-checking operations (check-chapter, check-full, check-entity) that provide deterministic wiki validation using the ConStory-Bench error taxonomy.

## Closes
Closes #17

## Changes
- [x] Implementation complete
- [x] All tests passing (verified)
- [x] Linting clean

## Plan
- `src/tools/wiki_lint.py` — 3 operations: check-chapter, check-full, check-entity
- `.opencode/tools/wiki-lint.ts` — TypeScript wrapper with Zod schema
- `contradictions.md` append logic for detected findings
- `tests/unit/test_wiki_lint_tool.py` — 16 test methods across 4 test classes

## Implementation Details

### Operations

| Operation | Purpose | Key Checks |
|-----------|---------|------------|
| `check-chapter` | Post-chapter contradiction detection | Dead character mentions, missing entity pages, broken wikilinks, timeline violations |
| `check-full` | Comprehensive periodic lint | Orphan pages, stale claims (5+ chapters), broken wikilinks, timeline ordering, confidence downgrades, index integrity |
| `check-entity` | Single entity validation | Required frontmatter, detail levels, wikilink resolution, index presence, correct directory |

### ConStory-Bench Taxonomy
- `timeline_plot_logic`: temporal_ordering, chapter_ordering_violation
- `characterization`: status_contradiction
- `factual_consistency`: missing_entity, broken_wikilink, orphan_reference, naming_inconsistency
- `narrative_style`: stale_claim, confidence_downgrade

### Security
- Path traversal protection on all inputs (story name, slug, chapter-text path)
- Chapter-text path validated within stories directory using `Path.resolve()` + `is_relative_to()`