### PR TITLE
Build Scene Writer Subagent

### DIFF
--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -120,7 +120,7 @@ The `chapter-writer` is named to avoid collision with the existing `scene-writer
 
 ## Skills
 
-Four skills defined in `.opencode/skills/`:
+Three skills defined in `.opencode/skills/`:
 
 | Skill | File | Used By | Purpose |
 |-------|------|---------|---------|

--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -107,6 +107,27 @@ Pattern: `.opencode/tools/*.ts` (Zod schema + execFileSync) → `src/tools/*.py`
 
 See [Tools Reference](docs/tools.md) for full documentation.
 
+## Agents
+
+Two agents defined in `.opencode/agents/`, registered in `opencode.json`:
+
+| Agent | Definition | Skills | Purpose |
+|-------|-----------|--------|---------|
+| `story-orchestrator` | `.opencode/agents/story-orchestrator.md` | `story-pipeline` | Primary pipeline controller — coordinates 9-phase story generation lifecycle, delegates to subagents |
+| `chapter-writer` | `.opencode/agents/chapter-writer.md` | `scene-writing`, `character-voice` | Per-chapter scene generation — invoked by orchestrator during Phase 8b, generates scenes sequentially using wiki-snapshot context |
+
+The `chapter-writer` is named to avoid collision with the existing `scene-writer` tool. The orchestrator delegates to `chapter-writer` for the per-chapter scene generation loop; the agent in turn calls the `scene-writer` tool for individual scene generation.
+
+## Skills
+
+Four skills defined in `.opencode/skills/`:
+
+| Skill | File | Used By | Purpose |
+|-------|------|---------|---------|
+| `story-pipeline` | `.opencode/skills/story-pipeline/SKILL.md` | `story-orchestrator` | Pipeline reference — phases, quality gates, savepoints, config settings |
+| `scene-writing` | `.opencode/skills/scene-writing/SKILL.md` | `chapter-writer` | Scene writing conventions — narrative structure, pacing, transitions, generation best practices |
+| `character-voice` | `.opencode/skills/character-voice/SKILL.md` | `chapter-writer` | Character voice consistency — dialogue patterns, internal thought, behavioural coherence across scenes |
+
 ## Planned Architecture (Post-Migration)
 
 See [PRD](docs/planning/opencode-migration/prd.md) and ADRs:

--- a/.github/notes/reflections/issue-19-stale-count-recurrence.md
+++ b/.github/notes/reflections/issue-19-stale-count-recurrence.md
@@ -1,0 +1,32 @@
+---
+date: "2026-04-15"
+issue: 19
+pr: 63
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Stale count pattern — eighth occurrence ("Four skills" when three existed)
+
+### Finding
+
+During issue #19 (Build Scene Writer Subagent), the Coder/Documenter wrote "Four skills" in the story-orchestrator feature doc when only three skills existed. This was caught by the Synthesized Review as U-W-01 and fixed in the review-fix cycle.
+
+### Observation
+
+This is the **eighth** occurrence of the stale-count pattern across issues #4, #5, #11, #12, #30, #13, #17, and #19. The issue #13 reflection established that this is an **accuracy** problem, not a compliance problem — the Coder is attempting the count but getting it wrong. The issue #17 reflection added inventory table cross-checking to the Documenter.
+
+This occurrence has a slight variant: the agent was writing a *new* file (not updating an existing count), and the count was wrong from initial authoring — likely a simple miscount of deliverables during composition, counting an item that hadn't been created yet or double-counting.
+
+No rule text change is warranted. The review system catches this reliably (8 for 8). The cost per occurrence is one review-fix cycle.
+
+### Suggested Improvement
+
+No rule change. Recording for continued tracking evidence.
+
+### Action Taken
+
+No action needed — recurrence of known pattern recorded for evidence.

--- a/.github/notes/reflections/issue-19-tool-schema-fabrication.md
+++ b/.github/notes/reflections/issue-19-tool-schema-fabrication.md
@@ -1,0 +1,44 @@
+---
+date: "2026-04-15"
+issue: 19
+pr: 63
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: major
+status: active
+---
+
+## Coder fabricates tool parameter names instead of verifying against actual schema
+
+### Finding
+
+During issue #19 (Build Scene Writer Subagent), the Coder wrote the `.opencode/agents/chapter-writer.md` agent definition referencing tools with invented parameter names. The `wiki-snapshot` tool was referenced with 5 incorrect parameter names (`story_name`, `chapter_number`, `scene_number`, `setting`, `tokenBudget`) and 2 missing parameters. The Synthesized Review caught this as S-W-01 — the parameter names in the agent definition did not match the actual `.opencode/tools/wiki-snapshot.ts` schema.
+
+### Observation
+
+This is a **new class** of Coder defect, distinct from prior patterns:
+
+- **Issue #3/6 — pattern amnesia:** Coder fails to apply established patterns from prior implementations. Fixed by Rule 9 and proposed Rule 10.
+- **Issue #10 — semantic correctness:** Coder writes syntactically valid but functionally broken code (wiring bugs). Pending semantic verification rule.
+- **Issue #19 — schema fabrication:** Coder invents reference data instead of consulting the source of truth.
+
+The root cause is that writing agent definitions is a **documentation-adjacent** task — the Coder treats parameter names as prose to be drafted rather than facts to be looked up. The Coder has no rule requiring verification of external schema references when writing agent or skill files.
+
+This is particularly impactful because agent definitions are consumed by other agents at runtime. Incorrect parameter names cause tool invocation failures that surface later, far from the original authoring context — making them expensive to debug.
+
+The existing Rule 6 (text sweep after changes) doesn't cover this because no prior text is being replaced — the parameters are freshly authored. The issue is **fabrication**, not **staleness**.
+
+### Suggested Improvement
+
+Add a new rule to the Coder agent (`.github/agents/coder.agent.md`), after the existing rules:
+
+```markdown
+10. **When writing agent definitions or skill files that reference tools**, verify all tool parameter names, types, and descriptions against the actual tool schema files (`.opencode/tools/*.ts` for TypeScript wrappers, `src/tools/*.py` for Python scripts). Never invent parameter names from memory — always read the schema file. For tool tables in agent definitions, verify every tool mentioned in the workflow prose appears in the table with correct parameter documentation.
+```
+
+This is a new numbered rule, complementary to the existing Rule 9 (security validation) and the proposed Rule 10 (prior-tool review from issue #6). If Rule 10 is applied first, this becomes Rule 11.
+
+### Action Taken
+
+Proposed for approval — adds a new numbered rule to the Coder agent.

--- a/.github/notes/reflections/issue-19-undeclared-tool-references.md
+++ b/.github/notes/reflections/issue-19-undeclared-tool-references.md
@@ -1,0 +1,30 @@
+---
+date: "2026-04-15"
+issue: 19
+pr: 63
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: active
+---
+
+## Agent definition references tools in prose but omits them from tools table
+
+### Finding
+
+During issue #19 (Build Scene Writer Subagent), the `.opencode/agents/chapter-writer.md` agent definition referenced `character-mgr` and `setting-mgr` as fallback tools in its workflow prose but did not list them in the tools table. The Synthesized Review caught this as U-W-02 — the tools table was incomplete relative to the workflow text.
+
+### Observation
+
+This is an internal consistency issue within a single authored file — the prose section and the tools table diverge. It's related to the stale-count pattern (issue #17's inventory table cross-check) but the variant is different: here the source of truth is the *same file's own prose*, not files on disk. The Documenter's existing Step 3 verification bullet covers cross-checking tables against files on disk, but doesn't explicitly cover cross-checking an agent definition's tools table against its own workflow prose.
+
+This is a minor oversight easily caught by review and unlikely to cause runtime failures (tools not in the table are still available if declared in `opencode.json`). The cost is one review-fix cycle.
+
+### Suggested Improvement
+
+No rule change. The existing inventory verification bullet in the Documenter's Step 3 is close enough — extending it to cover intra-file consistency would over-specify the checklist. The review system catches this reliably.
+
+### Action Taken
+
+No action needed — recording for pattern tracking.

--- a/.github/notes/reviews/2026-04-15-pr63-synthesis.md
+++ b/.github/notes/reviews/2026-04-15-pr63-synthesis.md
@@ -1,0 +1,34 @@
+## Synthesized Code Review — 2026-04-15 (PR #63)
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-19-scene-writer-subagent
+**PR:** #63 (Issue #19)
+**Model Agreement Score:** 7/10
+**Overall Assessment:** Needs Fixes
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 2       | 1          |
+| ★★☆ Majority      | 0        | 0       | 1          |
+| ★☆☆ Singular      | 0        | 2       | 2          |
+
+### Key Findings
+
+- [S-W-01] wiki-snapshot parameter names in agent instructions don't match actual tool schema — 5 mismatches + 2 omissions verified (★☆☆, but verified genuine, highest impact)
+- [U-W-01] Stale "Four skills" count in architecture.md — should be "Three" (★★★)
+- [U-W-02] Undeclared tools (character-mgr, setting-mgr) for documented fallback path in chapter-writer (★★★)
+- [S-W-02] Stale line count "259 lines" for story-orchestrator — actual is 266 (★☆☆, verified)
+- [U-S-01] Task 19 acceptance criteria still reference pre-rename filename scene-writer.md (★★★)
+- [M-S-01] Feature doc Related section missing Issue #19 / PR #63 reference (★★☆)
+
+### Divergences
+
+- [D-01] Severity of fallback path finding — Claude=Suggestion vs GPT/Gemini=Warning. Resolved as Warning (correctness, not just documentation).
+- [D-02] wiki-snapshot parameter accuracy — Only Claude identified; GPT and Gemini missed. Verified genuine against tool schema.
+
+### Actions Required
+
+- Findings requiring fixes: 4 (S-W-01, U-W-01, U-W-02, S-W-02)
+- Findings deferred: 4 (U-S-01, M-S-01, S-S-01, S-S-02 — suggestions, can be addressed in follow-up)

--- a/.opencode/agents/chapter-writer.md
+++ b/.opencode/agents/chapter-writer.md
@@ -15,6 +15,8 @@ You receive a chapter number and story name from the orchestrator. You generate 
 | `recap-manager` | Load previous chapter recap for continuity |
 | `story-state` | Read chapter outline, story config |
 | `savepoint-mgr` | Save/load scene-level progress checkpoints |
+| `character-mgr` | Load character sheets directly (fallback when wiki unavailable) |
+| `setting-mgr` | Load setting sheets directly (fallback when wiki unavailable) |
 
 ---
 
@@ -54,13 +56,16 @@ Generate scenes **sequentially** — never in parallel. Narrative flow depends o
 For each scene M in the chapter (M = 1, 2, ..., scene_count):
 
 1. **Assemble context.** Call `wiki-snapshot` (operation: `snapshot`) with:
-   - `story_name`: the current story
-   - `chapter_number`: the current chapter N
-   - `scene_number`: the current scene M
-   - `characters`: characters listed in the scene definition
-   - `setting`: the scene's setting
+   - `name`: the current story name
+   - `chapter`: the current chapter number N
+   - `scene`: the current scene number M
+   - `outline`: the scene outline text (from the scene definition's description)
+   - `povCharacter`: the POV character slug (from the scene definition's characters list)
+   - `characters`: comma-separated character slugs from the scene definition
+   - `primaryLocation`: the primary location slug from the scene definition
+   - `locations`: comma-separated location slugs (if multiple locations)
    - `sceneType`: the scene type (dialogue, action, exposition, mixed)
-   - `tokenBudget`: 15000 (default, configurable via story config)
+   - `budget`: 15000 (default, configurable via story config)
 
 2. **Build generation context.** Combine:
    - The wiki snapshot (primary context)

--- a/.opencode/agents/chapter-writer.md
+++ b/.opencode/agents/chapter-writer.md
@@ -1,0 +1,128 @@
+# Chapter Writer
+
+You are the **chapter-writer**, a subagent invoked per-chapter by the `story-orchestrator` during Phase 8b. Your purpose is to generate all scenes for a single chapter using wiki-based context assembly, producing a complete, polished chapter from scene definitions.
+
+You receive a chapter number and story name from the orchestrator. You generate each scene sequentially, assembling context from the wiki knowledge base before each generation, and finally combine all scenes into the completed chapter.
+
+---
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `scene-writer` | Parse scene definitions, generate scenes, revise, assemble chapter |
+| `wiki-snapshot` | Assemble token-budgeted context from wiki for each scene |
+| `recap-manager` | Load previous chapter recap for continuity |
+| `story-state` | Read chapter outline, story config |
+| `savepoint-mgr` | Save/load scene-level progress checkpoints |
+
+---
+
+## Workflow
+
+Execute these steps sequentially for the assigned chapter:
+
+1. **Load chapter outline.** Read the chapter's expanded outline from `story-state`, including the scene breakdown produced in Phase 8a.
+2. **Parse scene definitions.** Call `scene-writer` (operation: `parse-definitions`) to extract structured scene definitions from the chapter outline. Each scene definition includes: title, description, characters, setting, conflict, tone, key_events, dialogue, ending, lead_in_to_next_scene, and literary_devices.
+3. **Create scene definitions savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_definitions`.
+4. **Load previous chapter recap.** If this is not the first chapter, call `recap-manager` (operation: `load`) for chapter N-1. This provides continuity context — where the story left off, active tensions, character emotional states.
+5. **Enter the scene generation loop** (see [Scene Generation Loop](#scene-generation-loop) below). Generate each scene sequentially.
+6. **Assemble the chapter.** After all scenes are generated, call `scene-writer` (operation: `assemble-chapter`) to combine all scenes into the final chapter text.
+7. **Create assembly savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/assembled`.
+8. **Return the assembled chapter** to the orchestrator for post-chapter processing (wiki update, recap, lint, quality evaluation).
+
+---
+
+## Context Assembly Strategy
+
+The `wiki-snapshot` tool is the **primary context source** for scene generation. Do not manually load and concatenate character sheets, setting sheets, or other raw documents.
+
+**Why wiki-snapshot:**
+- It provides pre-synthesized, token-budgeted context tailored to the specific scene being generated.
+- It runs the three-stage context retrieval pipeline: entity matching → metadata query → semantic search → wikilink traversal → detail level selection → structured assembly.
+- It respects the token budget, ensuring context fits within the generation window.
+- It prioritises entities relevant to the current scene (POV character, scene setting, active plot threads).
+
+**Fallback only:** Character sheets and setting sheets are passed directly to the generation prompt only when the wiki has not been initialised (i.e., Phase 7 was skipped or failed). In normal pipeline execution, all entity information is accessed through the wiki via `wiki-snapshot`.
+
+---
+
+## Scene Generation Loop
+
+Generate scenes **sequentially** — never in parallel. Narrative flow depends on each prior scene's content.
+
+For each scene M in the chapter (M = 1, 2, ..., scene_count):
+
+1. **Assemble context.** Call `wiki-snapshot` (operation: `snapshot`) with:
+   - `story_name`: the current story
+   - `chapter_number`: the current chapter N
+   - `scene_number`: the current scene M
+   - `characters`: characters listed in the scene definition
+   - `setting`: the scene's setting
+   - `sceneType`: the scene type (dialogue, action, exposition, mixed)
+   - `tokenBudget`: 15000 (default, configurable via story config)
+
+2. **Build generation context.** Combine:
+   - The wiki snapshot (primary context)
+   - The scene definition (from parsed definitions)
+   - The chapter outline (for overall chapter direction)
+   - Previous chapter recap (if available, for chapter 2+)
+   - Previous scene content (if M > 1, for direct continuity)
+
+3. **Generate the scene.** Call `scene-writer` (operation: `generate`) with the assembled context.
+
+4. **Save scene savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_{M}`.
+
+5. **Extract scene events.** Optionally extract key events, character state changes, and new information from the generated scene. These feed into context for subsequent scenes and post-chapter wiki updates.
+
+6. **Save scene summary savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_{M}_summary`.
+
+7. **Save scene title savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_{M}_title`.
+
+8. **Proceed to the next scene.** Pass the generated scene content as `previous_scene` context to the next iteration.
+
+---
+
+## Savepoint Strategy
+
+Savepoints are created at each significant milestone within a chapter, enabling fine-grained resume after interruption.
+
+**Naming convention:** `chapter_{N}/{descriptor}` — N is the chapter number (unpadded), descriptor is lowercase with underscores.
+
+| Savepoint | Created After |
+|-----------|--------------|
+| `chapter_{N}/scene_definitions` | Scene definitions parsed from outline (step 3) |
+| `chapter_{N}/scene_{M}` | Scene M generated successfully (loop step 4) |
+| `chapter_{N}/scene_{M}_summary` | Scene M events/summary extracted (loop step 6) |
+| `chapter_{N}/scene_{M}_title` | Scene M title confirmed (loop step 7) |
+| `chapter_{N}/assembled` | All scenes assembled into chapter (step 7) |
+
+**Resuming from a savepoint:**
+1. Load the savepoint via `savepoint-mgr` (operation: `restore`)
+2. Determine the last completed scene from the savepoint name
+3. Resume the scene generation loop from the next scene, or proceed to assembly if all scenes are complete
+
+---
+
+## Error Handling
+
+1. **Scene generation failure.** If `scene-writer generate` fails, retry up to 3 attempts with the same context. On each retry, log the failure reason. If all 3 attempts fail, log the error and fall back to single-chapter generation mode.
+
+2. **Single-chapter fallback.** If the scene generation pipeline fails entirely (repeated generation failures, context assembly errors), generate the chapter as a single unit using the chapter outline and wiki snapshot. This produces a lower-quality result but prevents pipeline stalls.
+
+3. **Wiki-snapshot failure.** If `wiki-snapshot` fails, check whether the wiki is initialised. If not, fall back to loading character sheets and setting sheets directly. If the wiki exists but the snapshot fails, retry once, then fall back to direct sheet loading.
+
+4. **Savepoint failure.** If a savepoint cannot be created, log the warning and continue generation. The scene content is still held in memory and can be assembled. Loss of savepoints means loss of resume capability for that specific scene.
+
+5. **Context overflow.** If the assembled context exceeds the token budget, reduce the wiki snapshot token budget by 25% and regenerate the snapshot. If still over budget, omit the previous chapter recap and retry. As a last resort, use only the scene definition and a minimal wiki snapshot.
+
+---
+
+## Important Constraints
+
+- **Never generate scenes out of order.** Scene M+1 depends on Scene M's content for narrative continuity. Parallel generation produces incoherent narratives.
+- **Never skip wiki-snapshot context assembly** unless the wiki has not been initialised. The wiki snapshot provides the richest, most relevant context for generation.
+- **Always save each scene as a savepoint before proceeding to the next.** This ensures resume capability at scene-level granularity.
+- **Token budget:** Wiki snapshot defaults to 15000 tokens. Total assembled context (snapshot + scene definition + outline + recap + previous scene) must fit within the 65536 token context window, leaving sufficient space for the generation output.
+- **Chapter assembly must preserve exact scene content.** The `assemble-chapter` operation concatenates scenes with appropriate transitions but does not modify the generated scene text. Scene content is final after generation (or revision).
+- **Config is authoritative.** Read token budgets, quality thresholds, and feature flags from story config. Never hardcode these values.

--- a/.opencode/skills/character-voice/SKILL.md
+++ b/.opencode/skills/character-voice/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: character-voice
+description: Character voice consistency — dialogue patterns, internal thought, behavioral coherence across scenes.
+version: 1.0.0
+---
+
+# Character Voice Skill
+
+Guide for maintaining consistent, distinct character voices across a long-form narrative. In AI-generated fiction, voice drift — where all characters begin sounding like the narrator or each other — is the most common quality failure. This skill provides concrete techniques to prevent it.
+
+---
+
+## Dialogue Patterns
+
+Each character should have identifiable speech patterns that persist across scenes and chapters:
+
+- **Vocabulary level.** A scholar uses precise, technical language. A street vendor uses colloquial, direct language. A child uses simple words and asks questions. These patterns should remain stable.
+- **Sentence length.** Some characters speak in clipped fragments. Others construct elaborate, clause-heavy sentences. Match sentence structure to character background and personality.
+- **Verbal tics.** Repeated phrases, filler words, or habitual expressions (e.g., "Listen here," "If you follow my meaning," "Ah, well"). Use sparingly — one or two per scene — but consistently.
+- **Formality register.** A diplomat speaks formally even in private. A soldier relaxes their register off-duty. A teenager shifts register between parents and friends. Track each character's register pattern.
+- **Dialogue as character revelation.** What a character chooses to say — and what they avoid — reveals their priorities, fears, and values. A character who deflects personal questions with humour is revealing something.
+
+---
+
+## Internal Thought
+
+The POV character's internal monologue is a direct expression of their personality:
+
+- **Voice matches the character, not the narrator.** Internal thought should reflect the character's vocabulary, concerns, and worldview. A pragmatic character doesn't wax poetic in their head. A romantic character doesn't think in spreadsheets.
+- **Personality traits as guardrails.** Use the character sheet's personality traits and motivations to filter internal observations. A suspicious character notices exits and escape routes. A compassionate character notices people in distress.
+- **Current emotional state.** Internal thought reflects the character's emotional state from the wiki's `current_state` field. A grieving character's thoughts keep circling back to their loss. An excited character's thoughts race and jump.
+- **Values and worldview.** What a character judges, dismisses, admires, or fears in their internal monologue reveals their core values. These should align with the character sheet and remain consistent.
+
+---
+
+## Behavioral Consistency
+
+Actions must align with established character traits, growth arcs, and current state:
+
+- **Trait-action coherence.** A cowardly character doesn't charge into danger without a compelling, earned reason. A methodical character doesn't act impulsively. When breaking pattern, acknowledge it — the character should notice their own deviation.
+- **Growth arc respect.** Reference the character sheet's `growth_arc` field. Early in the arc, the character should exhibit their starting traits. Growth should be gradual and motivated by story events.
+- **Current state continuity.** A character who was injured in the previous scene should still be injured. A character who received devastating news should still be processing it. Use the `current_state` field and prior scene events.
+- **Habitual behaviours.** Small, repeated actions ground a character: the way they sit, how they handle objects, their response to silence. Establish these early and maintain them.
+
+---
+
+## Character Relationships
+
+Dialogue and interaction patterns must reflect relationship dynamics from wiki pages:
+
+- **Power dynamics.** A subordinate speaks differently to their superior than to their peers. Deference, challenge, formality — these shift based on relative status and respect.
+- **Familiarity levels.** Old friends use shorthand, inside jokes, and comfortable silence. New acquaintances are more formal, more careful. Track how long characters have known each other.
+- **Unspoken tensions.** Subtext in dialogue and interaction reveals tensions that characters won't address directly. A betrayed character might be excessively polite. Rivals might be overly casual.
+- **History-informed reactions.** If characters have a shared history (documented in wiki relationships), their reactions to each other carry that weight. A reunion is different from a first meeting, even when the words are similar.
+- **Group dynamics.** Characters behave differently in groups than one-on-one. A character who is bold with one person may be reserved in a crowd. Track these patterns.
+
+---
+
+## Voice Differentiation Techniques
+
+Concrete techniques for ensuring characters don't sound alike:
+
+- **Unique speech patterns.** Give each character at least one distinctive verbal habit: a favourite curse, a tendency to ask rhetorical questions, a habit of finishing others' sentences, or a pattern of understatement.
+- **Contrasting formality levels.** In a scene with multiple characters, vary their formality registers. If one character speaks formally, another should speak casually. The contrast makes both more vivid.
+- **Culture-specific expressions.** Characters from different cultures, regions, or social classes use different idioms, metaphors, and references. Draw from the character sheet's background and the world-building wiki.
+- **Character-specific metaphors.** A sailor uses nautical metaphors. A baker thinks in terms of ingredients and timing. A warrior frames problems as battles. Source domain for metaphors should align with the character's life experience.
+- **Silence and avoidance.** What a character refuses to talk about is as distinctive as what they say. Some characters fill silence nervously. Others weaponise it.
+
+---
+
+## Emotional Continuity
+
+Character emotional state must carry between scenes and chapters:
+
+- **No emotional resets.** A character doesn't go from devastated to cheerful between scenes without a reason. Emotional transitions take time and should be visible in the character's behaviour and internal thought.
+- **Reference prior scene events.** When a character enters a new scene, their emotional state should reflect what happened in their last appearance. Use prior scene content and the character's `current_state` from the wiki.
+- **Emotional undercurrents.** Even when a character is focused on a task, underlying emotions create texture. A character performing routine work while grieving will do it differently — slower, more mistakes, moments of distraction.
+- **Emotional response proportionality.** Major events produce major emotional responses. Minor annoyances produce minor ones. Over-reaction or under-reaction should be intentional character traits, not generation artifacts.
+
+---
+
+## Character Growth
+
+Voice should evolve subtly as the character develops through the story:
+
+- **Early-story vs. late-story voice.** A character who starts naive and becomes worldly should shift vocabulary, speech patterns, and internal thought register over the course of the narrative. The shift should be gradual.
+- **Pivotal moment effects.** Trauma, revelation, and transformation moments should leave lasting marks on voice. A character who discovers betrayal may become more guarded, more prone to suspicion in internal thought.
+- **Growth through dialogue.** As characters grow, their dialogue should reflect it — new confidence, new doubt, new understanding. Returning to identical speech patterns after a growth event undermines the arc.
+- **Regression under pressure.** Under extreme stress, characters may revert to earlier speech patterns and behaviours. This is realistic and can be a powerful storytelling tool.
+
+---
+
+## Common Pitfalls
+
+Failure modes to actively avoid during generation:
+
+- **Voice drift.** All characters gradually converge toward a single "default narrator" voice. Prevent by explicitly checking each character's dialogue against their speech pattern profile before finalising.
+- **Emotional whiplash.** Characters swing between extreme emotions without transition or justification. Ensure emotional changes are motivated by story events and have visible progression.
+- **Out-of-character actions for plot convenience.** A character acts completely against their established personality because the plot requires it. If the plot needs a character to act differently, provide in-story motivation and let the character struggle with the deviation.
+- **Over-explaining motivations in dialogue.** Characters explain their feelings and reasoning in perfect, articulate paragraphs. Real people are often inarticulate about their own motivations. Use action and subtext instead.
+- **Identical conflict responses.** Every character responds to conflict the same way (usually with wit or stoic calm). Vary responses: anger, withdrawal, deflection, humour, tears, silence, over-compensation.
+- **Relationship amnesia.** Characters interact as if they have no history together. Always reference relationship dynamics from prior scenes and wiki relationship entries.
+- **Static voice across growth arcs.** A character whose voice is identical in chapter 1 and chapter 25 despite major story events. Track and implement voice evolution deliberately.

--- a/.opencode/skills/scene-writing/SKILL.md
+++ b/.opencode/skills/scene-writing/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: scene-writing
+description: Scene writing conventions — narrative structure, pacing, transitions, and generation best practices.
+version: 1.0.0
+---
+
+# Scene Writing Skill
+
+Guide for generating high-quality individual scenes within a chapter. This skill covers narrative structure, pacing, transitions, and best practices for AI-driven scene generation using wiki-based context.
+
+---
+
+## Scene Structure
+
+Every scene follows a three-part structure grounded in the scene definition fields:
+
+### Beginning (Hook/Grounding)
+- Open with a **hook** — a compelling image, line of dialogue, or sensory detail that draws the reader in.
+- **Ground** the reader in the scene's setting (from the `setting` field) and establish the POV character's immediate situation.
+- Use the `lead_in_to_next_scene` from the *previous* scene to create continuity. If this is the chapter's first scene, use the chapter-opening hook.
+
+### Middle (Rising Action)
+- Develop the scene's central `conflict` through character interaction, internal tension, or environmental pressure.
+- Introduce `key_events` progressively — not all at once. Each event should feel earned by the preceding action.
+- Weave in `dialogue` beats and `literary_devices` naturally. Dialogue should advance conflict, not just fill space.
+- Build toward the scene's turning point.
+
+### End (Turning Point or Transition)
+- Deliver a **turning point** — a moment that changes the character's situation, understanding, or emotional state.
+- Set up the `ending` as defined in the scene definition.
+- Plant the `lead_in_to_next_scene` seed — a question, tension, or momentum that carries the reader forward.
+
+### Scene Definition Fields Reference
+- `title` — scene name (used for savepoints and chapter table of contents)
+- `description` — brief summary of what happens
+- `characters` — who appears in this scene
+- `setting` — where and when the scene takes place
+- `conflict` — the central tension or problem
+- `tone` — emotional register (tense, reflective, humorous, etc.)
+- `key_events` — plot-critical events that must occur
+- `dialogue` — key dialogue beats or exchanges
+- `ending` — how the scene resolves or suspends
+- `lead_in_to_next_scene` — transition hook for narrative flow
+- `literary_devices` — specific devices to employ (foreshadowing, metaphor, irony, etc.)
+
+---
+
+## Narrative Pacing
+
+### Word Count Targets
+- **Default range:** 750–1500 words per scene (configurable in story config).
+- Action scenes trend toward the lower end — punchy, high-velocity prose.
+- Emotional and introspective scenes trend toward the higher end — room for reflection and nuance.
+- Exposition scenes fall in the middle — enough space to establish without dragging.
+
+### Pacing Variation
+- Alternate scene pacing within a chapter to create rhythm. A high-tension action scene followed by a quiet character moment creates breathing room.
+- Avoid consecutive scenes at the same pace — monotony kills engagement.
+- Chapter openings should establish pace quickly. Chapter closings should escalate toward a chapter-ending hook.
+
+### Chapter Rhythm
+- Early scenes in a chapter build the situation. Middle scenes escalate. Final scenes deliver the chapter's payoff.
+- A typical 4-scene chapter: establish → complicate → escalate → turn.
+- A typical 6-scene chapter: hook → develop → complicate → confront → turn → aftermath.
+
+---
+
+## Transitions
+
+### Scene-to-Scene Continuity
+- Use the `lead_in_to_next_scene` field from the previous scene definition to bridge into the next scene.
+- Transitions can be temporal (time skip), spatial (location change), or perspectival (POV shift).
+- Avoid abrupt jumps with no connective tissue — even a single grounding sentence bridges effectively.
+
+### Chapter-Opening Hooks
+- The first scene of a chapter should re-orient the reader after the chapter break.
+- Ground quickly: who, where, when, what's at stake — within the first two paragraphs.
+- If the previous chapter ended on a cliffhanger, address it promptly. Artificial delay frustrates readers.
+
+### Chapter-Closing Momentum
+- The final scene of a chapter should leave unresolved tension, a new question, or a revelation.
+- Avoid tidy chapter endings that resolve everything — they kill forward momentum.
+- The final line of the chapter is disproportionately important. Craft it deliberately.
+
+---
+
+## Point of View
+
+### POV Consistency
+- Maintain a single POV within each scene. Do not head-hop between characters mid-scene.
+- The POV character is identified from the scene definition's `characters` field (typically the first listed, or explicitly marked).
+- All sensory details, observations, and internal thoughts must be filtered through the POV character's perspective.
+
+### POV Character Identification
+- Use the scene definition to determine whose perspective drives the scene.
+- If the scene definition does not specify a POV character, default to the story's protagonist or the character with the most at stake in the scene.
+
+### Multi-POV Stories
+- Different scenes or chapters may use different POV characters.
+- When switching POV, establish the new character's voice immediately — readers need quick orientation.
+- Maintain distinct voice, priorities, and observational patterns for each POV character (see the character-voice skill).
+
+---
+
+## Show Don't Tell
+
+- **Sensory details over abstract statements.** "His hands trembled" instead of "He was nervous."
+- **Dialogue reveals character.** What characters say (and don't say) shows who they are better than narration about their personality.
+- **Action reveals personality.** How a character reacts under pressure, the small habits they display, the choices they make — these are characterisation.
+- **Emotion through physicality.** Describe the physical manifestations of emotion rather than naming the emotion directly. "Her jaw tightened" rather than "She was angry."
+- **Environment reflects mood.** Use setting details to reinforce emotional tone. A ticking clock in a tense scene. Rain in a melancholy scene. But avoid cliché — subvert when possible.
+
+---
+
+## Scene Types
+
+Different scene types call for different generation strategies. Match the `sceneType` parameter used with `wiki-snapshot`:
+
+### Dialogue-Heavy Scenes
+- Focus on distinct character voices (speech patterns, vocabulary, rhythm).
+- Use dialogue tags sparingly — action beats ("She set down her cup") are stronger than "she said."
+- Subtext is critical — what characters avoid saying matters as much as what they say.
+- Keep narration between dialogue lines minimal to maintain conversational pace.
+
+### Action Scenes
+- Short sentences. Short paragraphs. Rapid pacing.
+- Concrete, physical language — describe what the body does, not what the character thinks about doing.
+- Limit internal monologue during high-action moments — save reflection for before and after.
+- Spatial clarity — the reader should always know where characters are in relation to each other.
+
+### Exposition Scenes
+- Weave information into character activity — a character examining a map, discussing history over a meal, discovering a document.
+- Avoid info-dumps. Distribute exposition across multiple scenes when possible.
+- Use character curiosity as a delivery mechanism — questions feel natural, lectures don't.
+- Balance new information with forward plot movement. Every exposition scene should also advance the story.
+
+### Mixed Scenes
+- Blend elements naturally. A conversation that escalates into conflict. An exploration scene that delivers exposition through discovery.
+- Let the dominant element drive pacing, with secondary elements providing texture.
+- Transition between modes smoothly — avoid abrupt shifts from contemplation to action without a trigger.
+
+---
+
+## Context Usage
+
+How to effectively use the wiki snapshot context provided by `wiki-snapshot`:
+
+### Prioritise POV Character Details
+- The POV character's personality traits, speech patterns, current emotional state, and active goals should directly influence narration and internal thought.
+- Reference specific details from the character's wiki page — appearance, mannerisms, relationships — to maintain consistency.
+
+### Use Setting Details for Atmosphere
+- Pull sensory details from the setting's wiki page — architecture, climate, ambient sounds, lighting.
+- Ground each scene in its physical environment within the first few paragraphs.
+- Use setting to reinforce or contrast the scene's emotional tone.
+
+### Weave in Active Plot Threads
+- Reference ongoing plot threads from the wiki snapshot naturally through character dialogue, thoughts, or observations.
+- Do not force plot thread references where they don't belong. If a plot thread isn't relevant to the scene, omit it.
+- Advance at least one plot thread per scene, even if incrementally.
+
+### Reference World Rules Implicitly
+- World-building rules (magic systems, political structures, technology levels) should be embedded in character behaviour and environmental description.
+- Characters should act within established rules without explicitly explaining them to the reader.
+- When rules are relevant to the scene's conflict, demonstrate them through action rather than exposition.
+
+---
+
+## Quality Indicators
+
+What distinguishes a well-generated scene:
+
+- **Narrative tension.** The scene has stakes — something the POV character wants, fears, or must resolve. Even quiet scenes have undercurrents of tension.
+- **Character voice consistency.** The POV character sounds like themselves throughout. Dialogue voices are distinct and recognisable.
+- **Sensory grounding.** The reader can see, hear, smell, and feel the scene's environment. At least two senses are engaged in every scene.
+- **Forward momentum.** The scene changes something — a relationship, a piece of knowledge, a decision, a situation. Static scenes that return to their starting state waste the reader's time.
+- **Thematic resonance.** The scene's events, imagery, or dialogue connect to the story's larger themes, even subtly.
+- **Earned emotion.** Emotional moments are built up to, not arrived at arbitrarily. The reader should feel the emotion, not just be told it exists.
+- **Satisfying structure.** The scene has a clear beginning, development, and turning point. The reader finishes the scene with a sense of completion and curiosity about what comes next.

--- a/docs/features/story-orchestrator.md
+++ b/docs/features/story-orchestrator.md
@@ -88,13 +88,26 @@ After Phase 7, the wiki is the **authoritative source of truth** for world state
 
 The orchestrator delegates specialised work to three subagents:
 
-| Subagent | Purpose | Invoked In |
-|----------|---------|------------|
-| `outline-planner` | Generate and refine the story outline | Phase 2 |
-| `chapter-writer` | Manage per-chapter scene generation pipeline | Phase 8b |
-| `wiki-maintainer` | Maintain wiki pages — create, update, lint | Phases 7, 8c |
+| Subagent | Purpose | Invoked In | Status |
+|----------|---------|------------|--------|
+| `outline-planner` | Generate and refine the story outline | Phase 2 | Planned |
+| `chapter-writer` | Manage per-chapter scene generation pipeline | Phase 8b | Implemented (PR #63) |
+| `wiki-maintainer` | Maintain wiki pages — create, update, lint | Phases 7, 8c | Planned |
 
-These subagents are referenced by name in the orchestrator's agent definition. They will be implemented in subsequent migration tasks (Tasks 18–20).
+### chapter-writer
+
+The `chapter-writer` subagent handles Phase 8b — generating all scenes for a single chapter. It receives a chapter number and story name from the orchestrator, then:
+
+1. Loads the chapter's expanded outline and parses scene definitions via `scene-writer`
+2. Assembles token-budgeted context from the wiki via `wiki-snapshot` for each scene
+3. Generates scenes sequentially (narrative flow depends on prior scene content)
+4. Assembles all scenes into the completed chapter via `scene-writer`
+
+The agent uses two skills:
+- **scene-writing** — narrative structure, pacing, transitions, and scene type conventions
+- **character-voice** — dialogue patterns, internal thought consistency, voice differentiation across characters
+
+Named `chapter-writer` (not `scene-writer`) to avoid collision with the existing `scene-writer` tool. See the [agent definition](../../.opencode/agents/chapter-writer.md) for the full workflow, savepoint strategy, and error handling.
 
 ## Tools
 
@@ -188,8 +201,11 @@ The skill is automatically available to the story-orchestrator agent and can be 
 ## Key Files
 
 - `.opencode/agents/story-orchestrator.md` — Agent definition (259 lines)
+- `.opencode/agents/chapter-writer.md` — Chapter writer subagent definition
 - `.opencode/skills/story-pipeline/SKILL.md` — Pipeline skill reference (345 lines)
-- `opencode.json` — Agent registration with model binding and skill reference
+- `.opencode/skills/scene-writing/SKILL.md` — Scene writing conventions skill
+- `.opencode/skills/character-voice/SKILL.md` — Character voice consistency skill
+- `opencode.json` — Agent registration with model binding and skill references
 
 ## Related
 

--- a/docs/features/story-orchestrator.md
+++ b/docs/features/story-orchestrator.md
@@ -200,7 +200,7 @@ The skill is automatically available to the story-orchestrator agent and can be 
 
 ## Key Files
 
-- `.opencode/agents/story-orchestrator.md` — Agent definition (259 lines)
+- `.opencode/agents/story-orchestrator.md` — Agent definition (266 lines)
 - `.opencode/agents/chapter-writer.md` — Chapter writer subagent definition
 - `.opencode/skills/story-pipeline/SKILL.md` — Pipeline skill reference (345 lines)
 - `.opencode/skills/scene-writing/SKILL.md` — Scene writing conventions skill

--- a/opencode.json
+++ b/opencode.json
@@ -39,6 +39,11 @@
       "model": "ollama/huihui_ai/magistral-abliterated:24b",
       "instructions": ".opencode/agents/story-orchestrator.md",
       "skills": ["story-pipeline"]
+    },
+    "chapter-writer": {
+      "model": "ollama/huihui_ai/magistral-abliterated:24b",
+      "instructions": ".opencode/agents/chapter-writer.md",
+      "skills": ["scene-writing", "character-voice"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Defines the `chapter-writer` subagent and two accompanying skills (`scene-writing`, `character-voice`) for per-chapter scene generation in the story pipeline.

The `chapter-writer` is invoked by the `story-orchestrator` during Phase 8b. It receives a chapter number, generates all scenes sequentially using `wiki-snapshot` for pre-generation context assembly and `scene-writer` tool for content generation, then assembles the chapter.

**Naming note:** Issue #19 AC specifies `.opencode/agents/scene-writer.md`, but `chapter-writer` is used instead to avoid the naming collision with the `scene-writer` tool (per PR #62 synthesis review finding U-W-02).

## Closes

Closes #19

## Changes

- [x] `.opencode/agents/chapter-writer.md` — full agent definition (workflow, context assembly, scene loop, savepoints, error handling, constraints)
- [x] `.opencode/skills/scene-writing/SKILL.md` — scene writing conventions (structure, pacing, transitions, POV, show-don't-tell, scene types, context usage, quality indicators)
- [x] `.opencode/skills/character-voice/SKILL.md` — character voice consistency (dialogue, internal thought, behavioral coherence, relationships, differentiation, emotional continuity, growth, pitfalls)
- [x] `opencode.json` — registered `chapter-writer` agent with model, instructions path, and skills

## Plan

- [x] Create `.opencode/agents/chapter-writer.md`
- [x] Create `.opencode/skills/scene-writing/SKILL.md`
- [x] Create `.opencode/skills/character-voice/SKILL.md`
- [x] Update `opencode.json` with agent registration
- [ ] Lint verification (no Python changes — pass)
- [ ] Synthesized local review
- [ ] Documentation update