### PR TITLE
feat(lint): exclude legacy/ from ruff + fix src/ lint errors

### DIFF
--- a/.github/agents/_shared/dispatch-retry.md
+++ b/.github/agents/_shared/dispatch-retry.md
@@ -30,4 +30,9 @@ If an agent returns successfully but with an empty or "no response" message:
 3. **If work was NOT completed** — retry the dispatch (counts against retry limit above)
 4. **Log the empty response pattern** for reflection in the task summary
 
+If an agent returns successfully but explicitly states it made no changes (or returns a "no response" message with no side effects), and the work is not complete:
+- Retry the dispatch (counts against retry limit)
+- If retry fails or is not warranted (e.g., agent explicitly declines), proceed with direct Orchestrator implementation only for trivial changes
+- For non-trivial changes, escalate to the user rather than implementing complex logic directly
+
 This pattern occurs occasionally with some models that complete work but return empty responses.

--- a/.github/notes/reflections/issue-78-coder-empty-response.md
+++ b/.github/notes/reflections/issue-78-coder-empty-response.md
@@ -1,0 +1,38 @@
+---
+date: "2026-04-16"
+issue: 78
+pr: 81
+category: agent
+targets:
+  - ".github/agents/orchestrator-v3.agent.md"
+  - ".github/agents/_shared/dispatch-retry.md"
+severity: minor
+status: active
+---
+
+## Coder returned empty — Orchestrator implemented directly as fallback
+
+### Finding
+
+During issue #78 (Exclude legacy/ from repo-wide lint), the Coder subagent was dispatched but returned without making any changes (empty response, no file modifications). The Orchestrator then implemented the changes directly — creating pyproject.toml with `legacy/` excluded from ruff, removing an unused `chapter_list` assignment in outline_service.py, and replacing two bare `except:` with `except Exception:` in chapter_generator.py.
+
+### Observation
+
+This is a new subagent failure pattern distinct from the dispatch-retry.md empty response handling. The Coder returned "successfully" (no error, no retry triggered) but with no content and no side effects. The dispatch-retry.md empty response section assumes the agent will either complete work with side effects OR return empty — but doesn't cover the case where the agent explicitly states it made no changes.
+
+The Orchestrator correctly fell back to direct implementation per mode instructions ("If minor: apply the improvement immediately"). The work was straightforward (3 small changes), so the direct implementation was viable. For more complex work, this fallback would not be adequate — a retry or different agent would be needed.
+
+### Suggested Improvement
+
+Add a clause to dispatch-retry.md "Empty Response Handling" section:
+
+> If an agent returns successfully but explicitly states it made no changes (or returns a "no response" message with no side effects), and the work is not complete:
+> - Retry the dispatch (counts against retry limit)
+> - If retry fails or is not warranted (e.g., agent explicitly declines), proceed with direct Orchestrator implementation only for trivial changes
+> - For non-trivial changes, escalate to the user rather than implementing complex logic directly
+
+This distinguishes "agent finished but couldn't formulate return message" (has side effects, proceed) from "agent explicitly made no changes" (work incomplete, needs retry or escalation).
+
+### Action Taken
+
+Applied: Added the above clause to dispatch-retry.md Empty Response Handling section.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+exclude = ["legacy/"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/src/application/services/outline_service.py
+++ b/src/application/services/outline_service.py
@@ -45,11 +45,6 @@ class OutlineService:
                 prompt, story_elements, base_context, settings
             )
 
-            # Generate chapter list
-            chapter_list = await self._generate_chapter_list(
-                outline_content, base_context, story_elements, settings
-            )
-
             # Create outline entity
             outline = Outline(
                 story_elements=story_elements,

--- a/src/application/strategies/outline_chapter/chapter_generator.py
+++ b/src/application/strategies/outline_chapter/chapter_generator.py
@@ -152,7 +152,7 @@ class ChapterGenerator:
                                         f"  Chapter {chapter_num} has no synopsis, skipping..."
                                     )
                                     continue
-                            except:
+                            except Exception:
                                 print(
                                     f"  Chapter {chapter_num} synopsis not found, skipping..."
                                 )
@@ -420,7 +420,7 @@ class ChapterGenerator:
                                             f"chapter_{chapter_num - 1}/recap"
                                         )
                                     )
-                                except:
+                                except Exception:
                                     if settings.debug:
                                         print(
                                             f"    No previous recap found for chapter {chapter_num - 1}"


### PR DESCRIPTION
## Summary
Exclude `legacy/` from repo-wide `ruff check` to eliminate CI noise from the frozen archive. Also fix 2 real lint errors in active `src/` code (unused variable, bare `except`).

## Closes
Closes #78

## Changes
- [x] Implementation complete
- [x] All tests passing (verified)
- [x] Linting clean

## Plan
- [x] Create `pyproject.toml` with `legacy/` excluded from ruff
- [x] Remove unused `chapter_list` assignment in `outline_service.py`
- [x] Replace bare `except:` with `except Exception:` in `chapter_generator.py` (2 locations)
- [x] Verify `ruff check .` returns zero errors
- [x] Push and create PR