### PR TITLE
Fix bare except: clauses in rag_query_cli.py (#74)

### DIFF
--- a/rag_query_cli.py
+++ b/rag_query_cli.py
@@ -262,7 +262,7 @@ Examples:
         try:
             if "vector_store" in locals():
                 await vector_store.close()
-        except:
+        except Exception:
             pass
 
 
@@ -684,7 +684,7 @@ async def interactive_conversation(
             "story_name", f"Story {story_id}"
         )
         print(f"📖 Story: {story_name}")
-    except:
+    except Exception:
         story_name = f"Story {story_id}"
 
     # Initialize conversation history


### PR DESCRIPTION
## Summary
Replace bare `except:` clauses with `except Exception:` in rag_query_cli.py to prevent masking `KeyboardInterrupt` and other system exceptions.

## Closes
Closes #74

## Changes
- [x] Implementation complete (2 bare except: → except Exception:)
- [x] All tests passing (281 passed)
- [x] Linting clean (ruff check --fix)
- [x] Type check clean (mypy src/)

## Plan
1. ✅ Replace bare `except:` at line 265 (finally block) with `except Exception:`
2. ✅ Replace bare `except:` at line 687 (story info fetch) with `except Exception:`
3. ✅ Verify linting and type checks pass
4. ✅ Run full test suite (281 passed)
5. ✅ Commit and push
6. ✅ Create PR