### PR TITLE
Integration test: add wiki-read coverage (W-03 followup)

### DIFF
--- a/.github/agents/test-writer.agent.md
+++ b/.github/agents/test-writer.agent.md
@@ -49,6 +49,8 @@ Follow the test conventions and patterns established in the project (see `copilo
 3. Error handling — expected failure modes, exception paths
 4. Integration points — interactions between components, external service boundaries
 
+**Collection assertions:** When asserting on lists, sets, or decoded JSON arrays returned by a tool or API, verify specific expected values — not just count or existence. `len(results) >= 1` only confirms something was returned; it does not confirm correctness. Use subset membership (`assert expected_set <= actual_set`), intersection (`assert expected_set & actual_set`), or item-level checks (`assert any(item["name"] == "expected" for item in results)`) to confirm the returned data is meaningful and correct.
+
 After writing each test, run the project's test command (see `copilot-instructions.md`).
 
 ### 3. Classify Results

--- a/.github/notes/reflections/archive/issue-88-count-assertion-quality-2026-04-17.md
+++ b/.github/notes/reflections/archive/issue-88-count-assertion-quality-2026-04-17.md
@@ -1,0 +1,50 @@
+---
+date: "2026-04-17"
+issue: 88
+pr: 91
+category: agent
+targets:
+  - ".github/agents/test-writer.agent.md"
+severity: minor
+status: archived
+---
+
+## Count-only assertions on collection results are insufficient — content must be verified
+
+### Finding
+
+During issue #88 (Integration test: wiki-read path has no coverage), the Test Writer wrote a `test_wiki_read_match_entities` method containing only a count assertion:
+
+```python
+assert len(data["matches"]) >= 1
+```
+
+This was flagged as S-01 (weak assertion) during code review and immediately fixed by the Orchestrator to verify specific entity names:
+
+```python
+matched_names = {m["name"] for m in data["matches"]}
+assert matched_names & {"Alex", "ARIA", "Neo-Tokyo"}
+```
+
+### Observation
+
+Count-only assertions confirm that *something* was returned, but not that the returned data is correct. For operations like entity matching, the intent is to retrieve specific known entities — confirming count does not verify that the right entities were matched.
+
+This is the third instance of this pattern appearing in review findings:
+- **Issue #8** — `test_write_missing_value` had no assert at all
+- **Issue #15** — bare `except: pass` obscured assertion reachability
+- **Issue #88** — count-only assertion on match results
+
+The Test Writer's guidance covers priority order (validation → happy path → error → integration) and running tests incrementally, but does not address assertion *quality* — specifically that collection results must verify specific expected values, not just existence or count.
+
+### Suggested Improvement
+
+Add a **Collection Assertions** note to the Test Writer's "Write Tests" section, immediately after the priority order list:
+
+```markdown
+**Collection assertions:** When asserting on lists, sets, or decoded JSON arrays returned by a tool or API, verify specific expected values — not just count or existence. `len(results) >= 1` only confirms something was returned; it does not confirm correctness. Use subset membership (`assert expected_set <= actual_set`), intersection (`assert expected_set & actual_set`), or item-level checks (`assert any(item["name"] == "expected" for item in results)`) to confirm the returned data is meaningful and correct.
+```
+
+### Action Taken
+
+Applied: added collection assertion guidance to `.github/agents/test-writer.agent.md` in the "Write Tests" section, after the priority order list.

--- a/.github/notes/reflections/archive/issue-88-stale-review-bypass-2026-04-17.md
+++ b/.github/notes/reflections/archive/issue-88-stale-review-bypass-2026-04-17.md
@@ -1,0 +1,41 @@
+---
+date: "2026-04-17"
+issue: 88
+pr: 91
+category: agent
+targets:
+  - "/memories/orchestrator-issues.md"
+severity: minor
+status: archived
+---
+
+## Stale user memory caused unnecessary synthesized review bypass
+
+### Finding
+
+During issue #88 (Integration test: wiki-read path has no coverage), the Orchestrator bypassed the 3-reviewer synthesized review and used a single Claude reviewer instead, citing "the known VS Code stability issue noted in user memory."
+
+The user memory at `/memories/orchestrator-issues.md` still contains the old workaround note from issue #68:
+
+> "Dispatching 3 parallel reviewer subagents causes VS Code window to become non-responsive. Workaround: do single-pass direct review instead of Synthesized Review."
+
+However, this problem was **fully resolved** in PR #70 (issue #68) via the flattened dispatch architecture:
+- The Orchestrator now dispatches all three reviewers **sequentially** (depth-1) and each writes a report to disk
+- The Synthesizing Reviewer reads the pre-written reports — it no longer dispatches sub-agents
+- This architecture was validated in PR #70 as the definitive resolution
+
+The user memory was supposed to be updated to reflect this resolution (the archive note from issue #68 explicitly states "User memory updated to reflect resolution"), but the update was never actually applied.
+
+### Observation
+
+Stale memory caused the review pipeline to silently degrade. The Orchestrator read old workaround guidance that has been superseded, and used a single reviewer instead of the full synthesized review. This reduced review quality for PR #91 without any actual need — the flattened architecture should have prevented the freeze.
+
+Keeping user memory accurate is as important as keeping agent files accurate. Stale workaround notes persist as operational risk.
+
+### Suggested Improvement
+
+Update `/memories/orchestrator-issues.md` to accurately reflect the current state: the VS Code freeze issue was resolved in PR #70 via the flattened architecture. The workaround note should be replaced with a resolved status and a reference to the flattened architecture.
+
+### Action Taken
+
+Applied: updated the user memory file at the actual path (`/home/shaun/.config/Code/User/globalStorage/github.copilot-chat/memory-tool/memories/orchestrator-issues.md`) to mark the issue as resolved and document the flattened architecture fix.

--- a/.github/notes/reflections/issue-88-count-assertion-quality.md
+++ b/.github/notes/reflections/issue-88-count-assertion-quality.md
@@ -1,0 +1,50 @@
+---
+date: "2026-04-17"
+issue: 88
+pr: 91
+category: agent
+targets:
+  - ".github/agents/test-writer.agent.md"
+severity: minor
+status: archived
+---
+
+## Count-only assertions on collection results are insufficient — content must be verified
+
+### Finding
+
+During issue #88 (Integration test: wiki-read path has no coverage), the Test Writer wrote a `test_wiki_read_match_entities` method containing only a count assertion:
+
+```python
+assert len(data["matches"]) >= 1
+```
+
+This was flagged as S-01 (weak assertion) during code review and immediately fixed by the Orchestrator to verify specific entity names:
+
+```python
+matched_names = {m["name"] for m in data["matches"]}
+assert matched_names & {"Alex", "ARIA", "Neo-Tokyo"}
+```
+
+### Observation
+
+Count-only assertions confirm that *something* was returned, but not that the returned data is correct. For operations like entity matching, the intent is to retrieve specific known entities — confirming count does not verify that the right entities were matched.
+
+This is the third instance of this pattern appearing in review findings:
+- **Issue #8** — `test_write_missing_value` had no assert at all
+- **Issue #15** — bare `except: pass` obscured assertion reachability
+- **Issue #88** — count-only assertion on match results
+
+The Test Writer's guidance covers priority order (validation → happy path → error → integration) and running tests incrementally, but does not address assertion *quality* — specifically that collection results must verify specific expected values, not just existence or count.
+
+### Suggested Improvement
+
+Add a **Collection Assertions** note to the Test Writer's "Write Tests" section, immediately after the priority order list:
+
+```markdown
+**Collection assertions:** When asserting on lists, sets, or decoded JSON arrays returned by a tool or API, verify specific expected values — not just count or existence. `len(results) >= 1` only confirms something was returned; it does not confirm correctness. Use subset membership (`assert expected_set <= actual_set`), intersection (`assert expected_set & actual_set`), or item-level checks (`assert any(item["name"] == "expected" for item in results)`) to confirm the returned data is meaningful and correct.
+```
+
+### Action Taken
+
+Applied: added collection assertion guidance to `.github/agents/test-writer.agent.md` in the "Write Tests" section, after the priority order list.

--- a/.github/notes/reflections/issue-88-stale-review-bypass.md
+++ b/.github/notes/reflections/issue-88-stale-review-bypass.md
@@ -1,0 +1,41 @@
+---
+date: "2026-04-17"
+issue: 88
+pr: 91
+category: agent
+targets:
+  - "/memories/orchestrator-issues.md"
+severity: minor
+status: archived
+---
+
+## Stale user memory caused unnecessary synthesized review bypass
+
+### Finding
+
+During issue #88 (Integration test: wiki-read path has no coverage), the Orchestrator bypassed the 3-reviewer synthesized review and used a single Claude reviewer instead, citing "the known VS Code stability issue noted in user memory."
+
+The user memory at `/memories/orchestrator-issues.md` still contains the old workaround note from issue #68:
+
+> "Dispatching 3 parallel reviewer subagents causes VS Code window to become non-responsive. Workaround: do single-pass direct review instead of Synthesized Review."
+
+However, this problem was **fully resolved** in PR #70 (issue #68) via the flattened dispatch architecture:
+- The Orchestrator now dispatches all three reviewers **sequentially** (depth-1) and each writes a report to disk
+- The Synthesizing Reviewer reads the pre-written reports — it no longer dispatches sub-agents
+- This architecture was validated in PR #70 as the definitive resolution
+
+The user memory was supposed to be updated to reflect this resolution (the archive note from issue #68 explicitly states "User memory updated to reflect resolution"), but the update was never actually applied.
+
+### Observation
+
+Stale memory caused the review pipeline to silently degrade. The Orchestrator read old workaround guidance that has been superseded, and used a single reviewer instead of the full synthesized review. This reduced review quality for PR #91 without any actual need — the flattened architecture should have prevented the freeze.
+
+Keeping user memory accurate is as important as keeping agent files accurate. Stale workaround notes persist as operational risk.
+
+### Suggested Improvement
+
+Update `/memories/orchestrator-issues.md` to accurately reflect the current state: the VS Code freeze issue was resolved in PR #70 via the flattened architecture. The workaround note should be replaced with a resolved status and a reference to the flattened architecture.
+
+### Action Taken
+
+Applied: updated `/memories/orchestrator-issues.md` to mark the issue as resolved and document the flattened architecture fix.

--- a/.github/notes/reviews/2026-04-17-pr91-claude-raw.md
+++ b/.github/notes/reviews/2026-04-17-pr91-claude-raw.md
@@ -1,0 +1,112 @@
+# Code Review Report — feat/issue-88-wiki-read-integration-test
+
+**Date:** 2026-04-17
+**Reviewer:** Claude Sonnet 4.6 (Reviewer sub-agent)
+**Branch:** `feat/issue-88-wiki-read-integration-test`
+**Commit:** `81d043b test(integration): add wiki-read coverage — read and match-entities paths (#88)`
+
+---
+
+## Review Summary
+
+A single-file, single-commit change that adds two integration tests covering the previously-unused `WIKI_READ_SCRIPT`. The scope is minimal (51 lines added, all in `tests/integration/test_e2e_opencode.py`), the tests follow the established E2E patterns, and the assertions are grounded in verifiable implementation behavior. No critical or warning-level findings were identified.
+
+**Files Reviewed:** 1  
+**Findings:** 0 Critical, 0 Warning, 2 Suggestion
+
+---
+
+## Findings
+
+### Critical Findings
+
+None.
+
+### Warning Findings
+
+None.
+
+### Suggestions
+
+```
+[S-01] match-entities assertion does not verify specific expected entities
+Category: Testing
+Severity: Suggestion
+File: tests/integration/test_e2e_opencode.py
+Lines: 935-941
+Description: The assertion `len(data["matches"]) >= 1` confirms at least one match exists
+but does not validate *which* entities were matched. The test text ("Alex and ARIA discuss
+their plans in Neo-Tokyo.") contains three named entities that are all written to the wiki
+index by the pipeline fixture (Alex, ARIA, Neo-Tokyo). A stronger assertion would verify
+that at least one known entity name appears in the results, making test failures more
+diagnosable (i.e., distinguishing "no matches at all" from "matches exist but for wrong
+entities").
+Suggestion: Add a name-level check, e.g.:
+    matched_names = {m["name"] for m in data["matches"]}
+    assert matched_names & {"Alex", "ARIA", "Neo-Tokyo"}
+```
+
+```
+[S-02] No error-path coverage for either operation
+Category: Testing
+Severity: Suggestion
+File: tests/integration/test_e2e_opencode.py
+Lines: 892-941 (general — new test block)
+Description: Both new tests only exercise the happy path. Neither verifies the tool's
+behaviour when given a non-existent slug (expected: `{"status": "ok", "pages": []}`) or
+when `match-entities` is invoked against a story with no wiki (expected: empty matches
+list). These empty-result branches exist in wiki_read.py and are currently untested.
+Suggestion: Add a third test (or parametric variant) that calls `--operation read` with
+`--slug does-not-exist` and asserts `data["pages"] == []`. This is low-cost given the
+existing fixture infrastructure and would close the obvious regression gap.
+```
+
+---
+
+## Phase-by-Phase Notes
+
+### Phase 1 — Structural
+
+- Commit message follows `type(scope): description (#issue)` convention. ✓
+- Branch name follows `feat/issue-N-description` convention. ✓
+- Change is 51 lines, well within scope. ✓
+- No unrelated changes. ✓
+- No file relocations, step-list numbering, or `tools:` array modifications. ✓
+
+### Phase 2 — Code
+
+- Tests follow the class-fixture pattern (`TestE2EFullPipeline`, `pipeline_result`) used throughout the file. ✓
+- Helper usage (`_make_env`, `_run_tool`, `_assert_success`) is consistent with existing tests. ✓
+- No new imports required; all symbols were already in scope. ✓
+
+### Phase 3 — Frontend
+
+Not applicable. No frontend changes.
+
+### Phase 4 — Security
+
+No security concerns. The test operates against a temporary, isolated directory created by the `pipeline_result` fixture, and no untrusted input is introduced.
+
+### Phase 5 — Testing
+
+- Both `read` and `match-entities` operations are now exercised (resolves the stated issue). ✓
+- Assertions are grounded in verifiable implementation behavior:
+  - `"alex"` slug: confirmed — `_slugify("Alex")` → `"alex"` and `wiki_update.py` writes `slug` into YAML frontmatter.
+  - `"character"` type: confirmed — pages created with `--page-type character`.
+  - `"confidence" in page["metadata"]`: confirmed — `confidence` is a required schema field, always written by `wiki_update.py` (`_REQUIRED_FIELDS` in `wiki_lint.py`, written at `wiki_update.py:164`).
+  - Match text contains entity names from `EXPECTED_CHARACTERS` + `EXPECTED_SETTINGS`, all registered in the wiki index during pipeline setup. ✓
+- See S-01 (weak match assertion) and S-02 (no error-path coverage) above.
+
+### Phase 6 — Performance
+
+Not applicable. Test-only change; no production code paths affected.
+
+### Phase 7 — Documentation
+
+No documentation changes required. The PR closes a known gap (unused constant), which was implicitly self-documenting. The issue reference in the commit message provides sufficient traceability.
+
+---
+
+## Overall Assessment
+
+This change is ready to merge. The two new tests are correctly structured, their assertions are valid and well-grounded in the underlying implementation, and the change achieves its stated goal of exercising both `wiki_read.py` operations that were previously defined but untested. The two suggestions are incremental improvements to test robustness — neither represents a blocking concern. No correctness, security, or convention issues were identified.

--- a/tests/integration/test_e2e_opencode.py
+++ b/tests/integration/test_e2e_opencode.py
@@ -939,3 +939,5 @@ class TestE2EFullPipeline:
         assert data["status"] == "ok"
         assert isinstance(data["matches"], list)
         assert len(data["matches"]) >= 1
+        matched_names = {m["name"] for m in data["matches"]}
+        assert matched_names & {"Alex", "ARIA", "Neo-Tokyo"}

--- a/tests/integration/test_e2e_opencode.py
+++ b/tests/integration/test_e2e_opencode.py
@@ -890,3 +890,52 @@ class TestE2EFullPipeline:
 
         for count in token_counts:
             assert count <= WIKI_SNAPSHOT_TOKEN_LIMIT
+
+    def test_wiki_read_character_page(self, pipeline_result: dict[str, Any]) -> None:
+        env = _make_env(pipeline_result["stories_dir"], pipeline_result["chromadb_dir"])
+        result = _run_tool(
+            WIKI_READ_SCRIPT,
+            [
+                "--operation",
+                "read",
+                "--name",
+                STORY_NAME,
+                "--slug",
+                "alex",
+                "--detail-level",
+                "full",
+            ],
+            env,
+            timeout=30,
+        )
+
+        data = _assert_success(result, "wiki-read character alex")
+
+        assert data["status"] == "ok"
+        assert len(data["pages"]) >= 1
+        page = data["pages"][0]
+        assert page["slug"] == "alex"
+        assert page["type"] == "character"
+        assert "confidence" in page["metadata"]
+
+    def test_wiki_read_match_entities(self, pipeline_result: dict[str, Any]) -> None:
+        env = _make_env(pipeline_result["stories_dir"], pipeline_result["chromadb_dir"])
+        result = _run_tool(
+            WIKI_READ_SCRIPT,
+            [
+                "--operation",
+                "match-entities",
+                "--name",
+                STORY_NAME,
+                "--text",
+                "Alex and ARIA discuss their plans in Neo-Tokyo.",
+            ],
+            env,
+            timeout=30,
+        )
+
+        data = _assert_success(result, "wiki-read match-entities")
+
+        assert data["status"] == "ok"
+        assert isinstance(data["matches"], list)
+        assert len(data["matches"]) >= 1


### PR DESCRIPTION
## Summary

Adds integration test coverage for `wiki_read.py`, which is the primary consumer of the wiki during scene generation but had no integration test coverage. `WIKI_READ_SCRIPT` was defined in the test file but never used.

## Closes
Closes #88

## Changes
- [x] `test_wiki_read_character_page` — exercises `read` operation; queries for slug "alex", asserts page returned with correct slug/type/confidence metadata
- [x] `test_wiki_read_match_entities` — exercises `match-entities` operation; passes text containing "Alex" and "ARIA", asserts at least one entity matched
- [x] All 297 unit tests still passing (verified)
- [x] Linting clean (ruff)

## Plan

**Summary:** Add two test methods to `TestE2EFullPipeline` in `tests/integration/test_e2e_opencode.py` that exercise both operations of `wiki_read.py`. `WIKI_READ_SCRIPT` was already defined but unused — both new tests use it directly.

**Task Checklist:**
- [x] `test_wiki_read_character_page` — `read` operation, `--slug alex`, assert slug/type/confidence in frontmatter
- [x] `test_wiki_read_match_entities` — `match-entities` operation, text with "Alex"/"ARIA"/"Neo-Tokyo", assert ≥1 match returned
- [x] Lint clean
- [x] 297 unit tests passing
