### PR TITLE
Implement all workflow improvement fixes from 2026-04-21 synthesis audit

### DIFF
--- a/.github/agents/_shared/dispatch-retry.md
+++ b/.github/agents/_shared/dispatch-retry.md
@@ -7,7 +7,7 @@
 When dispatching to any agent, the following errors are retryable:
 
 - "Response contained no choices"
-- Timeout failures
+- Timeout failures (see "Timeout with Possible Completion" below before retrying)
 - Rate limit errors
 
 **Retry protocol:**
@@ -18,6 +18,18 @@ When dispatching to any agent, the following errors are retryable:
 4. After 3 failed attempts, post a PR comment and notify the user — do not continue
 
 When retrying, include the same context but add: "This is retry attempt N of 3."
+
+---
+
+## Timeout with Possible Completion
+
+A timeout failure may mean the agent completed its work but ran out of time to return a report. Before retrying:
+
+1. **Check for side effects** — look for file changes, commits, or other expected outputs
+2. **If work appears completed** — treat as Empty Response (section below): proceed without retry
+3. **If no side effects found** — apply the standard retry protocol above
+
+Retrying a dispatch where work was already completed risks double-writes, duplicate commits, or conflicted state.
 
 ---
 

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -46,6 +46,7 @@ Read **`.github/agents/_shared/communication.md`** — use caveman for chat/prog
     - Grep the project for existing examples of the same artifact type and replicate the integration pattern.
     - **When writing or editing any agent or skill content** that includes tool operation names, parameter types, or return formats — verify each against the actual Python source (`src/tools/*.py`) and TypeScript wrapper (`.opencode/tools/*.ts`). Verify: (a) valid operation values by reading the Python dispatch/enum; (b) Zod parameter types (`z.string()` vs `z.object()`) from the TS wrapper; (c) return value shape from Python `return` statements; (d) parameter key names match the exact Zod field names declared in the TS wrapper (`z.object({ step: ... })` means the key is `step:`, not `savepoint:`) — mismatched keys pass Zod silently and produce misleading runtime failures. Wrong operation names and mismatched key names cause hard runtime failures invisible to lint or type checks.
 11. **Implement only the files listed in the dispatch.** The plan's task checklist defines the complete authorised scope of this dispatch. Do NOT modify, create, or delete files outside that list — no incidental improvements, no refactors, no abstractions, no "while I'm in here" changes to adjacent code. If you notice bugs, improvements, or technical debt in code you read while working, record them in your handoff summary under "Out-of-scope observations" but do not act on them. Every unauthorised change inflates the diff, pollutes the review, and may require manual revert work.
+   - **Test expectation drift:** when your implementation legitimately changes an output contract (savepoint key names, stdout format, internal counts), tests asserting the old values will break. These are **expectation drift** — they are not bugs in the implementation, and fixing them is **in scope** even if test files are not listed in the plan. The rule bars incidental improvements; it does not bar fixing the tests your own implementation breaks. Distinguish from genuine regression failures — if a test reveals an unintended behaviour change, fix the implementation rather than the test.
 
 > **When dispatched by the Orchestrator** (implementation or regression fix), do NOT commit, push, or post PR comments. The Orchestrator owns all git/GitHub operations. Just implement, lint, and return.
 
@@ -78,6 +79,8 @@ When implementing a feature that spans multiple layers:
 4. **Prompt templates last** — Jinja2/text templates in `src/infrastructure/prompts/`
 
 This ensures each layer's dependencies exist before it references them.
+
+**When modifying an existing Python tool's CLI** (adding or removing `--` flags, changing positional arguments) — treat Python tools (step 2) and TypeScript wrappers (step 3) as an **atomic pair**. Read the TypeScript wrapper alongside the Python changes and update the Zod schema AND the `args` builder in `execute()` to expose every new parameter. New Python `--flags` not added to the wrapper schema are silently dropped; the Python tool falls back to defaults and produces wrong output with no error — invisible to lint, type checks, and Python-layer tests.
 
 ## Code Patterns
 

--- a/.github/notes/audits/2026-04-21-workflow-improvement-synthesis.md
+++ b/.github/notes/audits/2026-04-21-workflow-improvement-synthesis.md
@@ -1,0 +1,63 @@
+## Synthesized Audit — 2026-04-21
+
+**Audit Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Focus:** Workflow improvement — savepoints/memory, token efficiency, structural clarity, logic gaps
+**Model Agreement Score:** 7/10
+**Overall Health:** At Risk — one unanimous critical defect (empty character/setting sheets) poisons entire downstream pipeline
+**Development Stage:** Phase 8 (per-chapter loop) — functionally blocked by empty sheet generation and unimplementable quality gate
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Info |
+| ----------------- | -------- | ------- | ---- |
+| ★★★ Unanimous     | 1        | 0       | 0    |
+| ★★☆ Majority      | 2        | 3       | 0    |
+| ★☆☆ Singular      | 2        | 8       | 5    |
+
+### Key Findings
+
+- [U-C-01] Phase 5/6 write empty character/setting sheets — no LLM generation step (★★★)
+- [M-C-01] Phase 8f chapter quality gate not implementable — critique-runner is outline-only (★★☆)
+- [M-C-02] Phase 8c invocation model contradictory — orchestrator says post-chapter, wiki-maintainer says post-scene (★★☆)
+- [M-W-01] Chunked outline previousChunks accumulation causes quadratic token growth (★★☆)
+- [M-W-02] Resume logic: no mechanism to determine current pipeline phase (★★☆)
+- [M-W-03] Phase 9 assembly underspecified — no tools, no format, no output path (★★☆)
+- [S-C-01] Wiki-snapshot token enforcement never drops pages — budget can overflow (★☆☆)
+- [S-C-02] Context window mismatch: pipeline assumes 65k, active config is 16384 (★☆☆)
+- [S-C-03] Critique-runner savepoint namespace collision between outline and chapter quality loops (★☆☆)
+- [S-W-01] Analysis chunk savepoint paths: code vs docs mismatch (★☆☆)
+- [S-W-02] Non-chunked outline savepoint name mismatch: initial_outline vs outline_complete (★☆☆)
+- [S-W-03] Phase 8a → chapter-writer expanded outline field name never specified (★☆☆)
+- [S-W-04] Post-revision: no re-run of wiki/recap/lint after chapter revision (★☆☆)
+- [S-W-05] generate-elements returns full story_elements in stdout (redundant after PR #71 pattern) (★☆☆)
+- [S-W-06] Unimplemented config flags exposed as supported: chapter_min_revisions, enable_final_edit, enable_scrubbing (★☆☆)
+- [S-W-07] Scene savepoints created redundantly by both tool and agent instructions (★☆☆)
+- [S-W-08] create_chunk.md references enrichment suggestions never provided in tool call (★☆☆)
+- [S-I-01] Missing savepoints for individual chunks in chunked outline generation (★☆☆)
+- [S-I-02] context-budgeting SKILL.md scoring formula diverges from code (★☆☆)
+- [S-I-03] Chapter-writer scene loop steps 5-7 create orphaned savepoints with no load path (★☆☆)
+- [S-I-04] critique_runner.py hardcoded threshold 85.0 vs config default 87 — workaround in docs not code (★☆☆)
+- [S-I-05] next_chapter_synopsis parameter on scene-writer never populated (★☆☆)
+
+### Divergences
+
+- [D-01] Empty sheets severity: GPT=Warning, Claude+Gemini=Critical → Assessed Critical (downstream poison to entire wiki)
+- [D-02] Chunked outline token growth severity: Gemini=Critical, GPT=Warning → Assessed Warning with Critical escalation at >30 chapters
+- [D-03] Resume logic severity: GPT=Critical (schema) + Warning (metadata), Claude=Warning → Assessed Warning (robustness gap, not immediate hard failure)
+- [D-04] Wiki snapshot budget enforcement bug: Gemini=Critical, others didn't inspect this code path → Singular but high-confidence
+
+### Priority Actions
+
+1. Add LLM generation steps to Phase 5 and Phase 6 before generate-sheet calls
+2. Implement chapter quality evaluation — extend critique-runner or build chapter-critique tool
+3. Resolve wiki-maintainer invocation granularity (commit to post-chapter)
+4. Fix wiki_snapshot.py _enforce_token_budget to drop pages when L1 demotion insufficient
+5. Investigate 65k vs 16k context window mismatch
+6. Remove previousChunks from expand-chapter — use continuitySummary only
+7. Add pipeline_state to story state for resume capability
+8. Specify Phase 9 assembly tools, format, output path
+
+### Actions Taken
+
+- Notes written: `.github/notes/audits/2026-04-21-workflow-improvement-synthesis.md`
+- Findings to embed into `audits` ChromaDB collection (pending)

--- a/.github/notes/reflections/archive/issue-117-coder-timeout-side-effects-2026-04-21.md
+++ b/.github/notes/reflections/archive/issue-117-coder-timeout-side-effects-2026-04-21.md
@@ -1,0 +1,33 @@
+---
+date: "2026-04-21"
+issue: 117
+pr: 118
+category: agent
+targets:
+  - ".github/agents/_shared/dispatch-retry.md"
+severity: minor
+status: archived
+---
+
+## Timeout failures should check for side effects before retrying
+
+### Finding
+
+During issue #117 (PR #118), the Coder subagent completed all implementation work (file changes present on disk) but timed out before returning a report. The Orchestrator correctly followed the dispatch-retry.md protocol: checked for side effects, found them, and proceeded with verification rather than re-dispatching. This validated that the Empty Response Handling section covers the case, but the protocol is ambiguous — the "Timeout failures" bullet in the initial retryable-errors list sends readers directly to the retry protocol without first checking for completed work.
+
+### Observation
+
+There are two distinct timeout scenarios:
+
+1. **Timeout before work begins or partway through** — no side effects. Retry is correct.
+2. **Timeout after work completes** — side effects present. Retrying dispatches the agent against already-completed work, risking double-writes, duplicate commits, or conflicted state.
+
+The current dispatch-retry.md structure lists timeout failures as retryable (correct for scenario 1) but does not instruct the reader to distinguish scenario 2. An Orchestrator following the protocol literally could retry a completed dispatch unnecessarily. The Empty Response Handling section below handles this correctly, but its connection to timeout cases is implicit.
+
+### Suggested Improvement
+
+Add a "Timeout with Possible Completion" subsection to dispatch-retry.md immediately before the Empty Response Handling section, and add a cross-reference note beside the "Timeout failures" bullet.
+
+### Action Taken
+
+Applied: added cross-reference note to the "Timeout failures" bullet and a "Timeout with Possible Completion" subsection to `.github/agents/_shared/dispatch-retry.md`.

--- a/.github/notes/reflections/archive/issue-117-test-expectation-drift-2026-04-21.md
+++ b/.github/notes/reflections/archive/issue-117-test-expectation-drift-2026-04-21.md
@@ -1,0 +1,43 @@
+---
+date: "2026-04-21"
+issue: 117
+pr: 118
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: archived
+---
+
+## Coder must update tests broken by legitimate implementation changes (expectation drift)
+
+### Finding
+
+After the Coder completed the PR #118 implementation, the test suite had six regressions. Three were test expectation drift — tests that were asserting incidental implementation details that the Coder's own changes made stale:
+
+1. Savepoint naming changed (`critique_results_iteration_N` → `{mode}_critique_results_iteration_N`) — test expected old key.
+2. Stdout output format changed — test checked old text.
+3. Prompt count changed — test asserted old count.
+
+All three were straightforward to fix by updating the test assertions. None represented bugs in the implementation. However, the Coder returned without fixing them, leaving regression cleanup to the Orchestrator's Step 5c pass.
+
+### Observation
+
+Rule 11 ("implement only listed files") guards against scope creep — the Coder must not make incidental improvements to code outside the dispatch scope. However, when the Coder's own implementation legitimately changes an output contract (savepoint key names, stdout formats, internal counts), tests asserting the old values are not "out of scope" — they are broken by the implementation. Updating them is not scope creep; it is completing the implementation.
+
+The existing guidance does not distinguish between:
+- Tests broken by the Coder's changes (expectation drift — Coder must fix)
+- Tests that were already failing before the task (not Coder's responsibility)
+- Tests that reveal bugs in the new implementation (fix the implementation, not the test)
+
+Without explicit guidance, the Coder interprets Rule 11 as a blanket prohibition on test file edits and returns with knowable regressions unfixed.
+
+This pattern is distinct from the collection assertion quality issue (issue #88) and independent expected value pinning (issue #89): those cover how tests should be written; this covers who is responsible for updating them when implementation changes break them.
+
+### Suggested Improvement
+
+Add a sub-bullet exception to Rule 11 in coder.agent.md clarifying that test expectation drift (tests the Coder's own implementation broke) must be fixed in the dispatch, even if test files are not listed in the plan.
+
+### Action Taken
+
+Applied: added "Test expectation drift" exception sub-bullet to Rule 11 of `.github/agents/coder.agent.md`.

--- a/.github/notes/reflections/archive/issue-117-ts-wrapper-python-cli-sync-2026-04-21.md
+++ b/.github/notes/reflections/archive/issue-117-ts-wrapper-python-cli-sync-2026-04-21.md
@@ -1,0 +1,34 @@
+---
+date: "2026-04-21"
+issue: 117
+pr: 118
+category: agent
+targets:
+  - ".github/agents/coder.agent.md"
+severity: minor
+status: archived
+---
+
+## Python CLI changes must propagate to TypeScript wrapper — TS layer invisible to Python-only reviews
+
+### Finding
+
+During PR #118, the Coder extended `critique_runner.py` with two new argparse flags (`--mode` and `--criterion-floor`) but did not update the corresponding TypeScript wrapper (`critique-runner.ts`) to expose them in the Zod schema or `args` builder. This caused the new chapter critique workflow to fail silently: the orchestrator passes `mode: "chapter"` to the tool, the wrapper strips it (unknown Zod field), and Python falls back to the `"outline"` default — producing wrong output with no error.
+
+Critically, Claude's review of the PR missed this entirely. Claude reviewed the Python layer and agent instructions thoroughly but did not verify whether the TypeScript wrapper matched the updated Python CLI contract. GPT and Gemini both independently caught the gap as a Critical finding. This confirms the gap is non-obvious and models can be blind to the TS layer when reviewing Python-heavy PRs.
+
+### Observation
+
+The existing Rule 10 verification checklist covers reading the TS wrapper to verify operation names, Zod parameter types, and parameter key names. However, this applies in the direction of "what does the wrapper expose?" — verifying documentation/agent files are accurate about the tool interface. It does not explicitly cover the inverse direction: "did I add new Python CLI parameters that also need TS wrapper entries?"
+
+The Implementation Order section lists Python tools (step 2) before TypeScript wrappers (step 3), which is correct for new tool creation. But for modifications to existing tools, the two layers must change atomically — a Python CLI change without a corresponding TS wrapper change is an incomplete implementation.
+
+This is the second related pattern after issue #113 (z.string vs z.object type representation) and issue #115 (parameter key name vs Zod field name). Together they form a cluster: the TS/Python boundary produces subtle failures invisible to lint and Python tests.
+
+### Suggested Improvement
+
+Add a paragraph to the Implementation Order section of coder.agent.md, after "This ensures each layer's dependencies exist before it references them," clarifying that modifying an existing Python tool's CLI requires an atomic Python+TS wrapper update.
+
+### Action Taken
+
+Applied: added "When modifying an existing Python tool's CLI" guidance block to the Implementation Order section of `.github/agents/coder.agent.md`.

--- a/.github/notes/reviews/2026-04-21-pr118-claude-raw.md
+++ b/.github/notes/reviews/2026-04-21-pr118-claude-raw.md
@@ -1,0 +1,169 @@
+# Code Review Report — PR #118 (feat/issue-117-workflow-improvement-fixes)
+
+**Branch:** `feat/issue-117-workflow-improvement-fixes`
+**Base:** `development`
+**Reviewer:** Claude (raw review)
+**Date:** 2026-04-21
+**Commits:** 2 (`324b02e`, `94be955`)
+
+---
+
+## Review Summary
+
+This PR delivers a well-scoped set of workflow improvement fixes covering five distinct concerns: wiki token-budget page-dropping, story-state `pipeline_state` field backfill, `critique-runner` chapter mode, `outline-generator` stdout compaction, and story assembly. The implementation is clean, the tests are relevant and all pass (330 suite, 48 directly changed). One documentation-code mismatch in the `context-budgeting` skill and one mode-blind content fallback path in `critique_runner` are the primary concerns.
+
+**Files Reviewed:** 20
+**Findings:** 0 Critical, 2 Warning, 2 Suggestion
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] context-budgeting/SKILL.md states "Pages are never dropped entirely" — now false
+Category: Documentation
+Severity: Warning
+File: .opencode/skills/context-budgeting/SKILL.md
+Lines: general (Stage 2 section)
+Description: The skill still reads: "Pages are never dropped entirely — minimum L1 ensures
+the generation LLM is at least aware of every relevant entity's existence." But
+_enforce_token_budget() in wiki_snapshot.py now has a page-dropping phase: after demoting
+all non-protected pages to L1, if current_total still exceeds budget it sorts removable pages
+by ascending relevance_score and pops them until within budget. An agent following
+SKILL.md guidance may incorrectly assume every entity survives the budget cap. The new
+test (TestWikiSnapshotTokenBudget) confirms the drop can and does occur.
+Suggestion: Update the Stage 2 section to describe the two-phase behaviour:
+  1. Iterative L3→L2→L1 demotion for non-protected pages
+  2. Page-dropping of the lowest-scoring non-protected pages if still over budget after
+     all demotions are exhausted
+Replace the "never dropped" sentence with: "If the total is still over budget after all
+non-protected pages reach L1, the lowest-scoring non-protected pages are removed entirely,
+starting from the bottom of the ranked list."
+```
+
+```
+[W-02] cmd_run_critics content fallback is mode-blind
+Category: Correctness
+Severity: Warning
+File: src/tools/critique_runner.py
+Lines: ~163-177 (the else branch inside cmd_run_critics)
+Description: When cmd_run_critics is invoked with mode="chapter" but no --content argument,
+the fallback savepoint lookup attempts to load "outline_iteration_{N-1}" then "outline",
+neither of which will exist for a chapter critique run. This causes an unhelpful error:
+"no outline content provided and no outline savepoint found". The variable holding the
+loaded text is also named `outline` throughout the function, even in chapter mode.
+In practice the story-orchestrator always passes --content for chapter mode, so this codepath
+is not reached at runtime. However, it is a silent assumption that could silently break if
+an operator calls the tool directly without --content, and the error message is actively
+misleading in chapter mode.
+Suggestion: Add a mode-aware fallback: for chapter mode, attempt to load from
+"chapter_{N-1}_complete" or similar chapter savepoints before the outline fallbacks.
+Alternatively, at minimum rename the local variable from `outline` to `content` and improve
+the error message to mention the mode:
+  _error(f"no content provided for {mode} critique and no {mode} savepoint found")
+```
+
+### Suggestions
+
+```
+[S-01] prompts/outline/create_chunk.md retains dead {previous_chunks} section
+Category: Style
+Severity: Suggestion
+File: prompts/outline/create_chunk.md
+Lines: ~22-24 (<PREVIOUS_CHUNKS> block)
+Description: outline-planner.md Phase 3 now explicitly instructs agents: "do NOT pass
+previousChunks as it causes quadratic token growth." The TypeScript wrapper also only
+pushes --previous-chunks when the argument is truthy, so the Python tool receives
+previous_chunks="" by default. The PromptLoader substitutes the empty string, leaving
+<PREVIOUS_CHUNKS></PREVIOUS_CHUNKS> in every rendered prompt. This costs a few tokens per
+call and leaves a vestigial section that could confuse future maintainers.
+Suggestion: Remove the <PREVIOUS_CHUNKS>{previous_chunks}</PREVIOUS_CHUNKS> section from
+create_chunk.md and remove the previous_chunks argument from the _load_prompt call in
+cmd_expand_chapter (since it defaults to empty and is never populated).
+```
+
+```
+[S-02] _load_chapter_content falls back to json.dumps for dict savepoints
+Category: Correctness
+Severity: Suggestion
+File: src/tools/story_assembler.py
+Lines: ~118-126 (_load_chapter_content)
+Description: If a chapter savepoint is stored as a JSON object rather than a bare string,
+the function returns json.dumps(data) which would embed raw JSON in the assembled story.md
+instead of prose. The helper _extract_state_chapter_text correctly handles the common dict
+field names (content, text, chapter_text, assembled) but is not called in the savepoint path
+— only in the story-state fallback path. The known real-world savepoints
+(chapter_{N}/assembled from chapter-writer, chapter_{N}_complete from the orchestrator) are
+normally stored as strings, so this is unlikely to trigger, but a future change to savepoint
+format would silently corrupt the output.
+Suggestion: Call _extract_state_chapter_text on dict savepoints before falling back to
+json.dumps:
+  if isinstance(data, dict):
+      extracted = _extract_state_chapter_text({"0": data}, 0)
+      if extracted:
+          return extracted
+      return json.dumps(data, indent=2, default=str)
+Or alternatively: when a savepoint is a dict, look for the text fields (content, text, etc.)
+before serialising.
+```
+
+---
+
+## Phase-by-Phase Notes
+
+### Phase 1 — Structural Review
+
+- **Commits:** Both messages are clear, reference issue #117, follow `feat:`/`test:` conventions. ✓
+- **Branch name:** `feat/issue-117-workflow-improvement-fixes` — follows convention. ✓
+- **Scope:** 20 files, ~700 lines. Reasonable for a multi-fix PR. All changes relate to the issue. ✓
+- **Step numbering (agents):** story-orchestrator.md Phases 1–9, chapter-writer.md steps 1–8, outline-planner.md Phases 1–5, wiki-maintainer.md Modes 1–2 — all checked, no gaps. ✓
+- **Companion file sweep:** `context-budgeting/SKILL.md` was partially updated (scoring formula aligned) but Stage 2 prose not updated — see W-01. ✓ on formula; ✗ on "never dropped" prose.
+- **`tools:` array coupling:** `story-assembler` added to story-orchestrator tools table and Phase 9 instructions simultaneously. ✓
+
+### Phase 2 — Code Review
+
+- **story_state.py:** `pipeline_state` added to both `INITIAL_STATE` and `_ensure_state_defaults()`. Called in both `_read_state()` and `cmd_write()`. Backfill logic is defensive (handles missing key and non-dict value). Clean. ✓
+- **wiki_snapshot.py `_enforce_token_budget`:** Page-dropping block correctly sorts by ascending relevance, skips protected slugs, mutates `pages` and `sorted_slugs` in-place (callers use local lists; mutation is safe). The `sorted_slugs.remove(slug)` is O(n) but lists are small. ✓ Mismatch with SKILL.md — see W-01.
+- **critique_runner.py:** Rename `CRITIC_TYPES`→`OUTLINE_CRITIC_TYPES`, new `CHAPTER_CRITIC_TYPES`, `MODES`, three mode helpers, `criterion_floor` extracted as CLI param (`--criterion-floor`). All command functions updated to accept `mode`. Mode routing in helpers is clean. Savepoint namespace `{mode}_critique_results_iteration_{N}` is correct and tested. See W-02 for content fallback.
+- **outline_generator.py `cmd_generate_elements`:** Now emits `{"savepoint": "story_elements"}` instead of full content (~varies in size). Avoids stdout flooding for large stories. Consistent with the savepoint check in the test. ✓
+- **story_assembler.py:** New tool with clear separation of concerns. `_discover_chapter_numbers`, `_load_chapter_content`, `_extract_state_chapter_text`, `cmd_assemble` are independently testable. CHAPTER_SAVEPOINT_PATTERNS tries the three expected naming conventions in the correct priority order. `output_path.parent.mkdir(parents=True, exist_ok=True)` before write is correct. See S-02 for dict savepoint fallback.
+- **story-assembler.ts:** Minimal wrapper. Uses `execFileSync` with `cwd: projectRoot` and relative path — resolves correctly since the Python tool adds `PROJECT_ROOT` to `sys.path` itself. No PYTHONPATH needed. ✓ No timeout specified on `execFileSync` — minor; assembly is fast.
+
+### Phase 3 — Frontend Review
+
+- TypeScript wrapper (`story-assembler.ts`) follows established patterns from other tools. Parameter schema matches Python CLI. ✓
+
+### Phase 4 — Security Review
+
+- All story name inputs validated via `_validate_story_name()` (path traversal check). ✓
+- No credentials, no raw SQL, no user-controlled HTML. ✓
+- `storyName` from the TS wrapper passed directly to `--story-name`; the Python tool calls `_validate_story_name` before any filesystem access. ✓
+
+### Phase 5 — Testing Review
+
+- **New tests (test_workflow_improvement_fixes.py):** 11 tests covering the four major changes. Token budget drop, pipeline_state defaults, generate-elements stdout, critique mode helpers, and assembler helpers all tested. ✓
+- **Updated tests:** `test_critique_runner_tool.py` savepoint helper updated to write `outline_critique_results_iteration_{N}` — consistent with renamed namespace. `test_outline_generator_tool.py` updated to assert `{"savepoint": "story_elements"}` output. `test_prompt_relocation.py` count updated 132→135 for 3 new chapter-review prompts. ✓
+- **Gap:** No end-to-end CLI test for `cmd_assemble` (story_assembler). The helper-level tests are adequate for correctness of the unit functions, but an integration test exercising `cmd_assemble` with a temporary story directory would catch any final path assembly bugs. This is a minor gap given the simplicity of the tool.
+- **Gap:** No test for `cmd_should_refine` or `cmd_run_critics` with `--mode chapter`, which would catch the W-02 fallback issue.
+
+### Phase 6 — Performance Review
+
+- `sorted_slugs.remove(slug)` in `_enforce_token_budget` is O(n) but lists are bounded by the retrieval tier caps (T1+T2+T3+T4, typically ≤50 pages). Not a concern. ✓
+- Page-dropping adds one sorted() pass per budget overflow event — negligible. ✓
+
+### Phase 7 — Documentation Review
+
+- **Scoring formula in context-budgeting SKILL.md:** Updated to match the 6-weight implementation. ✓
+- **"Pages are never dropped entirely" prose:** Not updated — see W-01.
+- **outline-planner.md:** `previousChunks` removal documented with a clear warning note. The dead template section is a residue — see S-01.
+- **story-orchestrator.md Phase 9:** Correctly documents `story-assembler` invocation and `story_complete` savepoint. ✓
+- **chapter-writer.md:** "next chapter synopsis populated" language added to scene context step (step 2 of the loop). ✓
+- **wiki-maintainer.md:** Post-scene → post-chapter throughput corrected. ✓
+
+---
+
+## Overall Assessment
+
+The PR is ready to merge. The implementation is sound, tests pass cleanly (330/330 excluding a pre-existing `aiohttp` import error unrelated to this branch), and the changes are appropriately scoped. W-01 is the most visible item — the `context-budgeting/SKILL.md` skill actively tells agents that pages are never dropped, which is now incorrect. This should be patched in a follow-up before the page-dropping behavior causes agent confusion in mid-chapter context assembly. W-02 is low-risk in practice (orchestrator always passes content) but warrants a follow-up to harden the error path. The two suggestions (S-01, S-02) are optional quality improvements.

--- a/.github/notes/reviews/2026-04-21-pr118-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-21-pr118-gemini-raw.md
@@ -1,0 +1,52 @@
+# Code Review Report
+
+## Review Summary
+
+The branch introduces workflow improvements by extracting a configurable criterion floor, adding a new chapter critique mode to `critique-runner`, and implementing a new `story-assembler` tool. However, a critical integration bug in the TypeScript wrapper blocks the primary feature from functioning correctly. Two documentation gaps also need to be resolved.
+
+**Files Reviewed:** 20
+**Findings:** 1 Critical, 2 Warning, 1 Suggestion
+
+## Findings
+
+### Critical Findings
+
+[C-01] Missing `--mode` mapping in TS wrapper breaks Chapter mode
+Category: Correctness
+Severity: Critical
+File: .opencode/tools/critique-runner.ts
+Lines: general
+Description: The PR added `--mode` to `src/tools/critique_runner.py` for 'chapter' critique support, but did not expose or pass this parameter through the TypeScript wrapper (`.opencode/tools/critique-runner.ts`). As a result, the Orchestrator's `mode: chapter` argument passed during Phase 8f is stripped by the wrapper, and `critique_runner.py` falls back to its default (`outline`), completely breaking the new chapter critique workflow.
+Suggestion: Add `mode: z.enum(["outline", "chapter"]).optional().describe("Critique mode")` to the Zod parameters schema and append it to `args` (`if (mode) { args.push("--mode", mode); }`).
+
+### Warning Findings
+
+[W-01] Missing `--criterion-floor` mapping in TS wrapper
+Category: Correctness
+Severity: Warning
+File: .opencode/tools/critique-runner.ts
+Lines: general
+Description: The `criterion_floor` parameter was extracted to an argparse flag in the Python script but not mapped in the TS wrapper, making the configurability inaccessible to agents.
+Suggestion: Add `criterionFloor: z.number().optional().describe(...)` to the schema and append `--criterion-floor` to `args`.
+
+[W-02] Stale documentation for critique-runner
+Category: Documentation
+Severity: Warning
+File: docs/tools.md
+Lines: 1020-1070
+Description: `docs/tools.md` still states that `critique-runner` uses six critic personas (the `OUTLINE_CRITIC_TYPES`), has no mention of the 3 `CHAPTER_CRITIC_TYPES`, omits the newly introduced `mode` and `qualityThreshold` / `criterion-floor` arguments, and incorrectly states it "Runs critics against story outlines" rather than outlines and chapters.
+Suggestion: Update the `docs/tools.md` section for `critique-runner` to document the new `mode`, `criterionFloor` arguments, and the separate critic pools for outline vs chapter mode.
+
+### Suggestions
+
+[S-01] Missing documentation for story-assembler tool
+Category: Documentation
+Severity: Suggestion
+File: docs/tools.md
+Lines: general
+Description: The new `story-assembler` tool was successfully added to the codebase and the Orchestrator's instructions, but it was not documented in `docs/tools.md` alongside the other tools.
+Suggestion: Add a new `## story-assembler` section to `docs/tools.md` detailing its purpose, arguments, and CLI Interface.
+
+## Overall Assessment
+
+While the Python-side changes, new prompts, and agent instruction modifications are robust, the code is currently **not ready for merge** due to the critical disconnect at the TypeScript wrapper layer. The `critique-runner.ts` changes are required to prevent the orchestrator from failing during Phase 8f. Once the missing TS parameters are mapped and the documentation is updated, the branch can be merged.

--- a/.github/notes/reviews/2026-04-21-pr118-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-21-pr118-gpt-raw.md
@@ -1,0 +1,54 @@
+# Code Review Report
+
+## Review Summary
+
+This branch fixes several real workflow gaps, but the chapter-critique path is not fully wired through the OpenCode tool layer yet. Most significant risk: the orchestrator now instructs `critique-runner` to run in `chapter` mode, while the TypeScript wrapper still exposes only the old outline-era interface, so the new phase cannot execute correctly through the agent runtime.
+
+The branch also leaves one active integration regression and several stale companion docs/skills around the renamed critique savepoints and post-chapter workflow. I do not consider this ready for merge until the wrapper/runtime mismatch is fixed.
+
+**Files Reviewed:** 20
+**Findings:** 1 Critical, 2 Warning, 1 Suggestion
+
+## Findings
+
+### Critical Findings
+
+[C-01] Critique Runner Wrapper Still Cannot Invoke Chapter Mode
+Category: Correctness
+Severity: Critical
+File: .opencode/tools/critique-runner.ts
+Lines: 9-86
+Description: The Python CLI now supports `--mode` and `--criterion-floor` and stores mode-namespaced savepoints (`outline_critique_results_iteration_N` / `chapter_critique_results_iteration_N`) in [src/tools/critique_runner.py](src/tools/critique_runner.py#L43) and [src/tools/critique_runner.py](src/tools/critique_runner.py#L353). This PR also changed the orchestrator to call `critique-runner` in chapter mode at [story-orchestrator.md](.opencode/agents/story-orchestrator.md#L193). However, the OpenCode wrapper schema and argument builder still expose only the old interface (`qualityThreshold`, no `mode`, no `criterionFloor`) and never forward the new CLI flags. In practice, agent calls with `mode: chapter` will be rejected at the schema layer or silently executed as outline critiques, which breaks the new Phase 8f workflow.
+Suggestion: Add `mode` and `criterionFloor` to the Zod schema and execution args in the TypeScript wrapper, update any wrapper-level tests, and verify the orchestrator can successfully call chapter critiques end-to-end.
+
+### Warning Findings
+
+[W-01] Chapter Critique Instructions Omit The Content Parameter Required By The New Runner
+Category: Correctness
+Severity: Warning
+File: .opencode/agents/story-orchestrator.md
+Lines: 193-199
+Description: The new Phase 8f text tells the agent to run `critique-runner` on the chapter with `mode: chapter`, but it never instructs the agent to pass the actual chapter text. That matters because `cmd_run_critics()` still falls back only to outline savepoints when `content` is omitted ([src/tools/critique_runner.py](src/tools/critique_runner.py#L168), [src/tools/critique_runner.py](src/tools/critique_runner.py#L172), [src/tools/critique_runner.py](src/tools/critique_runner.py#L175), [src/tools/critique_runner.py](src/tools/critique_runner.py#L179)). Once the wrapper bug above is fixed, the agent still has a good chance of invoking chapter critique incorrectly and getting `no outline content provided and no outline savepoint found`.
+Suggestion: Make the orchestrator contract explicit: pass the assembled chapter text via `content`, or teach `critique_runner.py` to load chapter savepoints automatically when `mode == "chapter"`.
+
+[W-02] End-To-End Integration Fixture Still Expects The Old `generate-elements` Payload
+Category: Testing
+Severity: Warning
+File: tests/integration/test_e2e_opencode.py
+Lines: 197-201
+Description: `outline_generator.py` now returns only `{"savepoint": "story_elements"}` for `generate-elements`, and the unit tests were updated accordingly. The integration fixture still does `results["story_elements"] = data["data"]["story_elements"]`, which will raise `KeyError` as soon as this path runs against a live LLM-backed environment. That means the branch no longer passes the documented full-suite integration path even though the related unit tests were updated.
+Suggestion: Update the fixture to load the `story_elements` savepoint after `generate-elements`, or read it from disk via the existing savepoint helpers before using it in downstream prompts.
+
+### Suggestions
+
+[S-01] Companion Docs And Skills Still Describe The Pre-Rename Critique Contracts
+Category: Documentation
+Severity: Suggestion
+File: .opencode/skills/outline-structure/SKILL.md
+Lines: 111
+Description: The interface changes in this PR were not swept through the companion documentation set. The skill still documents `critique_results_iteration_{N}` at [outline-structure/SKILL.md](.opencode/skills/outline-structure/SKILL.md#L111), while [docs/tools.md](docs/tools.md#L1071) still advertises the old CLI flags and savepoint name, and [story-orchestrator.md](docs/features/story-orchestrator.md#L131) plus [wiki-maintainer.md](docs/features/wiki-maintainer.md#L12) still describe the old post-scene workflow language. Because `outline-planner` explicitly loads the outline-structure skill, this is more than cosmetic drift: it leaves agent-facing instructions inconsistent with the implementation.
+Suggestion: Run a companion-file sweep for the renamed savepoints, new CLI flags, and post-chapter terminology across `.opencode/skills/`, `docs/`, and any agent-facing reference material before merge.
+
+## Overall Assessment
+
+Not ready for merge. The most important change in this branch, chapter-mode critique, is not fully connected through the tool wrapper that agents actually call, and the integration suite still contains a direct regression from the `generate-elements` output change. After those are fixed, I would also clean up the remaining skill/documentation drift so the agent instructions match the new runtime contract everywhere.

--- a/.github/notes/reviews/2026-04-21-pr118-synthesis.md
+++ b/.github/notes/reviews/2026-04-21-pr118-synthesis.md
@@ -1,0 +1,349 @@
+# Synthesized Code Review — PR #118 (feat/issue-117-workflow-improvement-fixes)
+
+**Branch:** `feat/issue-117-workflow-improvement-fixes`
+**Base:** `development`
+**Date:** 2026-04-21
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Raw reports:**
+- `.github/notes/reviews/2026-04-21-pr118-claude-raw.md`
+- `.github/notes/reviews/2026-04-21-pr118-gpt-raw.md`
+- `.github/notes/reviews/2026-04-21-pr118-gemini-raw.md`
+
+---
+
+## Synthesis Overview
+
+This PR delivers five distinct workflow improvements across `critique-runner`, `wiki_snapshot`, `outline_generator`, `story_assembler`, and agent instruction files. Two of the three models identified a **critical integration bug**: the `critique-runner.ts` TypeScript wrapper was not updated to expose `--mode` or `--criterion-floor`, which completely blocks the new chapter critique workflow that is the PR's primary feature. Claude missed this gap and assessed the PR as ready to merge; GPT and Gemini both independently caught it and assessed the PR as not ready. Verification confirms the wrapper omission is real. The models converge on a cluster of secondary documentation and correctness issues as well. The branch is **not ready to merge** until the wrapper is patched.
+
+**Model Agreement Score:** 5/10 — Models agreed on most findings once the TS wrapper issue is identified, but Claude's blindspot on that critical gap caused a significant top-level divergence in the merge verdict.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- |
+| Claude | Ready to merge | context-budgeting SKILL.md doc drift, story_assembler dict fallback, dead previous_chunks template | 0 | 2 |
+| GPT    | Not ready to merge | TS wrapper blocks chapter mode (Critical), integration test regression, companion doc sweep needed | 1 | 2 |
+| Gemini | Not ready to merge | TS wrapper blocks chapter mode (Critical), criterionFloor also missing from wrapper, tools.md stale | 1 | 2 |
+
+**Claude** produced a thorough phase-by-phase analysis and surfaced three unique findings (context-budgeting SKILL.md prose, `_load_chapter_content` dict fallback, dead `{previous_chunks}` section). However, it missed the critical TypeScript-layer gap that both other models flagged, leading to an incorrect merge verdict.
+
+**GPT** identified the TS wrapper critical gap, tied it directly to the broken orchestrator Phase 8f workflow, and also flagged a concrete integration test regression (`test_e2e_opencode.py` still expects the old `generate-elements` payload). Its documentation finding was the broadest, covering skills, feature docs, and tools.md.
+
+**Gemini** independently confirmed the TS wrapper critical gap and broke the wrapper failure into two discrete items (`--mode` and `--criterion-floor`). Its documentation finding was more focused, specifically targeting `docs/tools.md` for the critique-runner section.
+
+---
+
+## Consensus Findings
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+#### [M-C-01] critique-runner.ts wrapper does not expose `--mode` — chapter critique cannot execute
+
+```
+Severity: Critical
+Category: Correctness
+File: .opencode/tools/critique-runner.ts
+Lines: 9–100 (full parameter schema and execute body)
+Models: Claude ✗  GPT ✓  Gemini ✓
+Detail: The Python CLI (src/tools/critique_runner.py) was extended with --mode (accepting
+"outline" or "chapter"), --criterion-floor, and mode-namespaced savepoints
+(outline_critique_results_iteration_N / chapter_critique_results_iteration_N). The
+story-orchestrator was also updated to invoke critique-runner with mode: chapter during
+Phase 8f. However, the TypeScript wrapper's Zod parameter schema and execute() argument
+builder were not updated: neither `mode` nor `criterionFloor` appear in the schema or in
+the args array. This was verified directly against the file: the schema contains only
+operation, name, iteration, content, criticType, responseText, qualityThreshold, and model.
+When the orchestrator calls critique-runner with mode: chapter, the mode argument is silently
+stripped; Python falls back to its default ("outline"), running the wrong critic pool against
+chapter content. The new phase cannot produce correct output at all through the agent runtime.
+Dissenting view (Claude): Did not surface this finding. Claude's review was thorough at the
+Python and agent-instruction level but did not audit whether the TypeScript wrapper matched
+the new Python CLI contract, resulting in an incorrect "ready to merge" verdict.
+Suggestion: Add `mode: z.enum(["outline", "chapter"]).optional()` and
+`criterionFloor: z.number().optional()` to the Zod schema. In execute(), extend the
+TypeScript destructuring and args block:
+  if (mode) { args.push("--mode", mode); }
+  if (criterionFloor !== undefined) { args.push("--criterion-floor", String(criterionFloor)); }
+Also update the TypeScript type annotation block to include mode?: string and
+criterionFloor?: number.
+```
+
+#### [M-W-01] cmd_run_critics fallback is mode-blind — chapter mode falls back to outline savepoints
+
+```
+Severity: Warning
+Category: Correctness
+File: src/tools/critique_runner.py
+Lines: ~163–179 (else branch of cmd_run_critics)
+Models: Claude ✓ (W-02)  GPT ✓ (W-01)  Gemini ✗
+Detail: When cmd_run_critics is called with mode="chapter" but no --content argument, the
+fallback attempts to load "outline_iteration_{N-1}" then "outline" savepoints — neither of
+which exist for a chapter critique run. The error message "no outline content provided and no
+outline savepoint found" is actively misleading in chapter mode. GPT additionally notes that
+the story-orchestrator's Phase 8f instructions never explicitly direct the agent to pass the
+chapter text via the content parameter, so in practice the risk is real even after the
+wrapper is fixed (M-C-01). Claude notes the variable throughout the function is also named
+`outline` regardless of mode context. The orchestrator currently always passes --content in
+practice, so this does not fail at runtime — but it is a latent hazard for direct tool
+invocations and a poor failure mode if the orchestrator contract drifts.
+Dissenting view (Gemini): Did not flag this fallback issue independently.
+Suggestion: Two complementary fixes:
+  1. Make the orchestrator Phase 8f instructions explicit about passing assembled chapter
+     text via the content parameter (or cite the chapter savepoint to load from).
+  2. In cmd_run_critics, add a mode-aware fallback: for mode=="chapter", attempt to load
+     from "chapter_{N-1}_complete" or equivalent chapter savepoints before giving up.
+     Rename the local variable from `outline` to `content` and update the error message:
+     _error(f"no content provided for {mode} critique and no {mode} savepoint found")
+```
+
+#### [M-W-02] critique-runner.ts also does not expose --criterion-floor
+
+```
+Severity: Warning
+Category: Correctness
+File: .opencode/tools/critique-runner.ts
+Lines: 9–100 (same parameter schema)
+Models: Claude ✗  GPT ✓ (bundled with C-01)  Gemini ✓ (W-01)
+Detail: Separate from the --mode omission, the new --criterion-floor Python CLI flag
+(extracted from a hardcoded constant to a configurable parameter) is also absent from the
+wrapper schema and args. Agents have no way to override the criterion floor at runtime
+through the tool interface, defeating the purpose of the extraction.
+Dissenting view (Claude): Not mentioned.
+Suggestion: Covered by the same fix as M-C-01 — add criterionFloor to the Zod schema
+and the args block simultaneously.
+```
+
+#### [M-W-03] docs/tools.md critique-runner section is stale
+
+```
+Severity: Warning
+Category: Documentation
+File: docs/tools.md
+Lines: 1022–1075 (## critique-runner section)
+Models: Claude ✗  GPT ✓ (S-01, broader scope)  Gemini ✓ (W-02)
+Detail: The critique-runner section of docs/tools.md still states "Runs critics against
+story outlines" (outline-only framing), lists only the six outline critic personas
+(OUTLINE_CRITIC_TYPES), and documents no mode or criterion-floor arguments. The new
+CHAPTER_CRITIC_TYPES (three personas), the --mode flag, and the --criterion-floor flag
+are entirely absent. Verified directly: the section header reads "Runs critics against story
+outlines" and the arguments table omits both new parameters.
+GPT additionally flags outline-structure/SKILL.md still referencing the pre-rename savepoint
+key critique_results_iteration_{N} (which is now mode-prefixed), and docs/features/ files
+for story-orchestrator and wiki-maintainer using old workflow language. Gemini's finding is
+more narrowly scoped to tools.md.
+Dissenting view (Claude): Did not raise this specific doc. Claude raised a different
+documentation issue (context-budgeting SKILL.md — see S-W-01 below).
+Suggestion: Update docs/tools.md to document: (a) dual-mode operation (outline + chapter),
+(b) CHAPTER_CRITIC_TYPES, (c) mode and criterionFloor arguments and CLI flags. Also update
+outline-structure/SKILL.md to rename critique_results_iteration_{N} to
+{mode}_critique_results_iteration_{N}.
+```
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+#### [S-W-01] context-budgeting/SKILL.md still claims "Pages are never dropped entirely"
+
+```
+Severity: Warning
+Category: Documentation
+File: .opencode/skills/context-budgeting/SKILL.md
+Lines: ~93 (Stage 2 section)
+Model: Claude (W-01)
+Detail: The skill's Stage 2 section contains: "Pages are never dropped entirely — minimum
+L1 ensures the generation LLM is at least aware of every relevant entity's existence." This
+is now false: _enforce_token_budget() in wiki_snapshot.py has a second phase that drops
+non-protected pages sorted by ascending relevance_score when the total still exceeds budget
+after all demotions are exhausted. The new TestWikiSnapshotTokenBudget test confirms the
+drop can occur. Agents that load this skill will operate under incorrect assumptions about
+context assembly. Verified: the "never dropped" line exists in the file.
+Assessment: Genuine finding. The SKILL.md is agent-facing and will actively misinform
+orchestration decisions. Medium-priority fix before the page-dropping behaviour causes
+confusion during context assembly on large stories.
+```
+
+#### [S-W-02] Integration test fixture still expects old generate-elements payload shape
+
+```
+Severity: Warning
+Category: Testing
+File: tests/integration/test_e2e_opencode.py
+Lines: 197–201 (generate-elements block)
+Model: GPT (W-02)
+Detail: outline_generator.py now returns {"savepoint": "story_elements"} rather than the
+story elements content inline. The unit tests were correctly updated. However, the
+integration fixture at line 201 still does results["story_elements"] = data["data"]["story_elements"],
+which will raise KeyError when run against a live environment because "story_elements" is
+no longer a key in the data dict. The integration test suite would silently break at this
+point and corrupt all downstream steps that reference results["story_elements"]. Verified:
+the fixture line exists as described.
+Assessment: Genuine finding. The integration test is not run as part of the standard pytest
+suite (it requires a live LLM environment), which is why this slipped through. The regression
+should be fixed before the branch is merged to keep the integration harness in sync.
+```
+
+#### [S-I-01] prompts/outline/create_chunk.md retains dead {previous_chunks} section
+
+```
+Severity: Suggestion
+Category: Style
+File: prompts/outline/create_chunk.md
+Lines: ~22–24 (<PREVIOUS_CHUNKS> block)
+Model: Claude (S-01)
+Detail: outline-planner.md now explicitly instructs agents not to pass previousChunks (to
+avoid quadratic token growth). The TypeScript wrapper only pushes --previous-chunks when
+truthy. The prompt template still contains <PREVIOUS_CHUNKS>{previous_chunks}</PREVIOUS_CHUNKS>,
+which renders as an empty tag in every call. Minor token waste and potential confusion for
+future maintainers.
+Assessment: Likely genuine, low priority. Straightforward cleanup.
+```
+
+#### [S-I-02] _load_chapter_content may json.dumps a dict savepoint into the assembled story
+
+```
+Severity: Suggestion
+Category: Correctness
+File: src/tools/story_assembler.py
+Lines: ~118–126 (_load_chapter_content)
+Model: Claude (S-02)
+Detail: If a chapter savepoint is stored as a dict (rather than a bare string), the
+savepoint path returns json.dumps(data) which would embed raw JSON in the assembled story.md
+instead of prose. The _extract_state_chapter_text helper (which knows the common field names:
+content, text, chapter_text, assembled) is used in the story-state fallback path but not in
+the savepoint path. Known real-world savepoints are strings, so this is unlikely to trigger
+now, but a format change would silently corrupt output.
+Assessment: Plausible edge case. Low urgency given current savepoint formats. Consider as a
+defensive improvement.
+```
+
+#### [S-I-03] story-assembler tool missing from docs/tools.md
+
+```
+Severity: Suggestion
+Category: Documentation
+File: docs/tools.md
+Lines: general (tool listing section)
+Model: Gemini (S-01)
+Detail: The new story-assembler tool was wired into the codebase, the orchestrator, and the
+TypeScript tool table, but not documented in docs/tools.md alongside the other tools.
+Assessment: Genuine documentation gap. Low urgency but should be addressed as part of the
+docs/tools.md update already required by M-W-03.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Overall merge readiness verdict
+
+Claude says: "The PR is ready to merge." Two warnings and two suggestions, no criticals.
+GPT says: "Not ready for merge." One critical blocks chapter mode; integration regression present.
+Gemini says: "Not ready for merge." One critical blocks chapter mode; docs need updating.
+
+Assessment: The 2-vs-1 split is decisive. Claude's conclusion was based on a thorough
+review of the Python layer and agent instructions, but it did not verify that the TypeScript
+wrapper was updated to match the new Python CLI contract. GPT and Gemini both independently
+verified this gap and confirmed it at the source. Direct inspection of critique-runner.ts
+confirms neither `mode` nor `criterionFloor` appear in the schema or args. The branch
+cannot execute chapter critiques through the agent runtime in its current state.
+
+Resolution: Branch is NOT ready to merge. Claude's positive findings regarding Python
+implementation quality remain valid; the implementation itself is sound. The integration
+gap is purely at the TypeScript wrapper boundary.
+```
+
+```
+[D-02] Topic: Severity of documentation drift in docs/tools.md
+
+Claude says: Did not flag docs/tools.md at all. Raised context-budgeting SKILL.md instead.
+GPT says: Suggestion-level (S-01) — worth fixing but not a blocker.
+Gemini says: Warning-level (W-02) — should be fixed before merge.
+
+Assessment: Gemini's Warning classification is more appropriate. The docs/tools.md
+critique-runner section is agent-facing reference material; leaving it describe only six
+critics and no mode parameter creates a direct inconsistency with the orchestrator
+instructions that now invoke chapter mode. Because outline-structure/SKILL.md also
+retains the pre-rename savepoint key (verified), the documentation drift is broader than
+a single file and creates real risk of agent misconfiguration.
+
+Resolution: Treat as Warning. Address before merge, but does not independently block it
+(the wrapper fix in M-C-01 is the true blocker).
+```
+
+```
+[D-03] Topic: Scope of companion file drift
+
+Claude says: Focused narrowly on context-budgeting/SKILL.md (page-dropping claim) and
+outline prompt files.
+GPT says: Broad sweep needed — outline-structure/SKILL.md, docs/tools.md, docs/features/
+story-orchestrator.md, docs/features/wiki-maintainer.md all contain pre-rename
+critique references.
+Gemini says: Focused on docs/tools.md for critique-runner.
+
+Assessment: GPT's broader concern appears well-founded based on its specific citations.
+The outline-structure/SKILL.md savepoint name drift (critique_results_iteration_{N} →
+{mode}_critique_results_iteration_{N}) was verified and is genuine. The features/
+docs drift (story-orchestrator.md and wiki-maintainer.md post-scene language) was not
+independently verified in this synthesis, but the pattern is consistent with what was
+found elsewhere.
+
+Resolution: Treat as M-W-03 supplemental scope. The docs sweep should be broader than
+just tools.md, covering outline-structure/SKILL.md and docs/features/ as GPT suggests.
+Claude's context-budgeting SKILL.md finding is an additional unique item (S-W-01).
+```
+
+---
+
+## Recommended Actions (Prioritised)
+
+```
+1. [M-C-01] ★★☆ FIX BEFORE MERGE: Add `mode` and `criterionFloor` to critique-runner.ts
+   Zod schema and args builder — identical fix covers both M-C-01 and M-W-02.
+   (Critical — 2/3 models agree, verified in file)
+
+2. [M-W-01] ★★☆ FIX BEFORE MERGE: Make orchestrator Phase 8f explicitly pass chapter
+   content; add mode-aware fallback + better error message in cmd_run_critics.
+   (Warning — 2/3 models agree)
+
+3. [S-W-02] ★☆☆ FIX BEFORE MERGE: Update test_e2e_opencode.py integration fixture to
+   load story_elements from savepoint after generate-elements returns the savepoint
+   pointer, not inline content. Prevents KeyError on next live integration run.
+   (Warning — 1 model, verified in file)
+
+4. [M-W-03] ★★☆ FIX BEFORE MERGE: Update docs/tools.md critique-runner section for
+   dual-mode operation, chapter critic types, and new CLI flags. Extend sweep to
+   outline-structure/SKILL.md (rename savepoint key) and docs/features/ as GPT flags.
+   (Warning — 2/3 models, verified in file)
+
+5. [S-W-01] ★☆☆ Fix soon (follow-up): Update context-budgeting/SKILL.md Stage 2 prose
+   to remove "Pages are never dropped entirely" and describe two-phase budget enforcement.
+   (Warning — 1 model, verified in file — agent-facing, mid-priority)
+
+6. [S-I-03] ★☆☆ Nice to have: Add story-assembler section to docs/tools.md — can be
+   batched with item 4 above.
+   (Suggestion — 1 model)
+
+7. [S-I-01] ★☆☆ Nice to have: Remove dead {previous_chunks} section from
+   prompts/outline/create_chunk.md.
+   (Suggestion — 1 model)
+
+8. [S-I-02] ★☆☆ Nice to have: In _load_chapter_content, call _extract_state_chapter_text
+   on dict savepoints before falling back to json.dumps.
+   (Suggestion — 1 model)
+```
+
+---
+
+## Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★☆ Majority      | 1        | 3       | 0          |
+| ★☆☆ Singular      | 0        | 2       | 3          |
+| **Total**         | **1**    | **5**   | **3**      |
+
+**Overall Assessment:** Not Ready to Merge — one critical (TS wrapper gap blocks chapter critique) and one integration test regression must be resolved first. Four warning-level items should also be addressed before merge. Python implementation quality is sound.

--- a/.opencode/agents/chapter-writer.md
+++ b/.opencode/agents/chapter-writer.md
@@ -24,7 +24,7 @@ You receive a chapter number and story name from the orchestrator. You generate 
 
 Execute these steps sequentially for the assigned chapter:
 
-1. **Load chapter outline.** Read the chapter's expanded outline from `story-state`, including the scene breakdown produced in Phase 8a.
+1. **Load chapter outline.** Read the chapter's expanded outline from `story-state` key `chapters.{N}.expanded_outline`, including the scene breakdown produced in Phase 8a.
 2. **Parse scene definitions.** Call `scene-writer` (operation: `parse-definitions`) to extract structured scene definitions from the chapter outline. Each scene definition includes: title, description, characters, setting, conflict, tone, key_events, dialogue, ending, lead_in_to_next_scene, and literary_devices.
 3. **Create scene definitions savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_definitions`.
 4. **Load previous chapter recap.** If this is not the first chapter, call `recap-manager` (operation: `load`) for chapter N-1. This provides continuity context — where the story left off, active tensions, character emotional states.
@@ -81,18 +81,14 @@ For each scene M in the chapter (M = 1, 2, ..., scene_count):
    - The chapter outline (for overall chapter direction)
    - Previous chapter recap (if available, for chapter 2+)
    - Previous scene content (if M > 1, for direct continuity)
+   - For the last scene in the chapter, fetch the next chapter's outline from `story-state` key `chapters.{N+1}.outline` and pass it as `nextChapterSynopsis`
 
 3. **Generate the scene.** Call `scene-writer` (operation: `generate`) with the assembled context. Pass the wiki snapshot string as the `baseContext` parameter.
+   Note: scene summaries and titles are held in working context only, not persisted as savepoints.
 
-4. **Save scene savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_{M}`.
+4. **Extract scene events.** Optionally extract key events, character state changes, and new information from the generated scene. These feed into context for subsequent scenes and post-chapter wiki updates.
 
-5. **Extract scene events.** Optionally extract key events, character state changes, and new information from the generated scene. These feed into context for subsequent scenes and post-chapter wiki updates.
-
-6. **Save scene summary savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_{M}_summary`.
-
-7. **Save scene title savepoint.** Call `savepoint-mgr` to save: `chapter_{N}/scene_{M}_title`.
-
-8. **Proceed to the next scene.** Pass the generated scene content as `previous_scene` context to the next iteration.
+5. **Proceed to the next scene.** Pass the generated scene content as `previous_scene` context to the next iteration.
 
 ---
 
@@ -105,9 +101,7 @@ Savepoints are created at each significant milestone within a chapter, enabling 
 | Savepoint | Created After |
 |-----------|--------------|
 | `chapter_{N}/scene_definitions` | Scene definitions parsed from outline (step 3) |
-| `chapter_{N}/scene_{M}` | Scene M generated successfully (loop step 4) |
-| `chapter_{N}/scene_{M}_summary` | Scene M events/summary extracted (loop step 6) |
-| `chapter_{N}/scene_{M}_title` | Scene M title confirmed (loop step 7) |
+| `chapter_{N}/scene_{M}` | Scene M generated successfully (written internally by `scene-writer`) |
 | `chapter_{N}/assembled` | All scenes assembled into chapter (step 7) |
 
 **Resuming from a savepoint:**

--- a/.opencode/agents/outline-planner.md
+++ b/.opencode/agents/outline-planner.md
@@ -60,11 +60,12 @@ Execute these phases sequentially. Each phase must complete before the next begi
      - `chunkStart`: previous chunk end + 1
      - `chunkEnd`: min(chunk start + `outline_chunk_size` - 1, `wanted_chapters`)
      - `totalChapters`: `wanted_chapters`
-     - `previousChunks`: accumulated outline text from all prior chunks
      - `continuitySummary`: continuity analysis text from the previous chunk
 
+    Pass only `continuitySummary` (a condensed summary of prior chunks) — do NOT pass `previousChunks` as it causes quadratic token growth.
+
    **After each `expand-chapter` call**, parse the JSON response — the tool returns `{"status": "success", "operation": "expand-chapter", "data": {"chunk_outline": "...", "continuity_analysis": "..."}}`:
-   - Extract `data.chunk_outline` — append to `previousChunks` for the next iteration
+    - Extract `data.chunk_outline` — rely on the tool's chunk savepoint for persistence
    - Extract `data.continuity_analysis` — use as the `continuitySummary` value for the next chunk's call
 
    Continue until all `wanted_chapters` chapters are covered.
@@ -128,15 +129,18 @@ Savepoints are created automatically by the tools at each pipeline stage. The ag
 | Savepoint | Created During | Phase |
 |-----------|---------------|-------|
 | `understand_prompt` | Prompt analysis | 1 |
-| `analysis_chunk_{category}` (×8) | Prompt analysis | 1 |
+| `story_analysis/{chunk_type}_chunk` (×8) | Prompt analysis | 1 |
 | `story_start_date` | Prompt analysis | 1 |
 | `base_context` | Prompt analysis | 1 |
 | `story_elements` | Elements synthesis | 2 |
-| `outline_complete` | Non-chunked generation | 3 |
+| `initial_outline` | Non-chunked generation by `outline-generator` | 3 |
+| `outline_complete` | Orchestrator-level Phase 2 checkpoint | 3 |
 | `outline_chunk_{start}_{end}` | Chunked generation (e.g., `outline_chunk_1_10`, `outline_chunk_11_20`) | 3 |
 | `continuity_{start}_{end}` | Chunked generation (e.g., `continuity_1_10`, `continuity_11_20`) | 3 |
-| `critique_results_iteration_{N}` | Critique loop | 4 |
+| `outline_critique_results_iteration_{N}` | Critique loop | 4 |
 | `outline_refined_{N}` | Refinement | 4 |
+
+`initial_outline` is the savepoint written by the `outline-generator` tool at initial generation. `outline_complete` is the orchestrator's separate higher-level checkpoint.
 
 ---
 

--- a/.opencode/agents/story-orchestrator.md
+++ b/.opencode/agents/story-orchestrator.md
@@ -57,7 +57,14 @@ Execute these phases sequentially. Each phase completes fully before the next be
 2. The `outline-planner` handles the full pipeline internally — prompt analysis, element synthesis, outline generation (chunked or monolithic), and the critique/refinement loop. Do **not** run critique or revision steps at the orchestrator level.
 3. Receive the finalised outline from `outline-planner`. If the orchestrator's own revision cap (`outline_max_revisions`) has not been reached and the user requests further revisions (Phase 3 feedback), re-invoke `outline-planner` with feedback.
 4. Store the finalised outline via `story-state` (operation: `write`, field: `outline`, value: outline JSON string)
-5. Create savepoint: `outline_complete`
+5. Savepoint naming note: `initial_outline` is written by `outline-generator` during initial generation. `outline_complete` is the orchestrator-level Phase 2 checkpoint.
+6. If chunked outline generation is enabled, expect chunk savepoints in this pattern:
+
+| Chunk Range | Savepoint |
+|-------------|-----------|
+| Each completed chunk | `outline_chunk_{start}_{end}` |
+
+7. Create savepoint: `outline_complete`
 
 ### Phase 3: Approval
 
@@ -78,24 +85,32 @@ Execute these phases sequentially. Each phase completes fully before the next be
 **Purpose:** Generate character sheets for all characters identified in the outline.
 
 1. Extract the character list from the outline
-2. For each character, call `character-mgr` with:
+2. For each character, call `prompt-loader` with:
+   - `promptId`: `characters/create`
+   - `variables`: include `story_elements`, `character_name`, and any additional story context needed for the sheet
+3. Use the rendered prompt to generate the character sheet content as structured text/JSON via the model.
+4. Pass the generated content to `character-mgr` with:
    - `operation`: `"generate-sheet"`
    - `character`: the character's display name
-   - `data`: `"{}"` (JSON string — empty object; the TS wrapper accepts a JSON string, not a raw object)
-3. Store character sheet references in story state
-4. Create savepoint: `characters_complete`
+   - `data`: JSON string containing the generated character sheet content
+5. Store character sheet references in story state
+6. Create savepoint: `characters_complete`
 
 ### Phase 6: Settings
 
 **Purpose:** Generate setting sheets for all locations identified in the outline.
 
 1. Extract the settings/locations list from the outline
-2. For each setting, call `setting-mgr` with:
+2. For each setting, call `prompt-loader` with:
+   - `promptId`: `settings/create`
+   - `variables`: include `story_elements`, `setting_name`, and any additional story context needed for the sheet
+3. Use the rendered prompt to generate the setting sheet content as structured text/JSON via the model.
+4. Pass the generated content to `setting-mgr` with:
    - `operation`: `"generate-sheet"`
    - `setting`: the setting's display name (**note:** parameter is `setting`, not `character`)
-   - `data`: `"{}"` (JSON string — empty object; the TS wrapper accepts a JSON string, not a raw object)
-3. Store setting sheet references in story state
-4. Create savepoint: `settings_complete`
+   - `data`: JSON string containing the generated setting sheet content
+5. Store setting sheet references in story state
+6. Create savepoint: `settings_complete`
 
 ### Phase 7: Wiki Population
 
@@ -130,6 +145,7 @@ If `expand_outline` is true:
    - Extract `data.chunk_outline` as the expanded outline for this chapter.
    - Extract `data.continuity_analysis` and retain it for the next chapter's Phase 8a call as the `continuitySummary` parameter.
 4. Store the expanded outline via `story-state`
+5. Store it under key `chapters.{N}.expanded_outline` where N is the current chapter number.
 
 #### 8b. Scene Generation
 
@@ -148,6 +164,7 @@ If `scene_generation_pipeline` is false:
    - Timeline events from the chapter
    - Plot thread progression
 2. The wiki-maintainer updates existing pages and creates new ones as needed
+3. Run this once after the full chapter is complete, not after individual scenes.
 
 #### 8d. Recap Generation
 
@@ -173,12 +190,18 @@ If `scene_generation_pipeline` is false:
 #### 8f. Quality Evaluation
 
 If `enable_chapter_revisions` is true:
-1. Run `critique-runner` on the chapter
-2. If score < `chapter_quality`:
+1. Run `critique-runner` on the chapter with `mode: chapter`
+2. Before checking the quality gate score, ensure the chapter has been revised at least `chapter_min_revisions` times (default: 1). Do not accept the chapter until `chapter_min_revisions` is satisfied even if the first score passes.
+3. If score < `chapter_quality`:
    - Enter revision loop (max `chapter_max_revisions` iterations)
    - On each revision: regenerate/revise the chapter, re-run critique
    - If score >= `chapter_quality` or max revisions reached, proceed
-3. If score >= `chapter_quality`, accept the chapter
+4. If score >= `chapter_quality`, accept the chapter only after `chapter_min_revisions` is satisfied.
+5. After the chapter passes the quality gate or maximum revisions are reached:
+   - Re-run `wiki-maintainer` (Phase 8c)
+   - Re-run recap generation (Phase 8d)
+   - Re-run wiki lint (Phase 8e)
+6. `enable_final_edit` and `enable_scrubbing` are planned features — not yet implemented.
 
 #### 8g. Chapter Savepoint
 
@@ -188,10 +211,10 @@ If `enable_chapter_revisions` is true:
 
 **Purpose:** Assemble all chapters into the final story output.
 
-1. Collect all completed chapters from story state
-2. Assemble into the final output format
-3. Write the final story to the configured output directory
-4. Create savepoint: `story_complete`
+1. Invoke `story-assembler` with `storyName`: the story name
+2. The assembled story will be written to `stories/<name>/output/story.md` in Markdown format
+3. Create savepoint: `story_complete`
+4. Report the output path to the user
 
 ---
 
@@ -210,6 +233,7 @@ You have access to these tools for deterministic operations:
 | `outline-generator` | Generate and expand story outlines |
 | `scene-writer` | Generate individual scenes |
 | `critique-runner` | Evaluate content quality and produce scores |
+| `story-assembler` | Assemble completed chapter savepoints into final story markdown |
 | `wiki-init` | Initialise wiki directory structure and schema |
 | `wiki-read` | Read wiki pages by slug or type |
 | `wiki-search` | Semantic search across wiki pages |

--- a/.opencode/agents/story-orchestrator.md
+++ b/.opencode/agents/story-orchestrator.md
@@ -190,7 +190,7 @@ If `scene_generation_pipeline` is false:
 #### 8f. Quality Evaluation
 
 If `enable_chapter_revisions` is true:
-1. Run `critique-runner` on the chapter with `mode: chapter`
+1. Run `critique-runner` on the chapter with `mode: chapter` and `content: <assembled chapter text>`. Pass the assembled chapter text explicitly; do not rely on savepoint fallback for chapter critique.
 2. Before checking the quality gate score, ensure the chapter has been revised at least `chapter_min_revisions` times (default: 1). Do not accept the chapter until `chapter_min_revisions` is satisfied even if the first score passes.
 3. If score < `chapter_quality`:
    - Enter revision loop (max `chapter_max_revisions` iterations)

--- a/.opencode/agents/wiki-maintainer.md
+++ b/.opencode/agents/wiki-maintainer.md
@@ -1,6 +1,6 @@
 # Wiki Maintainer
 
-You are the **wiki-maintainer**, a subagent invoked by the `story-orchestrator` during Phase 7 (initial wiki population) and Phase 8c (post-scene incremental updates). Your purpose is to extract entities from story content and maintain the wiki knowledge base — creating pages, updating state, tracking timelines, and ensuring consistency.
+You are the **wiki-maintainer**, a subagent invoked by the `story-orchestrator` during Phase 7 (initial wiki population) and Phase 8c (post-chapter incremental updates). Your purpose is to extract entities from story content and maintain the wiki knowledge base — creating pages, updating state, tracking timelines, and ensuring consistency.
 
 You run on a smaller model for low overhead. Keep your reasoning focused and output structured. Follow the `wiki-maintenance` skill strictly for entity types, confidence levels, and output formats.
 
@@ -75,15 +75,15 @@ Called once after outline and character/setting sheets are generated. Populates 
 
 ---
 
-## Workflow — Mode 2: Post-Scene Incremental Update (Phase 8c)
+## Workflow — Mode 2: Post-Chapter Incremental Update (Phase 8c)
 
-Called after each scene is generated. Updates the wiki with verified information from the generated text.
+Called after each chapter is completed. Updates the wiki with verified information from the completed chapter text.
 
 ### Steps
 
-1. **Read the generated scene text.** The scene content is provided as input by the orchestrator.
+1. **Read the completed chapter text.** The assembled chapter content is provided as input by the orchestrator.
 
-2. **Match existing entities.** Call `wiki-read` (operation: `match-entities`, name: story name, text: scene text) to identify which known entities appear in the scene.
+2. **Match existing entities.** Call `wiki-read` (operation: `match-entities`, name: story name, text: chapter text) to identify which known entities appear in the chapter.
 
 3. **Compare against wiki state.** For matched entities, call `wiki-read` (operation: `read`, name: story name, slug: entity slug, detailLevel: `full`) to load current wiki state for comparison.
 
@@ -100,13 +100,13 @@ Called after each scene is generated. Updates the wiki with verified information
    - L2: three-sentence identity + state + role (~150 tokens)
    - L3: complete description (~500 tokens)
 
-6. **Build batch payload.** Assemble all creates, updates, and timeline entries into a single batch payload. All operations use `verified` confidence (they come from generated text).
+6. **Build batch payload.** Assemble all creates, updates, and timeline entries into a single batch payload. All operations use `verified` confidence (they come from generated chapter text).
 
    > **Batch payload naming:** Direct tool call parameters use `camelCase` (e.g., `pageType`, `pageName`, `firstAppearance`, `detailLevels`). Batch payload JSON keys use `snake_case` (e.g., `page_type`, `page_name`, `first_appearance`, `detail_levels`). **Always use `snake_case` inside the `payload` JSON string passed to `wiki-update (operation: batch)`.**
 
 7. **Execute batch operation.** Call `wiki-update` (operation: `batch`, name: story name, payload: JSON string of the batch payload).
 
-8. **Chapter boundary check.** If this is the last scene of the chapter:
+8. **Chapter boundary check.**
    - Call `wiki-lint` (operation: `check-chapter`, name: story name, chapter_number: current chapter number, chapter_text: path to assembled chapter file)
    - Review results for missing cross-references, orphaned entities, stale `planned` confidence, and contradictions
    - Fix critical issues via targeted `wiki-update` calls
@@ -125,9 +125,9 @@ The wiki-maintainer does not manage savepoints directly. Wiki state persists in 
 
 ## Error Handling
 
-1. **Empty extraction results.** If entity extraction produces no results for a non-empty scene, retry extraction once with simplified focus: look only for named characters, named locations, and explicit events. If still empty, log a warning and proceed — the scene may genuinely contain no new wiki-relevant information.
+1. **Empty extraction results.** If entity extraction produces no results for a non-empty chapter, retry extraction once with simplified focus: look only for named characters, named locations, and explicit events. If still empty, log a warning and proceed — the chapter may genuinely contain no new wiki-relevant information.
 
-2. **Validation errors from wiki-update.** If `wiki-update` returns validation errors for specific operations in a batch, log the error, skip the invalid operation, and continue with remaining operations. Do not block scene generation over a wiki update failure.
+2. **Validation errors from wiki-update.** If `wiki-update` returns validation errors for specific operations in a batch, log the error, skip the invalid operation, and continue with remaining operations. Do not block chapter progression over a wiki update failure.
 
 3. **Wiki-lint critical issues.** If `wiki-lint` reports critical issues (contradictions, confidence conflicts), report them to the orchestrator but do not halt the pipeline. The orchestrator decides whether to pause for resolution.
 
@@ -140,8 +140,8 @@ The wiki-maintainer does not manage savepoints directly. Wiki state persists in 
 - **Run reliably on 7b model** — keep instructions concise, structured, and explicit. Avoid complex multi-step reasoning chains.
 - **Always prefer `verified` confidence** for information directly from generated text.
 - **Never overwrite higher-confidence with lower-confidence** — `verified` > `planned` > `speculative`.
-- **Always include source provenance** — chapter and scene number for every extracted fact.
-- **Use `batch` operation for efficiency** — group all creates/updates/timeline entries for a single scene into one call.
+- **Always include source provenance** — chapter number for every extracted fact, and scene number only when it is explicitly known from the chapter text.
+- **Use `batch` operation for efficiency** — group all creates/updates/timeline entries for a single chapter into one call.
 - **Wikilinks must use existing slugs** — check with `wiki-search` before creating `[[slug]]` references. Broken wikilinks degrade the context retrieval pipeline.
 - **Alias arrays are additive** — never remove existing aliases, only add new ones.
 - **Deduplicate before creating** — always run `wiki-read` match-entities or `wiki-search` semantic before creating new pages.

--- a/.opencode/skills/context-budgeting/SKILL.md
+++ b/.opencode/skills/context-budgeting/SKILL.md
@@ -90,7 +90,7 @@ Pages are sorted by relevance score and assigned detail levels top-down within t
 - **Medium-priority:** world rules, graph-traversed entities → L2 default
 - **Low-priority:** themes, distant relationships → L1
 
-When total exceeds budget, lower-priority pages demote L3→L2→L1 starting from the bottom of the ranked list. Pages are never dropped entirely — minimum L1 ensures the generation LLM is at least aware of every relevant entity's existence.
+When total exceeds budget, lower-priority pages demote L3→L2→L1 starting from the bottom of the ranked list. If the token budget still cannot be satisfied after L1 demotion, non-protected pages are dropped entirely in ascending relevance order until the budget fits.
 
 ### Stage 3: Structured Context Assembly
 

--- a/.opencode/skills/context-budgeting/SKILL.md
+++ b/.opencode/skills/context-budgeting/SKILL.md
@@ -61,9 +61,10 @@ T4 exploits the wiki's existing `[[wikilinks]]` as a lightweight knowledge graph
 Each retrieved page receives a relevance score:
 
 ```
-score(p) = 0.40 × entity_match(p)
-         + 0.20 × wikilink_proximity(p)
-         + 0.20 × semantic_similarity(p)
+score(p) = 0.35 × entity_match(p)
+         + 0.20 × rrf(p)
+         + 0.15 × wikilink_proximity(p)
+         + 0.10 × semantic_similarity(p)
          + 0.10 × recency(p)
          + 0.10 × type_priority(p)
 ```

--- a/.opencode/tools/critique-runner.ts
+++ b/.opencode/tools/critique-runner.ts
@@ -24,6 +24,10 @@ export default {
       .string()
       .optional()
       .describe("Content to critique (if not loading from savepoint)"),
+    mode: z
+      .enum(["outline", "chapter"])
+      .optional()
+      .describe("Critique mode: outline or chapter (default: outline)"),
     criticType: z
       .string()
       .optional()
@@ -36,6 +40,12 @@ export default {
       .number()
       .optional()
       .describe("Quality threshold for should-refine (default: 85.0)"),
+    criterionFloor: z
+      .number()
+      .optional()
+      .describe(
+        "Minimum per-criterion score percentage for should-refine (default: 75.0)"
+      ),
     model: z.string().optional().describe("Override LLM model identifier"),
   }),
   execute: async ({
@@ -43,18 +53,22 @@ export default {
     name,
     iteration,
     content,
+    mode,
     criticType,
     responseText,
     qualityThreshold,
+    criterionFloor,
     model,
   }: {
     operation: string;
     name?: string;
     iteration?: number;
     content?: string;
+    mode?: string;
     criticType?: string;
     responseText?: string;
     qualityThreshold?: number;
+    criterionFloor?: number;
     model?: string;
   }) => {
     const projectRoot = resolve(__dirname, "../..");
@@ -73,6 +87,9 @@ export default {
     if (content) {
       args.push("--content", content);
     }
+    if (mode) {
+      args.push("--mode", mode);
+    }
     if (criticType) {
       args.push("--critic-type", criticType);
     }
@@ -81,6 +98,9 @@ export default {
     }
     if (qualityThreshold !== undefined) {
       args.push("--quality-threshold", String(qualityThreshold));
+    }
+    if (criterionFloor !== undefined) {
+      args.push("--criterion-floor", String(criterionFloor));
     }
     if (model) {
       args.push("--model", model);

--- a/.opencode/tools/story-assembler.ts
+++ b/.opencode/tools/story-assembler.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+
+export default {
+  name: "story-assembler",
+  description:
+    "Assemble completed chapter savepoints into a single story markdown file.",
+  parameters: z.object({
+    storyName: z.string().describe("Story name (directory under stories/)")
+  }),
+  execute: async ({
+    storyName,
+  }: {
+    storyName: string;
+  }) => {
+    const projectRoot = resolve(__dirname, "../..");
+    const args = [
+      "src/tools/story_assembler.py",
+      "assemble",
+      "--story-name",
+      storyName,
+    ];
+
+    try {
+      const stdout = execFileSync("python3", args, {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return stdout.trim();
+    } catch (error: unknown) {
+      const execError = error as { stderr?: string; message?: string };
+      const message =
+        execError.stderr?.trim() || execError.message || "Unknown error";
+      return `Error: ${message}`;
+    }
+  },
+};

--- a/docs/features/story-orchestrator.md
+++ b/docs/features/story-orchestrator.md
@@ -128,10 +128,10 @@ See the [agent definition](../../.opencode/agents/outline-planner.md) for the fu
 
 ### wiki-maintainer
 
-The `wiki-maintainer` subagent handles Phase 7 (initial wiki population) and Phase 8c (post-scene incremental updates). It operates in two modes:
+The `wiki-maintainer` subagent handles Phase 7 (initial wiki population) and Phase 8c (post-chapter incremental updates). It operates in two modes:
 
 - **Mode 1: Initial Population** (Phase 7) — Extracts all known entities from the outline, character sheets, and setting sheets. Creates wiki pages at `planned` confidence with L1/L2/L3 detail summaries and establishes cross-reference wikilinks between related entities.
-- **Mode 2: Incremental Update** (Phase 8c) — After each generated scene, extracts new entities, state changes, events, aliases, and plot thread progression from the text. Creates or updates wiki pages at `verified` confidence. At chapter boundaries, runs `wiki-lint` consistency checks.
+- **Mode 2: Incremental Update** (Phase 8c) — After each assembled chapter, extracts new entities, state changes, events, aliases, and plot thread progression from the text. Creates or updates wiki pages at `verified` confidence, then runs `wiki-lint` consistency checks for that chapter.
 
 The agent uses five tools: `wiki-read`, `wiki-update`, `wiki-lint`, `wiki-search`, and `story-state`. All wiki mutations are submitted as batch payloads for atomic execution with rollback on failure.
 

--- a/docs/features/wiki-maintainer.md
+++ b/docs/features/wiki-maintainer.md
@@ -9,7 +9,7 @@ The wiki maintainer is a specialised subagent invoked by the `story-orchestrator
 The agent operates in two distinct modes, mapped to pipeline phases:
 
 - **Mode 1: Initial Wiki Population** (Phase 7) — Extracts all known entities from the outline, character sheets, and setting sheets to populate the wiki before chapter generation begins.
-- **Mode 2: Post-Scene Incremental Update** (Phase 8c) — After each generated scene, extracts new entities, state changes, events, and aliases from the generated text to keep the wiki current.
+- **Mode 2: Post-Chapter Incremental Update** (Phase 8c) — After each assembled chapter, extracts new entities, state changes, events, and aliases from the generated text to keep the wiki current.
 
 The wiki maintainer runs on a smaller 7b model (`deepseek-r1-abliterated:7b`) through the project's OpenAI-compatible inference server configuration, with instructions kept concise and structured for reliable execution at that model size.
 
@@ -48,11 +48,11 @@ Called once after outline and character/setting sheets are generated. All entiti
 6. **Build and execute batch payload** — Assemble all entities into a single JSON batch payload and submit via `wiki-update` (operation: `batch`).
 7. **Establish wikilinks** — Ensure cross-references exist between related entities (characters to locations, relationships to participants, events to involved entities).
 
-## Workflow — Mode 2: Post-Scene Incremental Update (Phase 8c)
+## Workflow — Mode 2: Post-Chapter Incremental Update (Phase 8c)
 
-Called after each scene is generated. Updates the wiki with `verified` information from the generated text.
+Called after each chapter is assembled. Updates the wiki with `verified` information from the generated text.
 
-1. **Match existing entities** — Call `wiki-read` (operation: `match-entities`) to identify which known entities appear in the scene.
+1. **Match existing entities** — Call `wiki-read` (operation: `match-entities`) to identify which known entities appear in the chapter.
 2. **Compare against wiki state** — Load current wiki state for matched entities to detect changes.
 3. **Extract new information** — Following the extraction rules from the wiki-maintenance skill, identify:
    - New entities not yet in the wiki
@@ -90,7 +90,7 @@ Every wiki page carries a confidence level that governs how facts are treated:
 
 | Level | Meaning | Default Mode |
 |-------|---------|--------------|
-| `verified` | Explicitly stated in generated text | Mode 2 (post-scene) |
+| `verified` | Explicitly stated in generated text | Mode 2 (post-chapter) |
 | `planned` | From the outline, not yet generated | Mode 1 (initial population) |
 | `speculative` | Inferred from context, not explicitly stated | Either mode, with reasoning |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1021,7 +1021,7 @@ The `--model` argument overrides `LLM_MODEL` for a single invocation.
 
 ## critique-runner
 
-Runs critics against story outlines, parses scores, checks quality thresholds, and generates structured feedback for iterative outline refinement.
+Runs critics against story outlines or assembled chapters, parses scores, checks quality thresholds, and generates structured feedback for iterative refinement.
 
 **Source files:**
 - `.opencode/tools/critique-runner.ts` — TypeScript wrapper
@@ -1030,15 +1030,19 @@ Runs critics against story outlines, parses scores, checks quality thresholds, a
 
 ### Purpose
 
-During outline refinement, six specialised critic personas evaluate an outline against seven scoring criteria. This tool orchestrates the critique loop: running all critics, parsing their scores, determining whether the outline meets a quality threshold, and formatting feedback for the next refinement iteration.
+The critique-runner operates in two modes:
 
-The six critic types (evaluated in order):
-1. `audiobook-producer`
-2. `book-club-moderator`
-3. `commercial-fiction-editor`
-4. `literary-fiction-reviewer`
-5. `publishing-acquisitions-editor`
-6. `subject-expert`
+- **Outline mode** — evaluates story outlines during the outline refinement loop
+- **Chapter mode** — evaluates assembled chapter text during per-chapter quality review
+
+The tool orchestrates the critique loop: running all critics for the selected mode, parsing their scores, determining whether the content meets the configured thresholds, and formatting feedback for the next refinement iteration.
+
+Critic sets by mode:
+
+| Mode | Critics |
+|------|---------|
+| `outline` | `audiobook-producer`, `book-club-moderator`, `commercial-fiction-editor`, `literary-fiction-reviewer`, `publishing-acquisitions-editor`, `subject-expert` |
+| `chapter` | `commercial-fiction-editor`, `chapter-pacing`, `chapter-character-consistency` |
 
 The seven scoring criteria:
 
@@ -1059,35 +1063,41 @@ The seven scoring criteria:
 | `operation` | `"run-critics" \| "parse-scores" \| "should-refine" \| "generate-feedback"` | Yes | Operation to perform |
 | `name` | string | For `run-critics`, `should-refine`, `generate-feedback` | Story name (maps to directory under `stories/`) |
 | `iteration` | number | No | Critique iteration number (default: 1) |
-| `content` | string | No | Content to critique; if omitted, loads outline from savepoint |
+| `content` | string | No | Content to critique; if omitted, loads mode-appropriate content from savepoint |
+| `mode` | `"outline" \| "chapter"` | No | Critique mode (default: `outline`) |
 | `criticType` | string | For `parse-scores` | Critic type identifier |
 | `responseText` | string | For `parse-scores` | Raw critic response text to parse |
 | `qualityThreshold` | number | No | Quality threshold percentage for `should-refine` (default: 85.0) |
+| `criterionFloor` | number | No | Minimum per-criterion percentage for `should-refine` (default: 75.0) |
 | `model` | string | No | Override LLM model identifier |
 
 ### CLI Interface (Python script)
 
 ```bash
-python3 src/tools/critique_runner.py --operation <op> [--name <name>] [--iteration N] [--content '<text>'] [--critic-type <type>] [--response-text '<text>'] [--quality-threshold N] [--model <model>]
+python3 src/tools/critique_runner.py --operation <op> [--name <name>] [--iteration N] [--content '<text>'] [--mode outline|chapter] [--critic-type <type>] [--response-text '<text>'] [--quality-threshold N] [--criterion-floor N] [--model <model>]
 ```
 
 **Examples:**
 
 ```bash
-# Run all 6 critics against an outline (loads from savepoint)
+# Run all outline critics (loads outline content from savepoint)
 python3 src/tools/critique_runner.py --operation run-critics --name my-story --iteration 1
 
-# Run critics with inline content
+# Run chapter critics with explicit assembled chapter text
 python3 src/tools/critique_runner.py --operation run-critics --name my-story \
-  --content "Chapter 1: The Beginning..."
+  --mode chapter --content "Chapter 1: The Beginning..."
 
 # Parse scores from a single critic response
 python3 src/tools/critique_runner.py --operation parse-scores \
   --critic-type commercial-fiction-editor --response-text "### Pacing (12/15)..."
 
-# Check if outline needs further refinement
+# Check if an outline needs further refinement
 python3 src/tools/critique_runner.py --operation should-refine --name my-story \
   --iteration 1 --quality-threshold 85.0
+
+# Check if a chapter needs refinement with a stricter per-criterion floor
+python3 src/tools/critique_runner.py --operation should-refine --name my-story \
+  --mode chapter --iteration 3 --quality-threshold 85.0 --criterion-floor 80.0
 
 # Generate formatted feedback from critique results
 python3 src/tools/critique_runner.py --operation generate-feedback --name my-story \
@@ -1098,18 +1108,25 @@ python3 src/tools/critique_runner.py --operation generate-feedback --name my-sto
 
 | Operation | Effect | Output |
 |-----------|--------|--------|
-| `run-critics` | Runs all 6 critics via LLM, parses scores, saves results as savepoint `critique_results_iteration_{N}` | JSON with `iteration`, `critic_results`, `average_scores`, `overall_average` |
-| `parse-scores` | Parses scores from a single critic response text | Serialized `CritiqueResult` as JSON |
-| `should-refine` | Loads critique results from savepoint, checks if any criterion avg < 75% or overall avg < threshold | `{should_refine, average_scores, overall_average, threshold}` |
+| `run-critics` | Runs all critics for the selected mode via LLM, parses scores, saves results as `outline_critique_results_iteration_{N}` or `chapter_critique_results_iteration_{N}` | JSON with `iteration`, `mode`, `critic_results`, `average_scores`, `overall_average` |
+| `parse-scores` | Parses scores from a single critic response text; valid critic types depend on `mode` | Serialized `CritiqueResult` as JSON |
+| `should-refine` | Loads mode-specific critique results from savepoint, checks if any criterion avg < `criterionFloor` or overall avg < `qualityThreshold` | `{should_refine, average_scores, overall_average, threshold, criterion_floor}` |
 | `generate-feedback` | Loads critique results from savepoint, formats as structured markdown | `{feedback: "<markdown>"}` |
 
 ### Quality Threshold Logic
 
 The `should-refine` operation determines refinement need using two conditions:
-- **Any criterion average < 75%** — individual weakness detected
+- **Any criterion average < criterion_floor** — individual weakness detected (default: 75.0)
 - **Overall average < quality_threshold** — general quality below standard (default: 85.0)
 
 If either condition is true, `should_refine` returns `true`.
+
+When `content` is omitted, `run-critics` falls back to mode-appropriate savepoints:
+
+- `outline` mode: previous outline iteration or `outline`
+- `chapter` mode: `chapter_assembled`, `chapter_{iteration}_complete`, or `chapter_{iteration}/complete`
+
+For chapter critiques, passing the assembled chapter text explicitly via `content` is more reliable than relying on savepoint fallback.
 
 ### Exit Codes
 

--- a/prompts/chapter_review/chapter-character-consistency.md
+++ b/prompts/chapter_review/chapter-character-consistency.md
@@ -1,0 +1,51 @@
+Write a critique from a chapter character consistency specialist's perspective.
+
+Please critique the following chapter, providing both detailed feedback and a numerical score for each area. Break down your score by the categories below, and briefly justify each category score with specific examples from the chapter.
+
+<OUTLINE>
+{outline}
+</OUTLINE>
+
+As a character consistency specialist, evaluate the chapter based on these criteria:
+    - Pacing (15 points): Do character reactions, decisions, and emotional shifts unfold at a believable pace within the chapter?
+    - Details (15 points): Do dialogue, interiority, and behavioural details reinforce distinct character voice and established traits?
+    - Flow (15 points): Do character interactions and emotional transitions move naturally from one beat to the next?
+    - Genre (10 points): Do the characters behave and sound in ways that fit the genre's tonal and emotional expectations?
+    - Consistency (10 points): Are character voice, behaviour, motivations, and knowledge consistent within the chapter and with prior setup implied by the chapter?
+    - Character Arc & Theme (20 points): Does the chapter advance character arcs meaningfully while keeping motivations credible and thematically aligned?
+    - Structure (15 points): Are character beats arranged effectively so revelations, choices, and conflicts build in a coherent order?
+
+For each category, assign a score and provide justification based on character consistency standards, referencing specific parts of the chapter. The overall score should reflect the sum of all category scores.
+
+Present your results in this exact format:
+
+## Character Consistency Critique
+
+### Pacing (score/15)
+Notes about pacing of character reactions and changes
+
+### Details (score/15)
+Notes about dialogue, interiority, and behavioural detail
+
+### Flow (score/15)
+Notes about interaction flow and emotional continuity
+
+### Genre (score/10)
+Notes about genre-fit for character voice and behaviour
+
+### Consistency (score/10)
+Notes about voice, behaviour, and motivation consistency
+
+### Character Arc & Theme (score/20)
+Notes about arc advancement and thematic alignment
+
+### Structure (score/15)
+Notes about ordering and escalation of character beats
+
+### Summary
+Overall assessment of character voice and behaviour consistency within the chapter, including any drift, contradictions, or missed opportunities for stronger character coherence.
+
+IMPORTANT:
+- Score each category based on its maximum points (15, 10, or 20)
+- Do not include an overall score - this will be calculated automatically
+- Just output the critique. No commentary, introduction, or other metadata.

--- a/prompts/chapter_review/chapter-pacing.md
+++ b/prompts/chapter_review/chapter-pacing.md
@@ -1,0 +1,51 @@
+Write a critique from a chapter pacing specialist's perspective.
+
+Please critique the following chapter, providing both detailed feedback and a numerical score for each area. Break down your score by the categories below, and briefly justify each category score with specific examples from the chapter.
+
+<OUTLINE>
+{outline}
+</OUTLINE>
+
+As a chapter pacing specialist, evaluate the chapter based on these criteria:
+    - Pacing (15 points): Does each scene arrive at the right speed? Are buildup, conflict, and release distributed effectively across the chapter?
+    - Details (15 points): Do descriptive and reflective passages support pacing rather than stall it? Are slower beats purposeful?
+    - Flow (15 points): Do scene transitions, time jumps, and emotional handoffs feel smooth and legible?
+    - Genre (10 points): Does the chapter's pacing match genre expectations for urgency, suspense, reflection, or momentum?
+    - Consistency (10 points): Is the pacing logic consistent throughout, or does the chapter lurch between rushed and stagnant sections?
+    - Character Arc & Theme (20 points): Do character beats and thematic moments land at the right times to deepen impact without interrupting momentum?
+    - Structure (15 points): Does the chapter have a clear rhythm from opening through climax/end beat, with each scene doing distinct work?
+
+For each category, assign a score and provide justification based on chapter pacing standards, referencing specific parts of the chapter. The overall score should reflect the sum of all category scores.
+
+Present your results in this exact format:
+
+## Chapter Pacing Critique
+
+### Pacing (score/15)
+Notes about scene-by-scene pacing
+
+### Details (score/15)
+Notes about details and whether they help or hinder momentum
+
+### Flow (score/15)
+Notes about transitions and rhythm
+
+### Genre (score/10)
+Notes about genre-appropriate pacing expectations
+
+### Consistency (score/10)
+Notes about pacing consistency across the chapter
+
+### Character Arc & Theme (score/20)
+Notes about timing of character and thematic beats
+
+### Structure (score/15)
+Notes about chapter rhythm and structural progression
+
+### Summary
+Overall assessment of the chapter's pacing, including bottlenecks, rushed sections, scene-order concerns, and recommendations for stronger momentum.
+
+IMPORTANT:
+- Score each category based on its maximum points (15, 10, or 20)
+- Do not include an overall score - this will be calculated automatically
+- Just output the critique. No commentary, introduction, or other metadata.

--- a/prompts/chapter_review/commercial-fiction-editor.md
+++ b/prompts/chapter_review/commercial-fiction-editor.md
@@ -1,0 +1,51 @@
+Write a critique from a commercial fiction editor's perspective.
+
+Please critique the following chapter, providing both detailed feedback and a numerical score for each area. Break down your score by the categories below, and briefly justify each category score with specific examples from the chapter.
+
+<OUTLINE>
+{outline}
+</OUTLINE>
+
+As a commercial fiction editor, evaluate the chapter based on these criteria:
+    - Pacing (15 points): Does the prose-level pacing keep readers turning pages scene by scene? Are hooks, momentum, and reveals timed effectively within the chapter?
+    - Details (15 points): Are descriptive details vivid, clear, and commercially appealing without bogging down the prose?
+    - Flow (15 points): Does the chapter read smoothly from paragraph to paragraph and scene to scene? Are transitions clear and easy to follow?
+    - Genre (10 points): Does the chapter deliver the expected reading experience for its genre in tone, intensity, and reader payoff?
+    - Consistency (10 points): Is the prose voice consistent? Do character behaviour, emotional beats, and world details remain coherent throughout the chapter?
+    - Character Arc & Theme (20 points): Does the chapter advance character development and thematic material in a compelling, readable way?
+    - Structure (15 points): Is the chapter internally structured well, with a strong opening, escalation, and satisfying end beat?
+
+For each category, assign a score and provide justification based on commercial fiction standards, referencing specific parts of the chapter. The overall score should reflect the sum of all category scores.
+
+Present your results in this exact format:
+
+## Commercial Fiction Critique
+
+### Pacing (score/15)
+Notes about pacing for commercial appeal
+
+### Details (score/15)
+Notes about clarity and engagement of details
+
+### Flow (score/15)
+Notes about readability and narrative energy
+
+### Genre (score/10)
+Notes about meeting commercial genre expectations
+
+### Consistency (score/10)
+Notes about tone, style, and character relatability
+
+### Character Arc & Theme (score/20)
+Notes about character engagement and accessible themes
+
+### Structure (score/15)
+Notes about structural clarity and satisfaction
+
+### Summary
+Overall assessment of commercial appeal, including prose strengths, chapter-level reader engagement factors, and recommendations for strengthening the chapter.
+
+IMPORTANT:
+- Score each category based on its maximum points (15, 10, or 20)
+- Do not include an overall score - this will be calculated automatically
+- Just output the critique. No commentary, introduction, or other metadata.

--- a/prompts/outline/create_chunk.md
+++ b/prompts/outline/create_chunk.md
@@ -28,7 +28,6 @@ Create a brief skeleton outline for chapters {chunk_start} through {chunk_end} t
 - **Maintains proper escalation order** as specified in the continuity summary
 - Follows logical story progression from previous chapters (if any)
 - Maintains consistency with the established story elements and context
-- **Incorporates relevant enrichment suggestions** to deepen the story beyond its basic scope
 - **Respects established pacing and intensity patterns** from previous chunks
 - Provides concise chapter overviews suitable for later expansion
 - Connects smoothly to the overall story arc
@@ -40,14 +39,6 @@ Create a brief skeleton outline for chapters {chunk_start} through {chunk_end} t
 - **Plot Thread Continuity**: Address active storylines and unresolved elements from previous chunks
 - **Pacing Consistency**: Maintain the established rhythm of action/reflection and intensity patterns
 - **Thematic Development**: Continue building themes and symbols as established in previous chapters
-
-## ENRICHMENT INTEGRATION
-Use the provided enrichment suggestions to enhance your chapter outlines by:
-- **Character Development**: Integrate suggested character arcs, backstory reveals, and relationship dynamics
-- **World-Building**: Incorporate suggested setting details, cultural elements, and environmental factors
-- **Plot Complexity**: Weave in suggested subplots, foreshadowing, and obstacle escalation
-- **Thematic Depth**: Include suggested symbolic elements, moral dilemmas, and thematic reinforcement
-- **Chapter Placement**: Pay attention to suggested chapter ranges for implementing specific enrichments
 
 ## STORY STRUCTURE AWARENESS
 Based on your chunk position within the {total_chapters}-chapter story:
@@ -124,7 +115,6 @@ Before finalizing your output, verify each chapter meets these criteria:
 - ✅ **Specific Events**: Can someone clearly understand what exactly happens in this chapter?
 - ✅ **Clear Actions**: Are the character actions concrete and definitive (not vague)?
 - ✅ **Distinct Outcomes**: Does this chapter change something specific in the story?
-- ✅ **Enrichment Integration**: Does this chapter incorporate relevant suggestions to deepen the story?
 - ✅ **Thematic Resonance**: Does this chapter contribute to the story's emotional and thematic depth?
 
 ## OUTPUT REQUIREMENTS

--- a/src/tools/critique_runner.py
+++ b/src/tools/critique_runner.py
@@ -1,4 +1,4 @@
-"""CLI tool for running critics against story outlines (run-critics, parse-scores, should-refine, generate-feedback)."""
+"""CLI tool for running critics against story content."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ if _root_path not in sys.path:
 
 from src.tools._io import STORIES_DIR, _validate_story_name  # noqa: E402
 
-CRITIC_TYPES = [
+OUTLINE_CRITIC_TYPES = [
     "audiobook-producer",
     "book-club-moderator",
     "commercial-fiction-editor",
@@ -33,6 +33,14 @@ CRITIC_TYPES = [
     "publishing-acquisitions-editor",
     "subject-expert",
 ]
+
+CHAPTER_CRITIC_TYPES = [
+    "commercial-fiction-editor",
+    "chapter-pacing",
+    "chapter-character-consistency",
+]
+
+MODES = ["outline", "chapter"]
 
 
 def _make_repo(name: str) -> FilesystemSavepointRepository:
@@ -114,6 +122,25 @@ def _serialize_critique_result(result: Any) -> dict[str, Any]:
     }
 
 
+def _critique_results_step(mode: str, iteration: int) -> str:
+    """Return the namespaced critique savepoint key for the selected mode."""
+    return f"{mode}_critique_results_iteration_{iteration}"
+
+
+def _prompt_prefix(mode: str) -> str:
+    """Return the prompt subdirectory for the selected critique mode."""
+    if mode == "chapter":
+        return "chapter_review"
+    return "outline_review"
+
+
+def _critic_types_for_mode(mode: str) -> list[str]:
+    """Return the critic set for the selected critique mode."""
+    if mode == "chapter":
+        return CHAPTER_CRITIC_TYPES
+    return OUTLINE_CRITIC_TYPES
+
+
 # ---------------------------------------------------------------------------
 # Operations
 # ---------------------------------------------------------------------------
@@ -124,9 +151,10 @@ def cmd_run_critics(
     iteration: int,
     content: str | None,
     *,
+    mode: str = "outline",
     model: str | None = None,
 ) -> None:
-    """Run all 6 critic types against an outline."""
+    """Run all 6 critic types against story content."""
     from application.services.critique_parser import CritiqueParser
 
     story_dir = _validate_story_name(name)
@@ -153,17 +181,17 @@ def cmd_run_critics(
     parser = CritiqueParser()
     critique_results = []
 
-    for critic_type in CRITIC_TYPES:
+    for critic_type in _critic_types_for_mode(mode):
         try:
             prompt_content = _load_prompt(
-                f"outline_review/{critic_type}", variables={"outline": outline}
+                f"{_prompt_prefix(mode)}/{critic_type}", variables={"outline": outline}
             )
             messages = [
                 {
                     "role": "system",
                     "content": (
                         "You are an expert critic providing detailed, constructive "
-                        "feedback on story outlines. Always follow the exact format "
+                        "feedback on story content. Always follow the exact format "
                         "specified in the prompt."
                     ),
                 },
@@ -185,21 +213,25 @@ def cmd_run_critics(
     # Save combined results
     savepoint_data = {
         "iteration": iteration,
+        "mode": mode,
         "critic_results": [_serialize_critique_result(r) for r in critique_results],
         "average_scores": average_scores,
         "overall_average": overall_average,
     }
-    _save_savepoint(repo, f"critique_results_iteration_{iteration}", savepoint_data)
+    _save_savepoint(repo, _critique_results_step(mode, iteration), savepoint_data)
 
     _success("run-critics", savepoint_data)
 
 
-def cmd_parse_scores(critic_type: str, response_text: str) -> None:
+def cmd_parse_scores(
+    critic_type: str, response_text: str, *, mode: str = "outline"
+) -> None:
     """Parse scores from a single critic response."""
     from application.services.critique_parser import CritiqueParser
 
-    if critic_type not in CRITIC_TYPES:
-        _error(f"unknown critic type: {critic_type}. Valid: {', '.join(CRITIC_TYPES)}")
+    valid_critics = _critic_types_for_mode(mode)
+    if critic_type not in valid_critics:
+        _error(f"unknown critic type: {critic_type}. Valid: {', '.join(valid_critics)}")
 
     parser = CritiqueParser()
     result = parser.parse_critique(critic_type, response_text)
@@ -210,6 +242,9 @@ def cmd_should_refine(
     name: str,
     iteration: int,
     quality_threshold: float,
+    criterion_floor: float,
+    *,
+    mode: str = "outline",
 ) -> None:
     """Determine if content meets quality threshold."""
     story_dir = _validate_story_name(name)
@@ -217,7 +252,7 @@ def cmd_should_refine(
         _error(f"story not found: {name}")
 
     repo = _make_repo(name)
-    step = f"critique_results_iteration_{iteration}"
+    step = _critique_results_step(mode, iteration)
     if not _has_savepoint(repo, step):
         _error(f"critique results not found for iteration {iteration}")
 
@@ -228,9 +263,7 @@ def cmd_should_refine(
     average_scores: dict[str, float] = data.get("average_scores", {})
     overall_average: float = data.get("overall_average", 0.0)
 
-    # 75% per-criterion floor is a domain invariant — any criterion scoring below
-    # this indicates a fundamental quality issue regardless of overall average
-    any_criterion_low = any(score < 75.0 for score in average_scores.values())
+    any_criterion_low = any(score < criterion_floor for score in average_scores.values())
     # overall_average is raw score sum (max 100) — effectively a percentage
     overall_low = overall_average < quality_threshold
 
@@ -243,11 +276,12 @@ def cmd_should_refine(
             "average_scores": average_scores,
             "overall_average": overall_average,
             "threshold": quality_threshold,
+            "criterion_floor": criterion_floor,
         },
     )
 
 
-def cmd_generate_feedback(name: str, iteration: int) -> None:
+def cmd_generate_feedback(name: str, iteration: int, *, mode: str = "outline") -> None:
     """Format critique results as structured markdown."""
     from application.services.critique_parser import (
         CritiqueParser,
@@ -260,7 +294,7 @@ def cmd_generate_feedback(name: str, iteration: int) -> None:
         _error(f"story not found: {name}")
 
     repo = _make_repo(name)
-    step = f"critique_results_iteration_{iteration}"
+    step = _critique_results_step(mode, iteration)
     if not _has_savepoint(repo, step):
         _error(f"critique results not found for iteration {iteration}")
 
@@ -308,12 +342,18 @@ def cmd_generate_feedback(name: str, iteration: int) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run critics against story outlines")
+    parser = argparse.ArgumentParser(description="Run critics against story content")
     parser.add_argument(
         "--operation",
         required=True,
         choices=["run-critics", "parse-scores", "should-refine", "generate-feedback"],
         help="Operation to perform",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=MODES,
+        default="outline",
+        help="Critique mode: outline or chapter",
     )
     parser.add_argument("--name", help="Story name")
     parser.add_argument(
@@ -332,6 +372,12 @@ def main() -> None:
         default=85.0,
         help="Quality threshold for should-refine",
     )
+    parser.add_argument(
+        "--criterion-floor",
+        type=float,
+        default=75.0,
+        help="Minimum allowed per-criterion score for should-refine",
+    )
     parser.add_argument("--model", help="Override LLM model identifier")
 
     args = parser.parse_args()
@@ -340,21 +386,33 @@ def main() -> None:
     if op == "run-critics":
         if not args.name:
             _error("--name required for run-critics", exit_code=2)
-        cmd_run_critics(args.name, args.iteration, args.content, model=args.model)
+        cmd_run_critics(
+            args.name,
+            args.iteration,
+            args.content,
+            mode=args.mode,
+            model=args.model,
+        )
     elif op == "parse-scores":
         if not args.critic_type:
             _error("--critic-type required for parse-scores", exit_code=2)
         if not args.response_text:
             _error("--response-text required for parse-scores", exit_code=2)
-        cmd_parse_scores(args.critic_type, args.response_text)
+        cmd_parse_scores(args.critic_type, args.response_text, mode=args.mode)
     elif op == "should-refine":
         if not args.name:
             _error("--name required for should-refine", exit_code=2)
-        cmd_should_refine(args.name, args.iteration, args.quality_threshold)
+        cmd_should_refine(
+            args.name,
+            args.iteration,
+            args.quality_threshold,
+            args.criterion_floor,
+            mode=args.mode,
+        )
     elif op == "generate-feedback":
         if not args.name:
             _error("--name required for generate-feedback", exit_code=2)
-        cmd_generate_feedback(args.name, args.iteration)
+        cmd_generate_feedback(args.name, args.iteration, mode=args.mode)
 
 
 if __name__ == "__main__":

--- a/src/tools/critique_runner.py
+++ b/src/tools/critique_runner.py
@@ -154,7 +154,7 @@ def cmd_run_critics(
     mode: str = "outline",
     model: str | None = None,
 ) -> None:
-    """Run all 6 critic types against story content."""
+    """Run all critics for the selected mode against story content."""
     from application.services.critique_parser import CritiqueParser
 
     story_dir = _validate_story_name(name)
@@ -163,20 +163,31 @@ def cmd_run_critics(
 
     repo = _make_repo(name)
 
-    # Load outline content
-    outline: str
-    if content:
-        outline = content
-    else:
-        # Try loading from savepoint
-        if iteration > 1 and _has_savepoint(repo, f"outline_iteration_{iteration - 1}"):
-            data = _load_savepoint(repo, f"outline_iteration_{iteration - 1}")
-            outline = data if isinstance(data, str) else json.dumps(data, default=str)
-        elif _has_savepoint(repo, "outline"):
-            data = _load_savepoint(repo, "outline")
-            outline = data if isinstance(data, str) else json.dumps(data, default=str)
+    if content is None:
+        savepoint_steps: list[str] = []
+        if mode == "chapter":
+            savepoint_steps.extend(
+                [
+                    "chapter_assembled",
+                    f"chapter_{iteration}_complete",
+                    f"chapter_{iteration}/complete",
+                ]
+            )
         else:
-            _error("no outline content provided and no outline savepoint found")
+            if iteration > 1:
+                savepoint_steps.append(f"outline_iteration_{iteration - 1}")
+            savepoint_steps.append("outline")
+
+        for step in savepoint_steps:
+            if _has_savepoint(repo, step):
+                data = _load_savepoint(repo, step)
+                content = data if isinstance(data, str) else json.dumps(data, default=str)
+                break
+
+        if content is None:
+            _error(
+                f"no content provided for {mode} critique and no {mode} savepoint found"
+            )
 
     parser = CritiqueParser()
     critique_results = []
@@ -184,7 +195,7 @@ def cmd_run_critics(
     for critic_type in _critic_types_for_mode(mode):
         try:
             prompt_content = _load_prompt(
-                f"{_prompt_prefix(mode)}/{critic_type}", variables={"outline": outline}
+                f"{_prompt_prefix(mode)}/{critic_type}", variables={"outline": content}
             )
             messages = [
                 {

--- a/src/tools/outline_generator.py
+++ b/src/tools/outline_generator.py
@@ -254,7 +254,7 @@ def cmd_generate_elements(name: str, **_kwargs: Any) -> None:
     story_elements = "\n\n".join(combined_chunks)
     _save_savepoint(repo, "story_elements", story_elements)
 
-    _success("generate-elements", {"story_elements": story_elements})
+    _success("generate-elements", {"savepoint": "story_elements"})
 
 
 def cmd_generate_outline(

--- a/src/tools/story_assembler.py
+++ b/src/tools/story_assembler.py
@@ -1,0 +1,217 @@
+"""CLI tool for assembling saved chapter content into a single story markdown file."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+
+if TYPE_CHECKING:
+    from infrastructure.storage.savepoint_repository import FilesystemSavepointRepository
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+_src_path = str(PROJECT_ROOT / "src")
+_root_path = str(PROJECT_ROOT)
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+if _root_path not in sys.path:
+    sys.path.insert(0, _root_path)
+
+from src.tools._io import STORIES_DIR, _validate_story_name  # noqa: E402
+
+CHAPTER_SAVEPOINT_PATTERNS = (
+    "chapter_{chapter_num}_complete",
+    "chapter_{chapter_num}/complete",
+    "chapter_{chapter_num}",
+)
+
+
+def _make_repo(name: str) -> FilesystemSavepointRepository:
+    """Create a FilesystemSavepointRepository for the given story."""
+    from infrastructure.storage.savepoint_repository import FilesystemSavepointRepository
+
+    repo = FilesystemSavepointRepository(base_path=STORIES_DIR / name)
+    repo.set_story_directory("savepoints")
+    return repo
+
+
+def _load_savepoint(repo: FilesystemSavepointRepository, step: str) -> Any:
+    """Load a savepoint, returning its data."""
+    return asyncio.run(repo.load_savepoint(step))
+
+
+def _has_savepoint(repo: FilesystemSavepointRepository, step: str) -> bool:
+    """Check if a savepoint exists."""
+    return asyncio.run(repo.has_savepoint(step))
+
+
+def _list_savepoint_names(repo: FilesystemSavepointRepository) -> list[str]:
+    """List available savepoint names for the story."""
+    return asyncio.run(repo.list_savepoint_names())
+
+
+def _error(message: str, exit_code: int = 1) -> NoReturn:
+    """Print error to stderr and exit."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def _normalize_state(data: Any) -> dict[str, Any]:
+    """Validate story state payload shape."""
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _load_story_state(story_dir: Path) -> dict[str, Any]:
+    """Load story state from disk if available."""
+    state_path = story_dir / "state.json"
+    if not state_path.exists():
+        return {}
+    try:
+        return _normalize_state(json.loads(state_path.read_text(encoding="utf-8")))
+    except json.JSONDecodeError as exc:
+        _error(f"invalid state.json for story: {exc}")
+
+
+def _extract_state_chapter_text(chapters: Any, chapter_num: int) -> str | None:
+    """Extract chapter text from story state using common field names."""
+    chapter_data: Any = None
+
+    if isinstance(chapters, dict):
+        chapter_data = chapters.get(str(chapter_num), chapters.get(chapter_num))
+    elif isinstance(chapters, list):
+        for entry in chapters:
+            if not isinstance(entry, dict):
+                continue
+            number = entry.get("number")
+            if isinstance(number, int) and number == chapter_num:
+                chapter_data = entry
+                break
+
+    if isinstance(chapter_data, str):
+        return chapter_data
+    if not isinstance(chapter_data, dict):
+        return None
+
+    for key in ("content", "text", "chapter_text", "assembled"):
+        value = chapter_data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _load_chapter_content(
+    repo: FilesystemSavepointRepository,
+    story_state: dict[str, Any],
+    chapter_num: int,
+) -> str | None:
+    """Load chapter content from savepoints, falling back to story state."""
+    for pattern in CHAPTER_SAVEPOINT_PATTERNS:
+        step = pattern.format(chapter_num=chapter_num)
+        if _has_savepoint(repo, step):
+            data = _load_savepoint(repo, step)
+            if isinstance(data, str) and data.strip():
+                return data
+            if data is not None:
+                return json.dumps(data, indent=2, default=str)
+
+    return _extract_state_chapter_text(story_state.get("chapters", {}), chapter_num)
+
+
+def _discover_chapter_numbers(
+    repo: FilesystemSavepointRepository,
+    story_state: dict[str, Any],
+) -> list[int]:
+    """Determine chapter numbers from savepoints and story state."""
+    numbers: set[int] = set()
+
+    chapter_pattern = re.compile(r"^chapter_(\d+)(?:_complete|/complete)?$")
+    for step_name in _list_savepoint_names(repo):
+        match = chapter_pattern.match(step_name)
+        if match:
+            numbers.add(int(match.group(1)))
+
+    chapters = story_state.get("chapters", {})
+    if isinstance(chapters, dict):
+        for key in chapters:
+            if isinstance(key, int):
+                numbers.add(key)
+            elif isinstance(key, str) and key.isdigit():
+                numbers.add(int(key))
+    elif isinstance(chapters, list):
+        for entry in chapters:
+            if isinstance(entry, dict):
+                number = entry.get("number")
+                if isinstance(number, int):
+                    numbers.add(number)
+
+    return sorted(numbers)
+
+
+def cmd_assemble(story_name: str) -> None:
+    """Assemble all available chapter content into a single story markdown file."""
+    story_dir = _validate_story_name(story_name)
+    if not story_dir.exists():
+        _error(f"story not found: {story_name}")
+
+    repo = _make_repo(story_name)
+    story_state = _load_story_state(story_dir)
+
+    chapter_numbers = _discover_chapter_numbers(repo, story_state)
+    if not chapter_numbers:
+        _error("no chapter content found in savepoints or story state")
+
+    chapter_parts: list[str] = []
+    for chapter_num in chapter_numbers:
+        chapter_content = _load_chapter_content(repo, story_state, chapter_num)
+        if not chapter_content:
+            continue
+        chapter_parts.append(chapter_content.rstrip())
+
+    if not chapter_parts:
+        _error("no readable chapter content found in savepoints or story state")
+
+    output_path = story_dir / "output" / "story.md"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n\n".join(chapter_parts) + "\n", encoding="utf-8")
+
+    print(
+        json.dumps(
+            {
+                "output_path": f"stories/{story_name}/output/story.md",
+                "chapter_count": len(chapter_parts),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assemble completed chapter content")
+    subparsers = parser.add_subparsers(dest="command")
+
+    assemble_parser = subparsers.add_parser("assemble", help="Assemble story output")
+    assemble_parser.add_argument(
+        "--story-name",
+        required=True,
+        help="Story name (directory under stories/)",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "assemble":
+        cmd_assemble(args.story_name)
+        return
+
+    parser.print_help()
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/story_state.py
+++ b/src/tools/story_state.py
@@ -30,7 +30,17 @@ INITIAL_STATE = {
     "characters": {},
     "plot_threads": {},
     "chapters": {},
+    "pipeline_state": {"phase": None, "step": None, "chapter": None},
 }
+
+DEFAULT_PIPELINE_STATE = {"phase": None, "step": None, "chapter": None}
+
+
+def _ensure_state_defaults(data: dict) -> dict:
+    """Backfill newly added state fields for older stories."""
+    if "pipeline_state" not in data or not isinstance(data["pipeline_state"], dict):
+        data["pipeline_state"] = DEFAULT_PIPELINE_STATE.copy()
+    return data
 
 
 def _get_nested(data: dict, field: str) -> object:
@@ -81,7 +91,7 @@ def _read_state(state_path: Path) -> dict:
         print(f"Error: state file not found: {state_path}", file=sys.stderr)
         sys.exit(1)
     with open(state_path) as f:
-        return json.load(f)
+        return _ensure_state_defaults(json.load(f))
 
 
 def _write_state_atomic(state_path: Path, data: dict) -> None:
@@ -167,7 +177,7 @@ def cmd_write(name: str, field: str, value_str: str) -> None:
 
         # Read, modify, write all under the same lock to prevent TOCTOU
         with open(state_path) as f:
-            data = json.load(f)
+            data = _ensure_state_defaults(json.load(f))
         _set_nested(data, field, value)
 
         tmp_path = None

--- a/src/tools/wiki_snapshot.py
+++ b/src/tools/wiki_snapshot.py
@@ -601,6 +601,23 @@ def _enforce_token_budget(
         if not demoted:
             break  # All non-protected pages already at L1
 
+    if current_total > budget:
+        removable_slugs = sorted(
+            (
+                slug
+                for slug in sorted_slugs
+                if slug not in protected
+            ),
+            key=lambda slug: pages[slug].get("relevance_score", 0.0),
+        )
+        for slug in removable_slugs:
+            if current_total <= budget:
+                break
+            current_total -= slug_tokens.get(slug, 0)
+            pages.pop(slug, None)
+            if slug in sorted_slugs:
+                sorted_slugs.remove(slug)
+
 
 # ---------------------------------------------------------------------------
 # Stage 3: Structured Context Assembly

--- a/tests/unit/test_critique_runner_tool.py
+++ b/tests/unit/test_critique_runner_tool.py
@@ -146,7 +146,7 @@ def _make_critique_results_savepoint(
     _write_savepoint(
         stories_dir,
         story_name,
-        f"critique_results_iteration_{iteration}",
+        f"outline_critique_results_iteration_{iteration}",
         savepoint_data,
     )
 

--- a/tests/unit/test_outline_generator_tool.py
+++ b/tests/unit/test_outline_generator_tool.py
@@ -200,12 +200,8 @@ def test_generate_elements_with_savepoints(story_env: tuple[Path, str]) -> None:
     assert result.returncode == 0, f"stderr: {result.stderr}"
     out = json.loads(result.stdout)
 
-    # All 8 chunks should be concatenated in story_elements
-    story_elements = out["data"]["story_elements"]
-    for chunk_type in CHUNK_TYPES:
-        header = chunk_type.replace("_", " ").title()
-        assert f"=== {header} ===" in story_elements
-        assert f"Content for {chunk_type} analysis." in story_elements
+    # Output returns savepoint key only (not full content) to avoid stdout bloat
+    assert out["data"]["savepoint"] == "story_elements"
 
 
 def test_generate_elements_output_format(story_env: tuple[Path, str]) -> None:

--- a/tests/unit/test_prompt_relocation.py
+++ b/tests/unit/test_prompt_relocation.py
@@ -108,6 +108,6 @@ def test_prompt_file_count():
     """Count all .md files under prompts/ and verify there are 132."""
     prompts_dir = PROJECT_ROOT / "prompts"
     md_files = list(prompts_dir.rglob("*.md"))
-    assert len(md_files) == 132, (
-        f"Expected 132 .md files under prompts/, found {len(md_files)}"
+    assert len(md_files) == 135, (
+        f"Expected 135 .md files under prompts/, found {len(md_files)}"
     )

--- a/tests/unit/test_workflow_improvement_fixes.py
+++ b/tests/unit/test_workflow_improvement_fixes.py
@@ -1,0 +1,257 @@
+"""Verification tests for PR #118 workflow improvement fixes."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+OUTLINE_GENERATOR_SCRIPT = PROJECT_ROOT / "src" / "tools" / "outline_generator.py"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import src.tools.critique_runner as critique_runner
+import src.tools.story_assembler as story_assembler
+import src.tools.story_state as story_state
+import src.tools.wiki_snapshot as wiki_snapshot
+
+
+CHUNK_TYPES = (
+    "core_story_foundation",
+    "character_foundation",
+    "setting_foundation",
+    "plot_structure",
+    "theme_message",
+    "tone_style",
+    "conflict_stakes",
+    "world_rules_logic",
+)
+
+
+def _run_outline_generator(
+    *args: str, stories_dir: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONPATH": str(PROJECT_ROOT)}
+    if stories_dir is not None:
+        env["STORIES_DIR"] = str(stories_dir)
+    return subprocess.run(
+        [sys.executable, str(OUTLINE_GENERATOR_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _write_markdown_savepoint(
+    stories_dir: Path, story_name: str, step_name: str, data: str
+) -> None:
+    savepoint_dir = stories_dir / story_name / "savepoints"
+    if "/" in step_name:
+        parts = step_name.split("/")
+        filename = parts[-1]
+        target_dir = savepoint_dir.joinpath(*parts[:-1])
+        target_dir.mkdir(parents=True, exist_ok=True)
+        filepath = target_dir / f"{filename}.md"
+    else:
+        savepoint_dir.mkdir(parents=True, exist_ok=True)
+        filepath = savepoint_dir / f"{step_name}.md"
+    filepath.write_text(f"# Savepoint: {step_name}\n\n{data}", encoding="utf-8")
+
+
+class TestWikiSnapshotTokenBudget:
+    def test_enforce_token_budget_drops_lowest_relevance_pages_after_demotions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            wiki_snapshot,
+            "_get_page_content_at_level",
+            lambda page, level: str(page["token_map"][level]),
+        )
+        monkeypatch.setattr(wiki_snapshot, "count_tokens", lambda content: int(content))
+
+        pages = {
+            "alpha": {
+                "detail_level": "L3",
+                "relevance_score": 0.9,
+                "token_map": {"L1": 5, "L2": 15, "L3": 30},
+            },
+            "gamma": {
+                "detail_level": "L3",
+                "relevance_score": 0.4,
+                "token_map": {"L1": 5, "L2": 20, "L3": 40},
+            },
+            "beta": {
+                "detail_level": "L3",
+                "relevance_score": 0.2,
+                "token_map": {"L1": 5, "L2": 20, "L3": 40},
+            },
+        }
+        sorted_slugs = ["alpha", "gamma", "beta"]
+
+        wiki_snapshot._enforce_token_budget(
+            pages,
+            sorted_slugs,
+            pov_character=None,
+            primary_location=None,
+            budget=11,
+        )
+
+        assert sorted_slugs == ["alpha", "gamma"]
+        assert set(pages) == {"alpha", "gamma"}
+        assert "beta" not in pages
+        assert pages["alpha"]["detail_level"] == "L1"
+        assert pages["gamma"]["detail_level"] == "L1"
+
+
+class TestStoryStateDefaults:
+    def test_ensure_state_defaults_adds_missing_pipeline_state(self) -> None:
+        data = {"story_context": {}, "chapters": {}}
+
+        result = story_state._ensure_state_defaults(data)
+
+        assert result["pipeline_state"] == {
+            "phase": None,
+            "step": None,
+            "chapter": None,
+        }
+
+    def test_ensure_state_defaults_preserves_valid_pipeline_state(self) -> None:
+        data = {
+            "story_context": {},
+            "pipeline_state": {"phase": "outline", "step": "draft", "chapter": 3},
+        }
+
+        result = story_state._ensure_state_defaults(data)
+
+        assert result["pipeline_state"] == {
+            "phase": "outline",
+            "step": "draft",
+            "chapter": 3,
+        }
+
+    def test_ensure_state_defaults_replaces_invalid_pipeline_state(self) -> None:
+        data = {"story_context": {}, "pipeline_state": "broken"}
+
+        result = story_state._ensure_state_defaults(data)
+
+        assert result["pipeline_state"] == {
+            "phase": None,
+            "step": None,
+            "chapter": None,
+        }
+
+
+class TestOutlineGeneratorCliOutput:
+    def test_generate_elements_stdout_returns_savepoint_only(
+        self, tmp_path: Path
+    ) -> None:
+        stories_dir = tmp_path / "stories"
+        story_name = "test-story"
+        (stories_dir / story_name / "savepoints").mkdir(parents=True)
+
+        for chunk_type in CHUNK_TYPES:
+            _write_markdown_savepoint(
+                stories_dir,
+                story_name,
+                f"story_analysis/{chunk_type}_chunk",
+                f"Chunk content for {chunk_type}.",
+            )
+
+        result = _run_outline_generator(
+            "--operation",
+            "generate-elements",
+            "--name",
+            story_name,
+            stories_dir=stories_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        output = json.loads(result.stdout)
+        assert output["status"] == "success"
+        assert output["operation"] == "generate-elements"
+        assert output["data"] == {"savepoint": "story_elements"}
+        assert (stories_dir / story_name / "savepoints" / "story_elements.md").exists()
+
+
+class TestCritiqueRunnerModeHelpers:
+    def test_critique_results_step_namespaces_outline_and_chapter(self) -> None:
+        assert (
+            critique_runner._critique_results_step("outline", 1)
+            == "outline_critique_results_iteration_1"
+        )
+        assert (
+            critique_runner._critique_results_step("chapter", 2)
+            == "chapter_critique_results_iteration_2"
+        )
+
+    def test_prompt_prefix_matches_mode(self) -> None:
+        assert critique_runner._prompt_prefix("outline") == "outline_review"
+        assert critique_runner._prompt_prefix("chapter") == "chapter_review"
+
+    def test_critic_types_for_mode_returns_expected_sets(self) -> None:
+        expected_outline = [
+            "audiobook-producer",
+            "book-club-moderator",
+            "commercial-fiction-editor",
+            "literary-fiction-reviewer",
+            "publishing-acquisitions-editor",
+            "subject-expert",
+        ]
+        expected_chapter = [
+            "commercial-fiction-editor",
+            "chapter-pacing",
+            "chapter-character-consistency",
+        ]
+
+        assert critique_runner._critic_types_for_mode("outline") == expected_outline
+        assert critique_runner._critic_types_for_mode("chapter") == expected_chapter
+
+
+class TestStoryAssemblerHelpers:
+    def test_extract_state_chapter_text_reads_supported_fields(self) -> None:
+        chapters = {"2": {"assembled": "Chapter two text"}}
+
+        result = story_assembler._extract_state_chapter_text(chapters, 2)
+
+        assert result == "Chapter two text"
+
+    def test_load_chapter_content_falls_back_to_story_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(story_assembler, "_has_savepoint", lambda repo, step: False)
+
+        result = story_assembler._load_chapter_content(
+            repo=object(),
+            story_state={"chapters": {"3": {"content": "Chapter three"}}},
+            chapter_num=3,
+        )
+
+        assert result == "Chapter three"
+
+    def test_discover_chapter_numbers_merges_savepoints_and_story_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            story_assembler,
+            "_list_savepoint_names",
+            lambda repo: [
+                "chapter_2_complete",
+                "chapter_10/complete",
+                "chapter_3",
+                "outline",
+            ],
+        )
+
+        chapter_numbers = story_assembler._discover_chapter_numbers(
+            repo=object(),
+            story_state={"chapters": {"1": {}, 4: {}}},
+        )
+
+        assert chapter_numbers == [1, 2, 3, 4, 10]


### PR DESCRIPTION
## Summary

Implements all code-addressable fixes from the 2026-04-21 multi-model workflow improvement synthesis audit. Covers the unanimous critical finding (empty character/setting sheets), all majority critical/warning findings, and all singular findings that were clearly valid.

## Closes
Closes #117

## Changes

- [ ] Implementation complete
- [ ] All tests passing (verified)
- [ ] Linting clean

## Plan

### Findings Addressed

**★★★ Critical (Unanimous)**
- [U-C-01] Phase 5/6 empty sheets — orchestrator now calls `prompt-loader` to generate content before passing to `character-mgr`/`setting-mgr`

**★★☆ Critical (Majority)**
- [M-C-01] Chapter quality gate — `critique_runner.py` extended with `chapter` mode, `CHAPTER_CRITIC_TYPES`, namespaced savepoints, and `prompts/chapter_review/` prompt directory
- [M-C-02] Wiki-maintainer invocation granularity — committed to post-chapter; agent instructions updated throughout

**★★☆ Warning (Majority)**
- [M-W-01] Chunked outline quadratic growth — `previousChunks` removed from `expand-chapter` call in `outline-planner.md`; use `continuitySummary` only
- [M-W-02] Resume logic — `pipeline_state` field added to `INITIAL_STATE` in `story_state.py` with backfill migration for older stories
- [M-W-03] Phase 9 assembly — `story-assembler` tool created (`src/tools/story_assembler.py` + `.opencode/tools/story-assembler.ts`); orchestrator updated to invoke it; output path specified as `stories/<name>/output/story.md`

**★☆☆ Singular (fixed)**
- [S-C-01] `wiki_snapshot.py` `_enforce_token_budget` now drops pages by ascending relevance score after L1 demotion is exhausted
- [S-C-03] `critique_runner.py` savepoint namespace collision fixed — `critique_results_iteration_{N}` → `{mode}_critique_results_iteration_{N}`
- [S-W-01] Analysis chunk savepoint paths aligned: `analysis_chunk_{category}` → `story_analysis/{chunk_type}_chunk` in docs
- [S-W-02] Savepoint name mismatch documented: `initial_outline` (tool level) vs `outline_complete` (orchestrator checkpoint)
- [S-W-03] Phase 8a expanded outline field specified as `chapters.{N}.expanded_outline`
- [S-W-04] Post-revision re-runs added to Phase 8f: wiki-maintainer, recap, wiki-lint
- [S-W-05] `generate-elements` stdout reduced: returns `{"savepoint": "story_elements"}` instead of full content
- [S-W-06] Unimplemented flags (`enable_final_edit`, `enable_scrubbing`) marked as planned-only in orchestrator
- [S-W-07] Scene savepoint redundancy resolved: agent instructions clarified that `scene-writer` writes savepoints internally
- [S-W-08] Orphaned enrichment integration section removed from `create_chunk.md`
- [S-I-02] `context-budgeting` SKILL.md scoring formula updated to match code
- [S-I-03] Orphaned scene summary/title savepoints removed from chapter-writer instructions
- [S-I-04] `critique_runner.py` hardcoded threshold 85.0 addressed via newly namespaced savepoints
- [S-I-05] `next_chapter_synopsis` now populated from `chapters.{N+1}.outline` in chapter-writer

**Not addressed (config/runtime)**
- [S-C-02] Context window mismatch (65k vs 16384) — this is a runtime Ollama config the user must set; not codeable