### PR TITLE
Offload prose scrub and voice analysis LLM calls from prose-scrubber and final-editor agents to scene-writer tool

### DIFF
--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -90,6 +90,7 @@ Based on the changes, determine what documentation needs to be created or update
 > - For inventory tables (tools, collections, agents, categories): cross-check table entries against the actual source of truth on disk (e.g., `ls .opencode/tools/` for tool tables, `ls src/tools/` for script tables). Verify both that every row has a matching file AND that every file has a matching row — pre-existing missing entries compound with new additions to produce wrong counts.
 > - No hardcoded URLs — reference the project's routing conventions instead.
 > - Scan the entire file for `TODO`, `[placeholder]`, `...` stubs, and trivially short sections (3 lines or fewer where substance is expected). Remove or complete them before committing.
+> - For behavioral descriptions (routing logic, model selection, configuration options, feature flags): read the actual implementation to confirm the described behavior is present in the code. The issue description often contains planned behaviors that were not implemented — do not document them as if they were. Every behavioral claim in the docs must be verifiable in the current codebase by reading the relevant source file.
 
 Follow these conventions:
 

--- a/.github/agents/test-writer.agent.md
+++ b/.github/agents/test-writer.agent.md
@@ -57,6 +57,8 @@ Follow the test conventions and patterns established in the project (see `copilo
 
 **Custom URI schemes:** When testing functions that parse URI-format strings with project-specific schemes (e.g., `lm_studio://`, `llama_cpp://`), write at least one positive-path test per supported scheme. Python's `urlparse` silently ignores schemes containing underscores (see `gotchas.md` #006), so a positive-path assertion is the only reliable guard against silent parsing regressions — negative-path tests alone are insufficient.
 
+**LLM-response parse-error paths:** When writing tests for CLI tool operations that send a prompt to an LLM and parse the response as JSON (`json.loads()`), always include a test for the JSON decode failure path. Mock the LLM call to return a non-JSON string (e.g., `"not valid json"` or `""`), and assert the process exits with a non-zero return code (typically 1). Name these tests `test_<operation>_json_parse_error_exits`. This exit path is as mandatory as the happy path — reviewers will flag its absence unanimously. A tool that lacks this test has unverified error handling on a failure mode that LLMs produce regularly.
+
 After writing each test, run the project's test command (see `copilot-instructions.md`).
 
 ### 3. Classify Results

--- a/.github/notes/reflections/issue-134-documenter-unimplemented-feature.md
+++ b/.github/notes/reflections/issue-134-documenter-unimplemented-feature.md
@@ -1,0 +1,38 @@
+---
+date: "2026-04-23"
+issue: 134
+pr: 141
+category: agent
+targets:
+  - ".github/agents/documenter.agent.md"
+severity: minor
+status: active
+---
+
+## Documenter documents unimplemented feature behavior as implemented
+
+### Finding
+
+During issue #134 (PR #141, `feat/issue-134-scene-writer-scrub-voice-ops`), the Documenter wrote documentation stating that `scrub_model` is used for the scrub operation while `model` is used for voice analysis — a description of two separate model routing paths. This behavior was not implemented in the production code; only a single `--model` parameter exists on the CLI. The discrepancy was caught by two of three reviewers (GPT + Gemini). The Claude reviewer did not flag it.
+
+The Documenter's Step 3 verification checklist includes rules for output formats, file extensions, directory trees, inventory tables, and code blocks — but no explicit rule about behavioral prose. The Documenter read the issue description (which contained planning language about `scrub_model`) and incorporated it into the documentation as if it were implemented.
+
+### Observation
+
+The issue description and planning materials often contain proposed behaviors that were scoped out, deferred, or reconsidered during implementation. The Documenter has access to both the issue body and the PR diff. When the issue mentions `scrub_model` but the PR diff shows only `--model`, the Documenter should identify the discrepancy and document only what the PR actually implements.
+
+The existing rule "read the Python tool's `cmd_*` functions to verify the exact JSON structure returned" is close in intent but is framed around output format verification, not behavioral claim verification. There is no equivalent rule for routing logic, configuration options, or stated feature capabilities described in prose sections.
+
+This is distinct from the output-format inaccuracy in issue #7 (wrong file extension, wrong return type) — that was a structural fact. This is a **scope creep in documentation**: the Documenter documented the planned scope, not the implemented scope. Both lead to inaccurate docs, but the trigger and the fix are different.
+
+### Suggested Improvement
+
+Add a verification bullet to the Documenter's Step 3 checklist, after the "Scan for TODO stubs" bullet, covering behavioral claims:
+
+```markdown
+> - For behavioral descriptions (routing logic, model selection, configuration options, feature flags): read the actual implementation to confirm the described behavior is present in the code. The issue description often contains planned behaviors that were not implemented — do not document them as if they were. Every behavioral claim in the docs must be verifiable in the current codebase by reading the relevant source file.
+```
+
+### Action Taken
+
+Applied: added behavioral-description verification bullet to `.github/agents/documenter.agent.md` in the Step 3 checklist.

--- a/.github/notes/reflections/issue-134-llm-parse-error-test-coverage.md
+++ b/.github/notes/reflections/issue-134-llm-parse-error-test-coverage.md
@@ -1,0 +1,40 @@
+---
+date: "2026-04-23"
+issue: 134
+pr: 141
+category: agent
+targets:
+  - ".github/agents/test-writer.agent.md"
+severity: minor
+status: active
+---
+
+## Test Writer omits LLM-response JSON parse-error path tests
+
+### Finding
+
+During issue #134 (PR #141, `feat/issue-134-scene-writer-scrub-voice-ops`), the Test Writer wrote 7 tests for the new `scrub-analyze` and `voice-analyze` operations in `scene_writer.py`, but omitted `test_voice_analyze_json_parse_error_exits`. The `voice-analyze` operation calls an LLM and parses the response as JSON; if `json.loads()` fails, the tool is expected to exit with a non-zero code. This exit path had no test coverage until the post-review fix pass.
+
+The gap was caught unanimously by all three code reviewers. The Test Writer's existing guidance covers argparse validation errors (`returncode == 2`), infrastructure adapter error paths (issue #85 proposal), and graceful degradation paths (issue #92), but contains no explicit rule about testing LLM-response JSON decode failures.
+
+### Observation
+
+CLI tool operations that call an LLM and then parse the response as JSON have a distinct and predictable failure mode: `json.loads()` raises `JSONDecodeError` when the LLM returns malformed output (hallucinated text, truncated tokens, empty string). The caller typically wraps this in a `try/except` and calls `sys.exit(1)`. This failure mode is not covered by:
+
+- The "infrastructure adapter error paths" guidance (which addresses HTTP-level failures and provider classes)
+- The "CLI validation assertions" guidance (which addresses argparse argument parsing)
+- The "error handling" priority level (which is present but too general to trigger LLM-parse-path awareness)
+
+The absence is structural: the Test Writer has named guidance blocks for every known error-path category *except* LLM-output parsing. Reviewers caught the gap; the Test Writer should have too.
+
+### Suggested Improvement
+
+Add a named guidance block for LLM-response parse-error paths to the Test Writer's "Write Tests" section, after the existing "Custom URI schemes" block:
+
+```markdown
+**LLM-response parse-error paths:** When writing tests for CLI tool operations that send a prompt to an LLM and parse the response as JSON (`json.loads()`), always include a test for the JSON decode failure path. Mock the LLM call to return a non-JSON string (e.g., `"not valid json"` or `""`), and assert the process exits with a non-zero return code (typically 1). Name these tests `test_<operation>_json_parse_error_exits`. This exit path is as mandatory as the happy path — reviewers will flag its absence unanimously. A tool that lacks this test has unverified error handling on a failure mode that LLMs produce regularly.
+```
+
+### Action Taken
+
+Applied: added "LLM-response parse-error paths" named block to `.github/agents/test-writer.agent.md` after the "Custom URI schemes" block.

--- a/.github/notes/reviews/2026-04-23-pr141-claude-raw.md
+++ b/.github/notes/reviews/2026-04-23-pr141-claude-raw.md
@@ -1,0 +1,86 @@
+# Code Review Report — PR #141
+
+**Branch:** `feat/issue-134-scene-writer-scrub-voice-ops`
+**Reviewer:** Claude (Sonnet 4.6)
+**Date:** 2026-04-23
+**Base:** `development`
+
+---
+
+## Review Summary
+
+This PR moves the prose-analysis LLM calls for `scrub-analyze` and `voice-analyze` operations from agent-level `prompt-loader` + inline LLM steps into two new `scene-writer` operations (`cmd_scrub_analyze`, `cmd_voice_analyze`). Both `prose-scrubber` and `final-editor` agents are updated to call the tool directly, eliminating `prompt-loader` from their tool tables and workflow steps. The implementation is clean, the documentation is thorough, and the agent contracts are consistent with the Python CLI. One meaningful test gap was found (missing JSON parse error coverage for `voice-analyze`), and one style pattern carries forward a pre-existing convention violation.
+
+**Files Reviewed:** 8
+**Findings:** 0 Critical, 1 Warning, 2 Suggestion
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] Missing JSON parse-error test for voice-analyze
+Category: Testing
+Severity: Warning
+File: tests/unit/test_scene_writer.py
+Lines: general
+Description: test_scrub_analyze_json_parse_error_exits (test 13) verifies that an
+  unparseable LLM response causes cmd_scrub_analyze to call _error() and raise
+  SystemExit. The symmetric case for cmd_voice_analyze is absent. Both functions
+  share identical error handling — the same LLM garbage-response path exists in both
+  and should be covered symmetrically. The omission means a regression in voice-analyze's
+  error path would not be caught by the test suite.
+Suggestion: Add test_voice_analyze_json_parse_error_exits alongside the existing scrub test:
+
+    def test_voice_analyze_json_parse_error_exits(patched_env, monkeypatch):
+        _stories_dir, name = patched_env
+        monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: "not json")
+        with pytest.raises(SystemExit):
+            sw.cmd_voice_analyze(name, 1, "Chapter text", model="test")
+```
+
+---
+
+### Suggestions
+
+```
+[S-01] Import of _extract_json_block inside try block violates module-level import convention
+Category: Style
+Severity: Suggestion
+File: src/tools/scene_writer.py
+Lines: cmd_scrub_analyze and cmd_voice_analyze function bodies
+Description: Both new functions import _extract_json_block from src.tools._llm inside
+  the try block rather than at module level. The project convention (copilot-instructions.md)
+  requires imports at module level, not inside functions or loops. This is a pre-existing
+  pattern in cmd_parse_definitions in the same file, so the new functions are consistent
+  with the file's current style, but each new occurrence compounds the drift. An
+  ImportError from the _llm module would propagate uncaught and produce an opaque
+  traceback rather than a clean error message.
+Suggestion: Move the import to the top of the file with the other src.tools imports, or
+  add it to the TYPE_CHECKING block and use a runtime import only if needed.
+  As a minimum, address as part of a future file-level cleanup so the pattern doesn't
+  spread further.
+```
+
+```
+[S-02] No CLI tests for missing --chapter-num in scrub-analyze and voice-analyze
+Category: Testing
+Severity: Suggestion
+File: tests/unit/test_scene_writer.py
+Lines: general
+Description: The validation path _error("--chapter-num is required for scrub-analyze")
+  and its voice-analyze counterpart are untested via the CLI subprocess path. The
+  missing-chapter-text cases are covered (tests 16 and 17), but the missing-chapter-num
+  guard is not. The omission is minor — both paths are simple argparse guard clauses —
+  but symmetric coverage would complete the CLI contract tests for the new operations.
+Suggestion: Add two tests mirroring test_scrub_analyze_cli_missing_chapter_text but
+  omitting --chapter-num rather than --chapter-text.
+```
+
+---
+
+## Overall Assessment
+
+The PR is ready to merge. The implementation is correct, the agent contracts accurately reflect the Python CLI and Zod schema, the documentation is comprehensive, and all structural checks pass cleanly. The `prompt-loader` removal is complete: both agent tool tables and workflow bodies have been updated, and no stale references remain in companion files (`final-edit/SKILL.md`, `story-pipeline/SKILL.md` Phase 7.5 row, `story-orchestrator.md`). The single warning — missing `test_voice_analyze_json_parse_error_exits` — closes a minor asymmetric coverage gap for an error path that is identical to the already-tested scrub equivalent. It is low risk but worth adding before or shortly after merge.

--- a/.github/notes/reviews/2026-04-23-pr141-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-23-pr141-gemini-raw.md
@@ -1,0 +1,42 @@
+# Code Review Report — PR #141
+
+### Review Summary
+
+This PR successfully moves the prose-analysis LLM calls for `scrub-analyze` and `voice-analyze` operations out of the agent layer and into the `scene-writer` Python tool, establishing a more deterministic and centralized pipeline. The agent and documentation updates are mostly complete and effectively drop the `prompt-loader` dependency. The primary findings are a minor asymmetry in test coverage for JSON errors and a missed model override parameter in the `prose-scrubber` subagent.
+
+**Files Reviewed:** 8
+**Findings:** 0 Critical, 2 Warning, 1 Suggestion
+
+### Findings
+
+#### Warning Findings
+
+[W-01] Dropped `scrub_model` parameter from prose-scrubber instructions
+Category: Correctness
+Severity: Warning
+File: .opencode/agents/prose-scrubber.md
+Lines: 42
+Description: The original Step 5 of `prose-scrubber` instructed the agent to "Run the scrub analysis with the `scrub_model` role." The updated Step 4 replaces this with a call to the `scene-writer` tool but omits any instruction about the model. However, `docs/features/story-orchestrator.md` correctly notes that it should "return structured issues using the `scrub_model` named model role when configured". Without explicit instruction in the agent file, the agent will not pass `model: "scrub_model"` to the `scene-writer` tool parameter, causing it to fall back to the default LLM.
+Suggestion: Update Step 4 in `.opencode/agents/prose-scrubber.md` to instruct the agent to pass the `scrub_model` role: `Call scene-writer with operation: "scrub-analyze", name: story_name, chapterNum: chapter_number, chapterText: <chapter_text>, and model: "scrub_model" (if configured in environment).`
+
+[W-02] Missing test for voice-analyze JSON parse error
+Category: Testing
+Severity: Warning
+File: tests/unit/test_scene_writer.py
+Lines: general (around line 500)
+Description: The test suite includes `test_scrub_analyze_json_parse_error_exits` to verify that `cmd_scrub_analyze` gracefully catches a `json.JSONDecodeError` and exits via `_error` when the LLM returns completely malformed output. The exact same error path exists in the new `cmd_voice_analyze` function but lacks an equivalent test (e.g., `test_voice_analyze_json_parse_error_exits`).
+Suggestion: Add a `test_voice_analyze_json_parse_error_exits` test to close the asymmetrical coverage gap.
+
+#### Suggestions
+
+[S-01] Missing `sceneNum` in verified tool contracts
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/final-editor.md, .opencode/agents/prose-scrubber.md
+Lines: 19 (approx)
+Description: The `scene-writer` Verified Contract column in the Tools table for both `final-editor` and `prose-scrubber` does not list the `sceneNum` argument. The workflow steps explicitly instruct the agent to "use its index as `sceneNum`" for the `revise` operation, so omitting it from the table makes the agent's internal contract interface slightly inconsistent.
+Suggestion: Add `sceneNum` to the parameter list in the Verified Contract column for `scene-writer` in both `.opencode/agents/final-editor.md` and `.opencode/agents/prose-scrubber.md`.
+
+### Overall Assessment
+
+The code is architecturally sound, thoroughly documented, and mostly ready for merge. The changes correctly align with the hybrid agent-tool pattern by centralizing prompt logic inside the Python scripts. There are no critical blockers, but the omission of the `scrub_model` instruction in the `prose-scrubber` agent breaks configuration intent and should be fixed before merge. Test coverage is strong, with only one minor missing test for the voice analysis error path.

--- a/.github/notes/reviews/2026-04-23-pr141-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-23-pr141-gpt-raw.md
@@ -1,0 +1,42 @@
+# Code Review Report
+
+## Review Summary
+
+This PR is focused and architecturally sound: it moves prose-analysis prompt orchestration out of agents and into deterministic `scene-writer` operations, then updates the two prose-pass agents and their docs to match. The TypeScript wrapper, Python CLI dispatch, and the new unit tests are wired coherently, and a focused validation run of `pytest tests/unit/test_scene_writer.py -q` passed. Two issues remain: the new analysis handlers do not validate the shape of LLM JSON before dereferencing it, and the updated docs now promise `scrub_model` routing that the agent explicitly says is not implemented yet.
+
+**Files Reviewed:** 8
+**Findings:** 0 Critical, 2 Warning, 1 Suggestion
+
+## Findings
+
+### Warning Findings
+
+[W-01] `scrub-analyze` and `voice-analyze` trust LLM JSON shape without validation
+Category: Correctness
+Severity: Warning
+File: src/tools/scene_writer.py
+Lines: 305-306, 335-336
+Description: Both new analysis commands parse arbitrary LLM output and then immediately call `result.get("issues", [])`. That is only safe if the decoded JSON is an object with a list-valued `issues` field. If the model returns a valid JSON array, string, or an object whose `issues` member is not a list, the tool either crashes with an uncaught `AttributeError` or reports a meaningless `issues_found` count such as the character length of a string. This is a system-boundary validation gap on untrusted model output.
+Suggestion: Validate the decoded payload explicitly before success output. For example, require `isinstance(result, dict)` and `isinstance(result.get("issues", []), list)`, and route invalid shapes through `_error(...)` with a clear message.
+
+[W-02] Prose-pass docs advertise `scrub_model` routing that the agent workflow does not implement
+Category: Documentation
+Severity: Warning
+File: docs/features/story-orchestrator.md
+Lines: 256, 361
+Description: The updated docs now state that `prose-scrubber` runs `scene-writer scrub-analyze` using the `scrub_model` named model role and that it "reads `scrub_model` when configured." That is not the implemented contract. The updated agent workflow in `.opencode/agents/prose-scrubber.md` does not pass a `model` argument to `scene-writer`, and the agent itself explicitly says dynamic model routing is still aspirational pending platform support. As written, the docs promise configuration behavior users cannot actually rely on.
+Suggestion: Make the docs match the current runtime behavior: say the default agent model is used today, or implement end-to-end model propagation from config into the `scene-writer` `model` parameter before documenting it as supported.
+
+### Suggestions
+
+[S-01] Add the missing parse-error regression test for `voice-analyze`
+Category: Testing
+Severity: Suggestion
+File: tests/unit/test_scene_writer.py
+Lines: 455-574
+Description: The new test block covers success, empty-issues, and CLI validation paths for both operations, but only `scrub-analyze` has a direct invalid-JSON failure test. `voice-analyze` has the same `_extract_json_block` plus `json.loads(...)` failure path and should be covered symmetrically. The omission leaves one of the two new operations without regression coverage for its main error branch.
+Suggestion: Add a `test_voice_analyze_json_parse_error_exits` case mirroring `test_scrub_analyze_json_parse_error_exits`, with `_call_llm` returning non-JSON text and an assertion that `SystemExit` is raised.
+
+## Overall Assessment
+
+The change is close to merge-ready, and the main design choice in this PR is the right one: prose analysis belongs in the tool layer, not in agent-side prompt choreography. The narrow unit test file passes, the tool wrapper and CLI are aligned, and the agent workflows are materially simpler. I would fix the response-shape validation before merge because it affects runtime robustness on untrusted LLM output, and I would correct the `scrub_model` documentation in the same PR so the published contract does not overstate current capabilities.

--- a/.github/notes/reviews/2026-04-23-pr141-synthesis.md
+++ b/.github/notes/reviews/2026-04-23-pr141-synthesis.md
@@ -1,0 +1,261 @@
+# Synthesized Code Review — PR #141
+
+**Branch:** `feat/issue-134-scene-writer-scrub-voice-ops`
+**Review Type:** Multi-model synthesis (Claude Sonnet 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Base:** `development`
+**Date:** 2026-04-23
+**Synthesized by:** GitHub Copilot (Synthesizing Reviewer)
+
+---
+
+## Synthesis Overview
+
+PR #141 moves two prose-analysis LLM operations (`scrub-analyze`, `voice-analyze`) from agent-level prompt orchestration into the `scene-writer` Python tool, and updates the `prose-scrubber` and `final-editor` agents accordingly. All three reviewers assessed the same eight files and reached strong agreement on the key test coverage gap. Agreement on a documentation accuracy issue was split 2-vs-1, with divergence primarily in the proposed resolution direction. One unique correctness concern surfaced from a single model regarding unguarded LLM JSON shape assumptions. The PR is close to merge-ready with two findings warranting attention before or immediately after merge.
+
+**Model Agreement Score:** 7/10 — unanimous on the most important finding; solid 2/3 agreement on the second; independent singletons for the remaining four findings.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- |
+| Claude | Ready to merge | Style: function-level import pattern; CLI validation test gaps | 0 | 1 |
+| GPT    | Close to merge-ready | Correctness: unguarded LLM JSON shape access; docs overstating scrub_model | 0 | 2 |
+| Gemini | Mostly ready, one pre-merge fix | Agent instructions missing scrub_model routing step; sceneNum in tool contracts | 0 | 2 |
+
+**Claude** focused on test symmetry and style conventions — specifically the function-level `_extract_json_block` import and the absent `--chapter-num` CLI tests — giving a broadly positive overall verdict. **GPT** was the most technically rigorous on runtime correctness, flagging the unvalidated `result.get("issues", [])` call and identifying that the docs overstate current `scrub_model` capability. **Gemini** agreed on the scrub_model gap but diagnosed the wrong fix direction (updating agent instructions rather than the docs), and uniquely noticed the missing `sceneNum` entry in agent tool-contract tables.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+```
+[U-W-01] Missing voice-analyze JSON parse error test
+Severity: Warning (2/3 models) — one model rated Suggestion
+Category: Testing
+File: tests/unit/test_scene_writer.py
+Lines: After line 537 (no test_voice_analyze_json_parse_error_exits exists)
+Detail: test_scrub_analyze_json_parse_error_exits (test 13) verifies that
+  unparseable LLM output causes cmd_scrub_analyze to call _error() and raise
+  SystemExit. The identical error path exists in cmd_voice_analyze — both
+  functions call _extract_json_block then json.loads inside the same try/except
+  structure — but no equivalent test exists for voice-analyze. Confirmed via
+  grep: tests 14–17 cover voice-analyze success, empty-issues, and
+  CLI-missing-chapter-text, but no json-parse-error case. A regression in
+  voice-analyze's error handling would not be caught.
+Models: Claude ✓  GPT ✓  Gemini ✓
+Suggestion: Add test_voice_analyze_json_parse_error_exits immediately after
+  test 15:
+
+    def test_voice_analyze_json_parse_error_exits(patched_env, monkeypatch):
+        _stories_dir, name = patched_env
+        monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: "not json")
+        with pytest.raises(SystemExit):
+            sw.cmd_voice_analyze(name, 1, "Chapter text", model="test")
+```
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-W-01] Docs overstate scrub_model routing as implemented capability
+Severity: Warning
+Category: Documentation
+File: docs/features/story-orchestrator.md
+Lines: 256, 361
+Detail: Lines 256 and 361 state — in present tense with no qualification —
+  that prose-scrubber "returns structured issues using the scrub_model named
+  model role when configured" and "reads scrub_model when configured." In
+  reality, .opencode/agents/prose-scrubber.md line 26 explicitly marks this
+  behaviour as aspirational: "(Aspirational — pending platform support for
+  dynamic model routing.) When the platform supports per-call model overrides,
+  use the scrub_model role from story config. Until then, the default agent
+  model is used." The agent steps (line 42) confirm that no model argument is
+  passed to scene-writer today. The docs lead users to believe a configuration
+  knob is actionable when it is not yet wired end-to-end.
+Models: Claude ✗  GPT ✓  Gemini ✓
+Dissenting view: Claude did not surface this finding. Claude judged the agent
+  contracts to accurately reflect the Python CLI and found no stale references.
+Suggestion: Add the same aspirational qualifier to docs/features/
+  story-orchestrator.md at both locations. For example: "…using the scrub_model
+  named model role when configured. (Aspirational — not yet implemented
+  end-to-end; the default agent model is used until platform support for
+  per-call model overrides is available.)"
+  Do NOT update prose-scrubber.md agent instructions to add model: "scrub_model"
+  — the agent already correctly documents the limitation. The docs are the
+  source of the discrepancy.
+```
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] Unguarded LLM JSON shape assumption in scrub-analyze and voice-analyze
+Severity: Warning (GPT-rated)
+Category: Correctness
+File: src/tools/scene_writer.py
+Lines: 305–306, 335–336
+Detail: Both cmd_scrub_analyze and cmd_voice_analyze call result.get("issues", [])
+  immediately after json.loads without first asserting that result is a dict.
+  json.loads on a valid JSON string, array, or number returns a non-dict; calling
+  .get() on those types raises AttributeError, which propagates uncaught outside
+  the except json.JSONDecodeError block. In practice the structured prompt makes
+  a non-dict response unlikely, but this is a system-boundary validation gap on
+  untrusted model output.
+Model: GPT
+Assessment: Genuine finding. Confirmed by reading scene_writer.py lines 305 and
+  335 — neither function has an isinstance(result, dict) guard. The other two
+  models reviewed the same lines and did not flag it, likely treating the
+  structured-prompt precondition as sufficient. Given the project's explicit
+  boundary-validation rule (AGENTS.md: "Always validate at system boundaries"),
+  this is worth addressing. Risk is low in normal operation but the failure mode
+  — an unhandled AttributeError — is opaque and difficult to diagnose.
+```
+
+```
+[S-I-02] _extract_json_block imported inside function body rather than at module level
+Severity: Suggestion
+Category: Style
+File: src/tools/scene_writer.py
+Lines: cmd_scrub_analyze and cmd_voice_analyze function bodies
+Detail: Both new functions import _extract_json_block from src.tools._llm inside
+  the try block, continuing a pre-existing pattern from cmd_parse_definitions.
+  Project convention (copilot-instructions.md) calls for module-level imports.
+  Each new function compounds the drift; an ImportError from _llm would propagate
+  uncaught.
+Model: Claude
+Assessment: Minor style drift. Genuine but low-priority — the pre-existing
+  pattern means this is not newly introduced. Best addressed in a follow-up
+  file-level cleanup rather than blocking this PR.
+```
+
+```
+[S-I-03] No CLI tests for missing --chapter-num in scrub-analyze or voice-analyze
+Severity: Suggestion
+Category: Testing
+File: tests/unit/test_scene_writer.py
+Lines: After test 17 (~line 593)
+Detail: The CLI validation path _error("--chapter-num is required for
+  scrub-analyze") and its voice-analyze counterpart exist (scene_writer.py
+  lines 484, 498) but are not covered by any test. The missing-chapter-text
+  paths are tested (tests 16–17), but the missing-chapter-num guard is not.
+Model: Claude
+Assessment: Genuine gap. Low risk — these are simple argparse guard clauses —
+  but symmetric CLI contract coverage would be consistent with the pattern
+  established by tests 16 and 17.
+```
+
+```
+[S-I-04] sceneNum absent from Verified Contract column in agent tool tables
+Severity: Suggestion
+Category: Documentation
+File: .opencode/agents/final-editor.md, .opencode/agents/prose-scrubber.md
+Lines: approx line 19 in each file
+Detail: The scene-writer Verified Contract parameter list in both agent tool
+  tables does not include sceneNum, despite the workflow steps instructing the
+  agent to pass it for the revise operation.
+Model: Gemini
+Assessment: Minor contract completeness gap. The omission does not affect
+  runtime behaviour (the parameter is described in the workflow steps). Worth
+  a quick addition to keep the tool-table contracts authoritative.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: scrub_model fix direction
+Claude says: No issue surfaced. Agent contracts were assessed as accurate.
+GPT says:    Docs overstate the current capability; fix the docs to remove
+             the unsupported scrub_model claim (or implement the routing).
+Gemini says: Agent instructions should be updated to add model: "scrub_model"
+             to the Step 4 call, bringing agent behaviour in line with the docs.
+Assessment:  GPT is correct. prose-scrubber.md line 26 explicitly marks
+             scrub_model routing as "(Aspirational — pending platform support
+             for dynamic model routing.)" — the agent already correctly
+             describes the limitation. Implementing Gemini's suggestion would
+             instruct the agent to pass a parameter that the platform cannot
+             yet route, introducing misleading behaviour. The fix is to bring
+             the docs down to match the agent's documented reality, not to
+             elevate the agent instructions to match inaccurate docs.
+Resolution:  [M-W-01] is treated as a documentation fix to story-orchestrator.md,
+             not an agent instruction change. Gemini's suggestion is set aside.
+```
+
+```
+[D-02] Topic: Severity of missing voice-analyze JSON parse error test
+Claude says: Warning — a regression in voice-analyze's error path would not
+             be caught by the test suite.
+GPT says:    Suggestion — described as a coverage gap but not a blocker.
+Gemini says: Warning — named as a pre-merge fix recommendation.
+Assessment:  2-vs-1 split. The 2/3 majority (Claude, Gemini) assigning Warning
+             is more defensible: the error path is identical to the already-tested
+             scrub equivalent, and asymmetric coverage of an error handler is a
+             substantive gap, not merely a style preference.
+Resolution:  [U-W-01] carries Warning severity.
+```
+
+```
+[D-03] Topic: Unguarded result.get() — GPT unique, others silent
+Claude says: (Not reported)
+GPT says:    Warning — AttributeError risk on non-dict JSON response at
+             scene_writer.py lines 305-306 and 335-336.
+Gemini says: (Not reported)
+Assessment:  Both Claude and Gemini reviewed the same lines without flagging
+             the shape assumption. GPT's finding is technically correct —
+             json.loads can return a non-dict and .get() is not defined on
+             non-dicts — and aligns with the project boundary-validation
+             principle. The silence of the other two models likely reflects
+             an implicit reliance on the prompt guaranteeing dict output
+             rather than a deliberate dismissal. Treated as a genuine
+             singular finding at Suggestion severity (downgraded one tier
+             from GPT's Warning due to 1/3 consensus and low practical risk).
+Resolution:  [S-I-01] retained as Suggestion.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [U-W-01] ★★★ Fix: Add test_voice_analyze_json_parse_error_exits
+            (Warning — all three models agree)
+
+2. [M-W-01] ★★☆ Fix: Add aspirational qualifier to docs/features/story-orchestrator.md
+            lines 256 and 361 to match the existing prose-scrubber.md note
+            (Warning — 2/3 models agree; fix direction confirmed by GPT)
+
+3. [S-I-01] ★☆☆ Consider: Add isinstance(result, dict) guard before
+            result.get("issues", []) in cmd_scrub_analyze and cmd_voice_analyze
+            (Suggestion — 1 model only; genuine boundary-validation gap)
+
+4. [S-I-04] ★☆☆ Consider: Add sceneNum to Verified Contract column in
+            final-editor.md and prose-scrubber.md tool tables
+            (Suggestion — 1 model only; minor completeness gap)
+
+5. [S-I-03] ★☆☆ Consider: Add CLI tests for missing --chapter-num in
+            scrub-analyze and voice-analyze
+            (Suggestion — 1 model only; low risk, symmetric with tests 16-17)
+
+6. [S-I-02] ★☆☆ Defer: Move _extract_json_block import to module level
+            (Suggestion — 1 model only; pre-existing pattern, follow-up cleanup)
+```
+
+---
+
+## Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 1       | 0          |
+| ★★☆ Majority      | 0        | 1       | 0          |
+| ★☆☆ Singular      | 0        | 0       | 4          |
+| **Total**         | **0**    | **2**   | **4**      |
+
+**Overall Assessment:** Needs Fixes — two Warning findings (actions 1 and 2) are recommended before or immediately after merge. No critical blockers. Four low-priority suggestions can be deferred.

--- a/.opencode/agents/final-editor.md
+++ b/.opencode/agents/final-editor.md
@@ -16,9 +16,8 @@ Load `.opencode/skills/final-edit/SKILL.md` before proceeding. Follow its scope 
 | Tool | Purpose | Verified Contract |
 |------|---------|-------------------|
 | `story-state` | Read assembled chapter texts, update revised chapter entries | `operation`: `init`\|`read`\|`write`\|`list`, `name`, `field`, `value` |
-| `scene-writer` | Apply targeted chapter prose revisions | `operation`: `parse-definitions`\|`generate`\|`revise`\|`assemble-chapter`, `name`, `chapterNum`, `sceneContent`, `feedback`, `model` |
+| `scene-writer` | Analyze chapter prose and apply targeted revisions | `operation`: `parse-definitions`\|`generate`\|`revise`\|`assemble-chapter`\|`scrub-analyze`\|`voice-analyze`, `name`, `chapterNum`, `sceneContent`, `feedback`, `chapterText`, `priorChaptersSummary`, `model` |
 | `rag-query` | Query story-wide chapter context for prior voice/context examples | `operation`: `index`\|`query`, `name`, `query`, `contentType`, `nResults` |
-| `prompt-loader` | Load `final_edit/voice_consistency_pass` and `final_edit/prose_scrub` templates | `promptId`, `variables` |
 | `savepoint-mgr` | Create per-chapter and completion checkpoints | `operation`: `save`\|`load`\|`has`\|`list`\|`list-full`\|`clear`, `name`, `step`, `data` |
 
 You call tools only — never dispatch subagents.
@@ -41,11 +40,11 @@ You call tools only — never dispatch subagents.
    - Extract the current chapter text from the first populated text-bearing field in this order: `content`, `text`, `chapter_text`, `assembled`. If no text-bearing field exists, record `needs_review` for that chapter and continue.
    - Query prior context via `rag-query` with `operation: "query"`, `name: story_name`, `contentType: "chapter"`, `query: "voice consistency, pacing, character voice, tone, and continuity for chapters before chapter {N}"`, `nResults: 5`.
    - Distill the retrieved chunks into a concise `prior_chapters_summary` string for prompt substitution.
-   - Load the voice analysis prompt with `prompt-loader` using `promptId: "final_edit/voice_consistency_pass"` and variables `chapter_text` and `prior_chapters_summary`.
-   - Run the voice, pacing, and coherence analysis. Parse the returned JSON object.
+   - Call `scene-writer` with `operation: "voice-analyze"`, `name: story_name`, `chapterNum: N`, `chapterText: <chapter_text>`, `priorChaptersSummary: <prior_summary>`.
+   - Use the returned `{ issues: [...], issues_found: N }` payload for the voice, pacing, and coherence analysis results.
    - For up to 3 issues from the voice analysis that include a non-empty `suggested_fix`, identify the most likely matching scene by correlating the issue `location` with the scenes list. If a specific scene is identifiable, use its index as `sceneNum`; if no specific scene can be identified, use `sceneNum: 1` as the default. Call `scene-writer` with `operation: "revise"`, `name: story_name`, `chapterNum: N`, `sceneNum`, `sceneContent: current chapter text`, and `feedback` set to a surgical revision instruction anchored to the issue `location`, `description`, and `suggested_fix`. After each successful revision, replace the in-memory chapter text with the returned text.
-   - Load the scrub prompt with `prompt-loader` using `promptId: "final_edit/prose_scrub"` and variables `chapter_text` and `chapter_number`.
-   - Run the scrub analysis. Parse the returned JSON object.
+   - Call `scene-writer` with `operation: "scrub-analyze"`, `name: story_name`, `chapterNum: N`, `chapterText: <chapter_text>`.
+   - Use the returned `{ issues: [...], issues_found: N }` payload for the scrub analysis results.
    - For up to 3 scrub issues with actionable `suggested_replacement`, identify the most likely matching scene by correlating the issue `line_context` with the scenes list. If a specific scene is identifiable, use its index as `sceneNum`; if no specific scene can be identified, use `sceneNum: 1` as the default. Call `scene-writer` with `operation: "revise"`, `name: story_name`, `chapterNum: N`, `sceneNum`, `sceneContent: current chapter text`, and `feedback` set to a local revision instruction using the issue `original_text`, `line_context`, and `suggested_replacement`. After each successful revision, replace the in-memory chapter text with the returned text.
    - Write the revised chapter object back through `story-state` with `operation: "write"`, `name: story_name`, `field: "chapters.{N}"`, and `value` equal to the updated chapter object as a JSON string. Preserve all sibling fields. Update the existing text-bearing field that was originally present; if none was present, write the revised text to `content`.
    - Create a savepoint with `savepoint-mgr` using `operation: "save"`, `name: story_name`, `step: "chapter_{N}_final_edited"`, and `data` set to a JSON string containing the chapter number, issues found, revisions made, and status token.

--- a/.opencode/agents/prose-scrubber.md
+++ b/.opencode/agents/prose-scrubber.md
@@ -16,8 +16,7 @@ Load `.opencode/skills/final-edit/SKILL.md` before proceeding.
 | Tool | Purpose | Verified Contract |
 |------|---------|-------------------|
 | `story-state` | Read and write chapter text in story state | `operation`: `init`\|`read`\|`write`\|`list`, `name`, `field`, `value` |
-| `scene-writer` | Apply prose revisions | `operation`: `parse-definitions`\|`generate`\|`revise`\|`assemble-chapter`, `name`, `chapterNum`, `sceneContent`, `feedback`, `model` |
-| `prompt-loader` | Load the scrub analysis prompt | `promptId`, `variables` |
+| `scene-writer` | Analyze prose issues and apply prose revisions | `operation`: `parse-definitions`\|`generate`\|`revise`\|`assemble-chapter`\|`scrub-analyze`\|`voice-analyze`, `name`, `chapterNum`, `sceneContent`, `feedback`, `chapterText`, `priorChaptersSummary`, `model` |
 | `savepoint-mgr` | Create chapter scrub checkpoints | `operation`: `save`\|`load`\|`has`\|`list`\|`list-full`\|`clear`, `name`, `step`, `data` |
 
 You call tools only — never dispatch subagents.
@@ -40,12 +39,12 @@ You call tools only — never dispatch subagents.
 2. Read the current chapter object via `story-state` with `operation: "read"`, `name: story_name`, `field: "chapters.{N}"` where `N = chapter_number`.
 	Then read the scenes list via `story-state` with `operation: "read"`, `name: story_name`, `field: "chapters.{N}.scenes"` to collect available `sceneNum` values for revision.
 3. Extract the current chapter text from the first populated text-bearing field in this order: `content`, `text`, `chapter_text`, `assembled`. If no text-bearing field exists, return zero revisions with status `needs_review`.
-4. Load the prompt via `prompt-loader` with `promptId: "final_edit/prose_scrub"` and variables `chapter_text` and stringified `chapter_number`.
-5. Run the scrub analysis with the `scrub_model` role. Parse the returned JSON object.
-6. Iterate over actionable issues. For each issue, identify the most likely matching scene by correlating the issue's `line_context` with the scenes list. If a specific scene is identifiable, use its index as `sceneNum`; if no specific scene can be identified, use `sceneNum: 1` as the default. Call `scene-writer` with `operation: "revise"`, `name: story_name`, `chapterNum: N`, `sceneNum`, `sceneContent: current chapter text`, and `feedback` set to a surgical correction instruction derived from `type`, `original_text`, `suggested_replacement`, and `line_context`. Stop after 5 revision calls total for the chapter. After each successful revision, replace the in-memory chapter text with the returned text.
-7. Write the revised chapter object back through `story-state` with `operation: "write"`, `name: story_name`, `field: "chapters.{N}"`, and `value` equal to the updated chapter object as a JSON string. Preserve sibling fields and update the original text-bearing field when present.
-8. Create a savepoint via `savepoint-mgr` with `operation: "save"`, `name: story_name`, `step: "chapter_{N}_scrubbed"`, and `data` set to a JSON string summary containing the chapter number, issues found count, revisions applied count, and status token.
-9. Return the chapter number, issues found count, and revisions applied count.
+4. Call `scene-writer` with `operation: "scrub-analyze"`, `name: story_name`, `chapterNum: chapter_number`, `chapterText: <chapter_text>`.
+   The tool returns `{ issues: [...], issues_found: N }`.
+5. Iterate over actionable issues. For each issue, identify the most likely matching scene by correlating the issue's `line_context` with the scenes list. If a specific scene is identifiable, use its index as `sceneNum`; if no specific scene can be identified, use `sceneNum: 1` as the default. Call `scene-writer` with `operation: "revise"`, `name: story_name`, `chapterNum: N`, `sceneNum`, `sceneContent: current chapter text`, and `feedback` set to a surgical correction instruction derived from `type`, `original_text`, `suggested_replacement`, and `line_context`. Stop after 5 revision calls total for the chapter. After each successful revision, replace the in-memory chapter text with the returned text.
+6. Write the revised chapter object back through `story-state` with `operation: "write"`, `name: story_name`, `field: "chapters.{N}"`, and `value` equal to the updated chapter object as a JSON string. Preserve sibling fields and update the original text-bearing field when present.
+7. Create a savepoint via `savepoint-mgr` with `operation: "save"`, `name: story_name`, `step: "chapter_{N}_scrubbed"`, and `data` set to a JSON string summary containing the chapter number, issues found count, revisions applied count, and status token.
+8. Return the chapter number, issues found count, and revisions applied count.
 
 ## Constraints
 

--- a/.opencode/tools/scene-writer.ts
+++ b/.opencode/tools/scene-writer.ts
@@ -5,10 +5,17 @@ import { resolve } from "path";
 
 export default tool({
   description:
-    "Scene writing pipeline: parse chapter outline into scene definitions, generate individual scenes, revise scenes with feedback, or assemble scenes into a chapter.",
+    "Scene writing pipeline: parse chapter outline into scene definitions, generate individual scenes, revise scenes with feedback, assemble scenes into a chapter, or analyze chapter prose for scrub and voice issues.",
   args: {
     operation: z
-      .enum(["parse-definitions", "generate", "revise", "assemble-chapter"])
+      .enum([
+        "parse-definitions",
+        "generate",
+        "revise",
+        "assemble-chapter",
+        "scrub-analyze",
+        "voice-analyze",
+      ])
       .describe("Operation to perform"),
     name: z.string().describe("Story name (directory under stories/)"),
     chapterNum: z
@@ -85,6 +92,14 @@ export default tool({
       .string()
       .optional()
       .describe("Override LLM model identifier"),
+    chapterText: z
+      .string()
+      .optional()
+      .describe("Chapter text for scrub-analyze and voice-analyze operations"),
+    priorChaptersSummary: z
+      .string()
+      .optional()
+      .describe("Prior chapters summary for voice-analyze"),
   },
   execute: async ({
     operation,
@@ -106,6 +121,8 @@ export default tool({
     nextSceneDefinition,
     nextChapterSynopsis,
     model,
+    chapterText,
+    priorChaptersSummary,
   }: {
     operation: string;
     name: string;
@@ -126,6 +143,8 @@ export default tool({
     nextSceneDefinition?: string;
     nextChapterSynopsis?: string;
     model?: string;
+    chapterText?: string;
+    priorChaptersSummary?: string;
   }) => {
     const projectRoot = resolve(__dirname, "../..");
     const args = [
@@ -186,6 +205,12 @@ export default tool({
     }
     if (model) {
       args.push("--model", model);
+    }
+    if (chapterText) {
+      args.push("--chapter-text", chapterText);
+    }
+    if (priorChaptersSummary) {
+      args.push("--prior-chapters-summary", priorChaptersSummary);
     }
 
     try {

--- a/docs/features/prose-quality-passes.md
+++ b/docs/features/prose-quality-passes.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Issue #121 and PR #128 added two distinct prose-quality subagents to the story pipeline: `prose-scrubber` and `final-editor`. They improve prose quality at different points in the pipeline and at different scopes.
+Issue #121 and PR #128 added two distinct prose-quality subagents to the story pipeline: `prose-scrubber` and `final-editor`. PR #141 later moved their analysis LLM calls into `scene-writer` so both agents now stay tool-only.
 
 `prose-scrubber` runs inside the per-chapter loop after Phase 7f has accepted a chapter. It targets sentence and paragraph-level defects such as adverb overuse, filter words, repetitive phrasing, and show-vs-tell drift. `final-editor` runs after Phase 8 assembly and revisits each assembled chapter for voice consistency, pacing, and cross-chapter coherence.
 
@@ -42,7 +42,7 @@ When `enable_scrubbing` is true, the orchestrator dispatches `prose-scrubber` af
 
 ### `prose-scrubber`
 
-`prose-scrubber` reads one chapter from story state, analyzes it with the `final_edit/prose_scrub` prompt, and applies targeted `scene-writer` revisions.
+`prose-scrubber` reads one chapter from story state, delegates sentence-level issue extraction to `scene-writer` with `operation: "scrub-analyze"`, and applies targeted `scene-writer` revisions.
 
 It focuses on four issue types:
 
@@ -54,6 +54,7 @@ It focuses on four issue types:
 Operational details:
 
 - Uses `config.models.scrub_model` when present; otherwise uses the default model role
+- The analysis prompt loading and JSON parsing now live inside `scene-writer`, not the agent
 - Stops after at most five revision calls for one chapter
 - Writes the revised chapter object back to the original text-bearing field in story state
 - Creates `chapter_{N}_scrubbed` savepoints
@@ -67,13 +68,14 @@ Because this pass is prose-only, it does not re-run wiki updates, recap generati
 
 It performs two analysis passes per chapter:
 
-1. `final_edit/voice_consistency_pass` for voice consistency, pacing, and cross-chapter coherence
-2. `final_edit/prose_scrub` for a second sentence-level cleanup on the assembled chapter text
+1. `scene-writer` `voice-analyze` for voice consistency, pacing, and cross-chapter coherence
+2. `scene-writer` `scrub-analyze` for a second sentence-level cleanup on the assembled chapter text
 
 Operational details:
 
 - Reads chapter text from story state and preserves sibling fields when writing updates back
 - Uses `rag-query` to gather prior chapter context for stylistic continuity
+- Delegates prompt loading, LLM invocation, and JSON parsing to `scene-writer` for both analysis passes
 - Applies up to three targeted revisions from the voice-analysis pass and up to three targeted revisions from the scrub pass
 - Creates `chapter_{N}_final_edited` savepoints per chapter
 - Creates `final_edit_complete` when the full manuscript pass finishes
@@ -85,13 +87,11 @@ Operational details:
 | Agent | Tool | Purpose |
 |-------|------|---------|
 | `prose-scrubber` | `story-state` | Read and write chapter objects |
-| `prose-scrubber` | `scene-writer` | Apply local prose revisions |
-| `prose-scrubber` | `prompt-loader` | Load `final_edit/prose_scrub` |
+| `prose-scrubber` | `scene-writer` | Run `scrub-analyze` and apply local prose revisions |
 | `prose-scrubber` | `savepoint-mgr` | Record `chapter_{N}_scrubbed` |
 | `final-editor` | `story-state` | Read and write assembled chapter objects |
-| `final-editor` | `scene-writer` | Apply voice, pacing, and scrub revisions |
+| `final-editor` | `scene-writer` | Run `voice-analyze` and `scrub-analyze`, then apply voice, pacing, and scrub revisions |
 | `final-editor` | `rag-query` | Retrieve prior-chapter context |
-| `final-editor` | `prompt-loader` | Load `final_edit/voice_consistency_pass` and `final_edit/prose_scrub` |
 | `final-editor` | `savepoint-mgr` | Record per-chapter and final completion savepoints |
 
 ### Constraints
@@ -108,6 +108,8 @@ Both agents load `.opencode/skills/final-edit/SKILL.md` and inherit the same har
 
 - `.opencode/agents/prose-scrubber.md` — Phase 7.5 chapter scrub workflow
 - `.opencode/agents/final-editor.md` — Phase 9 manuscript polish workflow
+- `.opencode/tools/scene-writer.ts` — OpenCode wrapper exposing `scrub-analyze` and `voice-analyze`
+- `src/tools/scene_writer.py` — Prompt-loading, LLM-calling, JSON-parsing implementation for prose analysis and scene generation
 - `.opencode/skills/final-edit/SKILL.md` — shared constraints, pass types, revision budget, status tokens
 - `prompts/final_edit/prose_scrub.md` — sentence and paragraph-level issue extraction prompt
 - `prompts/final_edit/voice_consistency_pass.md` — voice, pacing, and cross-chapter coherence prompt
@@ -125,10 +127,12 @@ The passes mutate chapter text in story state and add savepoints. They do not ad
 
 ### Testing
 
-PR #128 updated the prompt relocation unit test to account for the new prompt files. For documentation changes, verify the feature descriptions against the source agent files and prompt templates:
+PR #141 added `scene-writer` tests covering both analysis operations, including success, empty-result, JSON-parse failure, and CLI validation cases. For documentation changes, verify the feature descriptions against the source agent files, tool contracts, and prompt templates:
 
 - `.opencode/agents/prose-scrubber.md`
 - `.opencode/agents/final-editor.md`
+- `.opencode/tools/scene-writer.ts`
+- `src/tools/scene_writer.py`
 - `.opencode/skills/final-edit/SKILL.md`
 - `prompts/final_edit/prose_scrub.md`
 - `prompts/final_edit/voice_consistency_pass.md`
@@ -148,3 +152,5 @@ PR #128 updated the prompt relocation unit test to account for the new prompt fi
 - [ADR 001: Hybrid Agent-Tool Architecture](../planning/adr/001-hybrid-agent-tool-architecture.md) — Depth-1 orchestration pattern
 - Issue #121 — Initial implementation request
 - PR #128 — Implemented `final-editor`, `prose-scrubber`, shared skill, and prompt templates
+- Issue #134 — Moved prose-analysis LLM calls into `scene-writer`
+- PR #141 — Added `scrub-analyze` and `voice-analyze` and removed `prompt-loader` from both agents

--- a/docs/features/story-orchestrator.md
+++ b/docs/features/story-orchestrator.md
@@ -253,7 +253,7 @@ The `prose-scrubber` subagent handles the conditional Phase 7.5 cleanup for one 
 
 1. Loads the shared `final-edit` skill for scope constraints and revision-budget rules
 2. Reads the current chapter object from story state and extracts the active text-bearing field
-3. Loads the `final_edit/prose_scrub` prompt and runs sentence/paragraph-level analysis using the `scrub_model` named model role when configured
+3. Calls `scene-writer` `scrub-analyze` to load the `final_edit/prose_scrub` prompt, run sentence/paragraph-level analysis, and return structured issues using the `scrub_model` named model role when configured
 4. Applies up to five targeted `scene-writer` revision calls for actionable issues such as adverb overuse, filter words, repetitive phrasing, and show-vs-tell drift
 5. Writes the revised chapter object back to story state and records a `chapter_{N}_scrubbed` savepoint
 
@@ -265,8 +265,8 @@ The `final-editor` subagent handles the conditional Phase 9 manuscript polish af
 
 1. Loads the shared `final-edit` skill for scope constraints, pass types, and revision budgets
 2. Reads each chapter from story state and retrieves prior-chapter context via `rag-query`
-3. Runs the `final_edit/voice_consistency_pass` prompt to detect voice, pacing, and cross-chapter coherence issues
-4. Runs the `final_edit/prose_scrub` prompt for a second sentence-level cleanup pass on the assembled manuscript text
+3. Calls `scene-writer` `voice-analyze` to run `final_edit/voice_consistency_pass` and return structured voice, pacing, and cross-chapter coherence issues
+4. Calls `scene-writer` `scrub-analyze` for a second sentence-level cleanup pass on the assembled manuscript text
 5. Applies targeted `scene-writer` revisions, writes each revised chapter back to story state, and creates `chapter_{N}_final_edited` savepoints plus a final `final_edit_complete` checkpoint
 
 This pass runs after assembly, not instead of Phase 7f. It preserves story events and facts while smoothing chapter-to-chapter style and pacing. See [Prose Quality Passes](./prose-quality-passes.md) and the [agent definition](../../.opencode/agents/final-editor.md) for details.

--- a/docs/features/story-orchestrator.md
+++ b/docs/features/story-orchestrator.md
@@ -253,7 +253,7 @@ The `prose-scrubber` subagent handles the conditional Phase 7.5 cleanup for one 
 
 1. Loads the shared `final-edit` skill for scope constraints and revision-budget rules
 2. Reads the current chapter object from story state and extracts the active text-bearing field
-3. Calls `scene-writer` `scrub-analyze` to load the `final_edit/prose_scrub` prompt, run sentence/paragraph-level analysis, and return structured issues using the `scrub_model` named model role when configured
+3. Calls `scene-writer` `scrub-analyze` to load the `final_edit/prose_scrub` prompt, run sentence/paragraph-level analysis, and return structured issues using the `scrub_model` named model role when configured (aspirational — not yet implemented end-to-end; uses the default agent model until platform support for per-call model overrides is available)
 4. Applies up to five targeted `scene-writer` revision calls for actionable issues such as adverb overuse, filter words, repetitive phrasing, and show-vs-tell drift
 5. Writes the revised chapter object back to story state and records a `chapter_{N}_scrubbed` savepoint
 
@@ -358,7 +358,7 @@ All pipeline settings are read from `config.md` YAML frontmatter under the `gene
 | `debug` | bool | true | Emit additional pipeline diagnostics |
 | `strategy` | string | `outline-chapter` | Story generation strategy identifier |
 
-Named model roles live under `config.models`. `prose-scrubber` reads `scrub_model` when configured; otherwise it falls back to the default model binding.
+Named model roles live under `config.models`. `prose-scrubber` reads `scrub_model` when configured (aspirational — per-call model routing is not yet implemented; falls back to the default agent model binding until platform support is available).
 
 ## Story Pipeline Skill
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -854,7 +854,7 @@ Invalid values produce exit code 1 with a descriptive error message.
 
 ## scene-writer
 
-Scene writing pipeline: parse a chapter outline into scene definitions, generate individual scenes, revise scenes with feedback, or assemble scenes into a chapter.
+Scene writing pipeline: parse a chapter outline into scene definitions, generate individual scenes, revise scenes with feedback, assemble scenes into a chapter, or analyze chapter prose for scrub and voice issues.
 
 **Source files:**
 - `.opencode/tools/scene-writer.ts` — TypeScript wrapper
@@ -867,15 +867,15 @@ Scene writing pipeline: parse a chapter outline into scene definitions, generate
 
 The scene writer breaks chapter-level generation into finer-grained scene units. A chapter outline is first parsed into individual scene definitions (structured JSON), then each scene is generated independently. Scenes can be revised with targeted feedback, and once all scenes in a chapter are complete they are assembled into a single chapter document with section headers and separators.
 
-All LLM-backed operations save their results to savepoints, making the pipeline fully resumable if interrupted.
+The same tool also owns the prose-analysis prompts used by the late-stage editing passes. `scrub-analyze` performs sentence-level issue extraction for accepted chapter prose, and `voice-analyze` performs manuscript-context voice and pacing analysis. Unlike scene generation operations, these analysis calls are stateless and do not create savepoints.
 
 ### Arguments
 
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
-| `operation` | `"parse-definitions" \| "generate" \| "revise" \| "assemble-chapter"` | Yes | Operation to perform |
+| `operation` | `"parse-definitions" \| "generate" \| "revise" \| "assemble-chapter" \| "scrub-analyze" \| "voice-analyze"` | Yes | Operation to perform |
 | `name` | string | Yes | Story name (directory under `stories/`) |
-| `chapterNum` | integer | For all except as noted | Chapter number (must be ≥ 1) |
+| `chapterNum` | integer | For all operations | Chapter number (must be ≥ 1) |
 | `sceneNum` | integer | For `generate`, `revise` | Scene number within the chapter (must be ≥ 1) |
 | `sceneCount` | integer | For `assemble-chapter` | Total number of scenes in the chapter (must be ≥ 1) |
 | `chapterOutline` | string | For `parse-definitions`, `generate`; optional for `revise` | Chapter outline text |
@@ -891,6 +891,8 @@ All LLM-backed operations save their results to savepoints, making the pipeline 
 | `previousScene` | string | No | Previous scene content (for `generate`) |
 | `nextSceneDefinition` | string | No | Next scene definition (for `generate`) |
 | `nextChapterSynopsis` | string | No | Next chapter synopsis (for `generate`) |
+| `chapterText` | string | For `scrub-analyze`, `voice-analyze` | Full chapter text to analyze |
+| `priorChaptersSummary` | string | No | Prior-chapter continuity summary for `voice-analyze` |
 | `model` | string | No | Override LLM model identifier |
 
 ### CLI Interface (Python script)
@@ -927,6 +929,17 @@ python3 src/tools/scene_writer.py --operation revise \
 python3 src/tools/scene_writer.py --operation assemble-chapter \
   --name my-story --chapter-num 3 --scene-count 4 \
   --chapter-title "The Ancient City"
+
+# Analyze accepted chapter prose for scrub issues
+python3 src/tools/scene_writer.py --operation scrub-analyze \
+  --name my-story --chapter-num 3 \
+  --chapter-text "Elena quickly looked around and felt afraid..."
+
+# Analyze chapter voice and pacing in manuscript context
+python3 src/tools/scene_writer.py --operation voice-analyze \
+  --name my-story --chapter-num 3 \
+  --chapter-text "Chapter 3 text..." \
+  --prior-chapters-summary "Chapters 1-2 used close third person with sparse exposition"
 ```
 
 ### Operations
@@ -937,6 +950,8 @@ python3 src/tools/scene_writer.py --operation assemble-chapter \
 | `generate` | Renders `scenes/create_content` prompt with scene definition and full story context, calls LLM, saves result to savepoint | `{"status": "success", "operation": "generate", "data": "<scene text>"}` |
 | `revise` | Renders `scenes/revise_content` prompt with current content, feedback, and optional context, calls LLM, overwrites the scene savepoint | `{"status": "success", "operation": "revise", "data": "<revised text>"}` |
 | `assemble-chapter` | Loads all scene savepoints for the chapter, retrieves scene titles from definitions savepoint, concatenates with `## <title>` headers and `---` separators | `{"status": "success", "operation": "assemble-chapter", "data": "# <title>\n\n## Scene 1\n\n..."}` |
+| `scrub-analyze` | Renders `final_edit/prose_scrub` with accepted chapter text, extracts the JSON block, and returns structured sentence-level issues for adverbs, filter words, repetition, and show-vs-tell drift. No savepoint is written. | `{"status": "success", "operation": "scrub-analyze", "data": {"issues": [{"type": "...", "original_text": "...", "suggested_replacement": "...", "line_context": "..."}], "issues_found": 2}}` |
+| `voice-analyze` | Renders `final_edit/voice_consistency_pass` with chapter text plus an optional prior-chapter summary, extracts the JSON block, and returns structured voice, pacing, and coherence issues. No savepoint is written. | `{"status": "success", "operation": "voice-analyze", "data": {"issues": [{"type": "...", "location": "...", "description": "...", "suggested_fix": "..."}], "issues_found": 1}}` |
 
 ### Scene Definition Format
 
@@ -962,22 +977,26 @@ The `parse-definitions` operation produces (and `generate` consumes) scene defin
 
 ### Prompt Templates
 
-The tool uses three prompt templates from the `prompts/scenes/` directory:
+The tool uses three scene-generation templates from `prompts/scenes/` plus two analysis templates from `prompts/final_edit/`:
 
 | Template | Used By | Purpose |
 |----------|---------|---------|
 | `scenes/parse_definitions` | `parse-definitions` | Analyse a chapter outline and extract scene objects as JSON |
 | `scenes/create_content` | `generate` | Generate 750–1500 words of scene prose from a definition and context |
 | `scenes/revise_content` | `revise` | Revise scene content based on specific feedback |
+| `final_edit/prose_scrub` | `scrub-analyze` | Extract sentence and paragraph-level prose issues as structured JSON |
+| `final_edit/voice_consistency_pass` | `voice-analyze` | Extract voice, pacing, and cross-chapter coherence issues as structured JSON |
 
 ### Savepoint Structure
 
-All intermediate results are persisted under `stories/<name>/savepoints/`:
+Savepoint-backed operations persist intermediate results under `stories/<name>/savepoints/`:
 
 | Savepoint Key | Created By | Content |
 |---------------|-----------|---------|
 | `chapter_N/scene_definitions` | `parse-definitions` | JSON array of scene definition objects |
 | `chapter_N/scene_M` | `generate`, `revise` | Scene prose text |
+
+`scrub-analyze`, `voice-analyze`, and `assemble-chapter` are stateless with respect to savepoint storage. `assemble-chapter` reads existing scene savepoints but does not write a new checkpoint.
 
 ### Resumability
 

--- a/src/tools/scene_writer.py
+++ b/src/tools/scene_writer.py
@@ -280,6 +280,62 @@ def cmd_assemble_chapter(
     _success("assemble-chapter", assembled)
 
 
+def cmd_scrub_analyze(
+    name: str,
+    chapter_num: int,
+    chapter_text: str,
+    *,
+    model: str | None = None,
+) -> None:
+    """Analyze chapter prose for sentence-level issues."""
+    _validate_story_name(name)
+    prompt_text = _load_prompt(
+        "final_edit/prose_scrub",
+        {"chapter_text": chapter_text, "chapter_number": str(chapter_num)},
+    )
+    try:
+        from src.tools._llm import _extract_json_block
+
+        raw = _call_llm(prompt_text, model=model)
+        json_str = _extract_json_block(raw)
+        result = json.loads(json_str)
+    except (json.JSONDecodeError, RuntimeError) as exc:
+        _error(f"scrub analysis failed: {exc}")
+
+    issues = result.get("issues", [])
+    _success("scrub-analyze", {"issues": issues, "issues_found": len(issues)})
+
+
+def cmd_voice_analyze(
+    name: str,
+    chapter_num: int,
+    chapter_text: str,
+    prior_chapters_summary: str = "",
+    *,
+    model: str | None = None,
+) -> None:
+    """Analyze chapter for voice consistency and pacing issues."""
+    _validate_story_name(name)
+    prompt_text = _load_prompt(
+        "final_edit/voice_consistency_pass",
+        {
+            "chapter_text": chapter_text,
+            "prior_chapters_summary": prior_chapters_summary,
+        },
+    )
+    try:
+        from src.tools._llm import _extract_json_block
+
+        raw = _call_llm(prompt_text, model=model)
+        json_str = _extract_json_block(raw)
+        result = json.loads(json_str)
+    except (json.JSONDecodeError, RuntimeError) as exc:
+        _error(f"voice analysis failed: {exc}")
+
+    issues = result.get("issues", [])
+    _success("voice-analyze", {"issues": issues, "issues_found": len(issues)})
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -290,7 +346,14 @@ def main() -> None:
     parser.add_argument(
         "--operation",
         required=True,
-        choices=["parse-definitions", "generate", "revise", "assemble-chapter"],
+        choices=[
+            "parse-definitions",
+            "generate",
+            "revise",
+            "assemble-chapter",
+            "scrub-analyze",
+            "voice-analyze",
+        ],
         help="Operation to perform",
     )
     parser.add_argument("--name", required=True, help="Story name")
@@ -319,6 +382,14 @@ def main() -> None:
         "--next-chapter-synopsis", default=None, help="Next chapter synopsis"
     )
     parser.add_argument("--model", default=None, help="Override LLM model identifier")
+    parser.add_argument(
+        "--chapter-text", default=None, help="Chapter text for scrub/voice analysis"
+    )
+    parser.add_argument(
+        "--prior-chapters-summary",
+        default=None,
+        help="Prior chapters summary for voice analysis",
+    )
     args = parser.parse_args()
 
     # --- Dispatch ---
@@ -406,6 +477,35 @@ def main() -> None:
             args.chapter_num,
             args.scene_count,
             chapter_title=args.chapter_title,
+        )
+
+    elif op == "scrub-analyze":
+        if args.chapter_num is None:
+            _error("--chapter-num is required for scrub-analyze")
+        if args.chapter_num < 1:
+            _error("--chapter-num must be >= 1")
+        if not args.chapter_text:
+            _error("--chapter-text is required for scrub-analyze")
+        cmd_scrub_analyze(
+            args.name,
+            args.chapter_num,
+            args.chapter_text,
+            model=args.model,
+        )
+
+    elif op == "voice-analyze":
+        if args.chapter_num is None:
+            _error("--chapter-num is required for voice-analyze")
+        if args.chapter_num < 1:
+            _error("--chapter-num must be >= 1")
+        if not args.chapter_text:
+            _error("--chapter-text is required for voice-analyze")
+        cmd_voice_analyze(
+            args.name,
+            args.chapter_num,
+            args.chapter_text,
+            prior_chapters_summary=args.prior_chapters_summary or "",
+            model=args.model,
         )
 
 

--- a/tests/unit/test_scene_writer.py
+++ b/tests/unit/test_scene_writer.py
@@ -541,6 +541,19 @@ def test_voice_analyze_empty_issues(
     assert out["data"]["issues"] == []
 
 
+def test_voice_analyze_json_parse_error_exits(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mock invalid voice response. Verify command exits on parse failure."""
+    _stories_dir, name = patched_env
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: "not json")
+
+    with pytest.raises(SystemExit):
+        sw.cmd_voice_analyze(name, 1, "Chapter text", model="test")
+
+
 # ---------------------------------------------------------------------------
 # 16. test_scrub_analyze_cli_missing_chapter_text
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scene_writer.py
+++ b/tests/unit/test_scene_writer.py
@@ -388,3 +388,204 @@ def test_invalid_story_name(story_env: tuple[Path, str]) -> None:
     )
     assert result.returncode == 1
     assert "escapes" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# 11. test_scrub_analyze_success
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_analyze_success(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock LLM scrub analysis response. Verify issues returned and counted."""
+    _stories_dir, name = patched_env
+
+    issues = [
+        {"type": "passive-voice", "excerpt": "was opened", "suggestion": "opened"},
+        {
+            "type": "wordiness",
+            "excerpt": "in order to",
+            "suggestion": "to",
+        },
+    ]
+    raw_llm = f"```json\n{json.dumps({'issues': issues})}\n```"
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: raw_llm)
+
+    sw.cmd_scrub_analyze(name, 1, "Chapter text", model="test")
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "success"
+    assert out["operation"] == "scrub-analyze"
+    assert out["data"]["issues_found"] == 2
+    assert issues == out["data"]["issues"]
+
+
+# ---------------------------------------------------------------------------
+# 12. test_scrub_analyze_empty_issues
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_analyze_empty_issues(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock empty scrub issues response. Verify zero count and empty list."""
+    _stories_dir, name = patched_env
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: '{"issues": []}')
+
+    sw.cmd_scrub_analyze(name, 1, "Chapter text", model="test")
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "success"
+    assert out["data"]["issues_found"] == 0
+    assert out["data"]["issues"] == []
+
+
+# ---------------------------------------------------------------------------
+# 13. test_scrub_analyze_json_parse_error_exits
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_analyze_json_parse_error_exits(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mock invalid scrub response. Verify command exits on parse failure."""
+    _stories_dir, name = patched_env
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: "not json")
+
+    with pytest.raises(SystemExit):
+        sw.cmd_scrub_analyze(name, 1, "Chapter text", model="test")
+
+
+# ---------------------------------------------------------------------------
+# 14. test_voice_analyze_success
+# ---------------------------------------------------------------------------
+
+
+def test_voice_analyze_success(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock voice analysis response. Verify issues and prior summary flow through."""
+    _stories_dir, name = patched_env
+
+    issues = [
+        {"type": "voice", "excerpt": "slang spike", "suggestion": "match tone"},
+        {"type": "pacing", "excerpt": "slow middle", "suggestion": "tighten"},
+        {
+            "type": "continuity",
+            "excerpt": "shifted worldview",
+            "suggestion": "align with prior chapters",
+        },
+    ]
+    raw_llm = f"```json\n{json.dumps({'issues': issues})}\n```"
+    captured_prompts: list[str] = []
+
+    def mock_load_prompt(prompt_id: str, variables: dict | None = None) -> str:
+        rendered = f"prompt:{prompt_id}"
+        if variables:
+            for key, value in variables.items():
+                rendered += f" {key}={value}"
+        captured_prompts.append(rendered)
+        return rendered
+
+    monkeypatch.setattr(sw, "_load_prompt", mock_load_prompt)
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: raw_llm)
+
+    prior_summary = "Summary of prior events"
+    sw.cmd_voice_analyze(
+        name,
+        1,
+        "Chapter text",
+        prior_chapters_summary=prior_summary,
+        model="test",
+    )
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "success"
+    assert out["operation"] == "voice-analyze"
+    assert out["data"]["issues_found"] == 3
+    assert issues == out["data"]["issues"]
+    assert len(captured_prompts) == 1
+    assert prior_summary in captured_prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# 15. test_voice_analyze_empty_issues
+# ---------------------------------------------------------------------------
+
+
+def test_voice_analyze_empty_issues(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock empty voice issues response. Verify zero count and empty list."""
+    _stories_dir, name = patched_env
+
+    monkeypatch.setattr(sw, "_call_llm", lambda *_a, **_kw: '{"issues": []}')
+
+    sw.cmd_voice_analyze(name, 1, "Chapter text", prior_chapters_summary="", model="test")
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["data"]["issues_found"] == 0
+    assert out["data"]["issues"] == []
+
+
+# ---------------------------------------------------------------------------
+# 16. test_scrub_analyze_cli_missing_chapter_text
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_analyze_cli_missing_chapter_text(
+    story_env: tuple[Path, str],
+) -> None:
+    """Run scrub analyze via CLI without chapter text. Verify validation failure."""
+    stories_dir, name = story_env
+
+    result = _run_tool(
+        "--operation",
+        "scrub-analyze",
+        "--name",
+        name,
+        "--chapter-num",
+        "1",
+        stories_dir=stories_dir,
+    )
+
+    assert result.returncode != 0
+    assert "chapter-text is required" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# 17. test_voice_analyze_cli_missing_chapter_text
+# ---------------------------------------------------------------------------
+
+
+def test_voice_analyze_cli_missing_chapter_text(
+    story_env: tuple[Path, str],
+) -> None:
+    """Run voice analyze via CLI without chapter text. Verify validation failure."""
+    stories_dir, name = story_env
+
+    result = _run_tool(
+        "--operation",
+        "voice-analyze",
+        "--name",
+        name,
+        "--chapter-num",
+        "1",
+        stories_dir=stories_dir,
+    )
+
+    assert result.returncode != 0
+    assert "chapter-text is required" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Adds `scrub-analyze` and `voice-analyze` operations to `scene_writer.py` (Python) and `scene-writer.ts` (TS wrapper). Simplifies `prose-scrubber` and `final-editor` agents to delegate analysis to the tool, removing their `prompt-loader` dependency.

## Closes

Closes #134

## Changes

- [x] `scrub-analyze` operation added to `src/tools/scene_writer.py`
- [x] `voice-analyze` operation added to `src/tools/scene_writer.py`
- [x] `scene-writer.ts` updated with both operations and new params (`chapterText`, `priorChaptersSummary`)
- [x] `prose-scrubber.md` simplified — `prompt-loader` removed, Steps 4–5 delegated to `scrub-analyze`
- [x] `final-editor.md` simplified — `prompt-loader` removed, voice/scrub steps delegated to `voice-analyze`/`scrub-analyze`
- [x] 7 new tests covering both operations (success, empty issues, JSON parse error, CLI validation)
- [x] All tests passing: 366 passed (17 scene_writer tests including 7 new)
- [x] Lint clean (changed files)

## Plan

### `src/tools/scene_writer.py`
- `cmd_scrub_analyze(name, chapter_num, chapter_text, *, model)` — loads `final_edit/prose_scrub`, calls LLM, parses JSON, returns `{issues: [...], issues_found: N}`
- `cmd_voice_analyze(name, chapter_num, chapter_text, prior_chapters_summary="", *, model)` — loads `final_edit/voice_consistency_pass`, calls LLM, parses JSON, returns `{issues: [...], issues_found: N}`
- New argparse args: `--chapter-text`, `--prior-chapters-summary`
- Both ops added to `choices=` + dispatch blocks in `main()`

### `.opencode/tools/scene-writer.ts`
- `"scrub-analyze"` and `"voice-analyze"` added to `z.enum`
- `chapterText` and `priorChaptersSummary` optional args added
- Push logic for `--chapter-text` and `--prior-chapters-summary`

### Agent simplifications
- `prose-scrubber.md`: Steps 4–5 → single `scene-writer scrub-analyze` call; `prompt-loader` removed from tools table
- `final-editor.md`: voice/scrub analysis steps → `scene-writer voice-analyze` + `scene-writer scrub-analyze`; `prompt-loader` removed from tools table