### PR TITLE
fix: escape newline in parts.join across 14 TS tool wrappers

### DIFF
--- a/.opencode/tools/character-mgr.ts
+++ b/.opencode/tools/character-mgr.ts
@@ -115,8 +115,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/critique-runner.ts
+++ b/.opencode/tools/critique-runner.ts
@@ -140,8 +140,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/outline-generator.ts
+++ b/.opencode/tools/outline-generator.ts
@@ -147,8 +147,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/rag-query.ts
+++ b/.opencode/tools/rag-query.ts
@@ -106,8 +106,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/recap-manager.ts
+++ b/.opencode/tools/recap-manager.ts
@@ -84,8 +84,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/scene-writer.ts
+++ b/.opencode/tools/scene-writer.ts
@@ -242,8 +242,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/setting-mgr.ts
+++ b/.opencode/tools/setting-mgr.ts
@@ -115,8 +115,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/story-assembler.ts
+++ b/.opencode/tools/story-assembler.ts
@@ -66,8 +66,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/story-state.ts
+++ b/.opencode/tools/story-state.ts
@@ -65,8 +65,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/wiki-init.ts
+++ b/.opencode/tools/wiki-init.ts
@@ -45,8 +45,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/wiki-lint.ts
+++ b/.opencode/tools/wiki-lint.ts
@@ -84,8 +84,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/wiki-read.ts
+++ b/.opencode/tools/wiki-read.ts
@@ -84,8 +84,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/wiki-search.ts
+++ b/.opencode/tools/wiki-search.ts
@@ -75,8 +75,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }

--- a/.opencode/tools/wiki-snapshot.ts
+++ b/.opencode/tools/wiki-snapshot.ts
@@ -129,8 +129,7 @@ export default tool({
       ].filter(Boolean) as string[];
       const errorMessage =
         parts.length > 0
-          ? parts.join("
-")
+          ? parts.join("\n")
           : execError.message || "Unknown error";
       return `Error: ${errorMessage}`;
     }


### PR DESCRIPTION
Closes #146

## Summary

Hotfix — replaces literal newline inside `parts.join("...")` with the escape sequence `\n` in 14 TS tool wrappers. The previous form is parsed by TypeScript as an unterminated string literal, blocking every agent that depends on these tools (story-orchestrator, wiki-maintainer, etc.).

## Affected (14)

character-mgr, critique-runner, outline-generator, rag-query, recap-manager, scene-writer, setting-mgr, story-assembler, story-state, wiki-init, wiki-lint, wiki-read, wiki-search, wiki-snapshot.

## Already correct (no change)

wiki-update, prompt-loader, .opencode/_run.ts.

## Verification

- vitest: 30/30 passing
- Pattern audit: `grep -n 'parts\.join' .opencode/tools/*.ts` confirms all 16 wrappers now contain `parts.join("\\n")`