### PR TITLE
fix(savepoints): deterministic resume via savepoint-mgr next-phase op

### DIFF
--- a/.opencode/commands/continue.md
+++ b/.opencode/commands/continue.md
@@ -11,7 +11,7 @@ Available stories:
 If a story name was provided ("$1"), resume that story. If no story name was provided (empty "$1"), ask the user which story from the list above they want to continue.
 
 Steps:
-1. List savepoints for the chosen story using the savepoint-mgr tool
-2. Identify the most recent savepoint
-3. Load that savepoint and read the story state
-4. Resume the pipeline from where it left off
+1. Call `savepoint-mgr` (operation: `next-phase`, name: chosen story name) — this returns a deterministic resume target. The output JSON contains `last_completed` (the highest-completed savepoint) and `next_phase` (the human-readable description of where to resume). Do NOT use `list` and reason about ordering yourself; the canonical phase walk is owned by the tool.
+2. Read story state via `story-state` (operation: `read`, name: story name) for context (config values, story_name, prompt metadata, chapter counts).
+3. If `missing_below_top` is non-empty in the response, log a warning that intermediate savepoints are missing — but proceed with resume from `next_phase` regardless. Missing intermediate savepoints indicate procedural drift in an earlier run, not a blocker.
+4. Resume the pipeline from `next_phase` as returned by the tool. Follow the `story-pipeline` skill for the phase definition.

--- a/.opencode/skills/story-pipeline/SKILL.md
+++ b/.opencode/skills/story-pipeline/SKILL.md
@@ -194,12 +194,22 @@ The pipeline uses ten subagents for specialised creative work. The `story-orches
 
 ## Savepoint Ownership
 
-**The orchestrator owns the savepoint lifecycle. Subagents must never call `savepoint-mgr` directly.**
+**The orchestrator owns the savepoint lifecycle. Subagents must never call `savepoint-mgr` directly, with the documented exceptions below.**
 
 - Savepoints are checkpoints created by `story-orchestrator` at the boundary of each phase — not by subagents during their internal work.
 - When a subagent completes its delegated work, it writes results to `story-state` (or produces handoff artifacts) and returns to the orchestrator. The orchestrator then creates the savepoint after confirming results are stored.
 - **Why this matters:** If a subagent creates its own savepoint and the orchestrator also creates one at the same step name, the orchestrator's write silently overwrites the subagent's richer payload (`savepoint-mgr` overwrites existing entries by default). A pipeline resumed from that savepoint recovers a degraded snapshot.
 - **Correct pattern:** `story-orchestrator` Phase 2.5 creates `arc_analysis_complete` with the full arc payload after `story-planner` returns. `story-planner` writes only to `story-state` — it never calls `savepoint-mgr`.
+
+### Documented exceptions
+
+The following subagents own specific savepoints because they perform per-entity work in a loop and the orchestrator has no equivalent re-entry point:
+
+| Subagent | Owned savepoints | Rationale |
+|----------|-------------------|-----------|
+| `character-sheet-generator` | `characters_complete`, `settings_complete` | Subagent loops over the full character/setting list and is the only context that knows when the loop has finished. The orchestrator must NOT also create these. |
+
+When adding a new exception: document it in this table, ensure the orchestrator does NOT create the same savepoint, and add the savepoint to the canonical phase order in `src/tools/savepoint_manager.py`'s `CANONICAL_PHASES` list.
 
 ---
 

--- a/.opencode/tools/savepoint-mgr.ts
+++ b/.opencode/tools/savepoint-mgr.ts
@@ -5,12 +5,20 @@ import { runTool } from "../_run";
 
 export default tool({
   description:
-    "Manage story savepoints: save, load, has, list, list-full, or clear. Use 'list' (names only, fast) for resume/discovery — NOT 'list-full' (dumps all data, wastes tokens). Supports hierarchical step paths like chapter_1/scene_2. Python script: src/tools/savepoint_manager.py.",
+    "Manage story savepoints: save, load, has, list, list-full, clear, or next-phase. Use 'list' (names only, fast) for resume/discovery — NOT 'list-full' (dumps all data, wastes tokens). Use 'next-phase' (preferred for /continue) to get the deterministic resume target. Supports hierarchical step paths like chapter_1/scene_2. Python script: src/tools/savepoint_manager.py.",
   args: {
     operation: z
-      .enum(["save", "load", "has", "list", "list-full", "clear"])
+      .enum([
+        "save",
+        "load",
+        "has",
+        "list",
+        "list-full",
+        "clear",
+        "next-phase",
+      ])
       .describe(
-        "Operation. 'list' returns names only (fast, preferred). 'list-full' returns names + data (large, avoid unless needed)."
+        "Operation. 'list' returns names only (fast, preferred). 'list-full' returns names + data (large, avoid unless needed). 'next-phase' returns the deterministic resume target."
       ),
     name: z.string().describe("Story name"),
     step: z
@@ -30,7 +38,14 @@ export default tool({
     step,
     data,
   }: {
-    operation: "save" | "load" | "has" | "list" | "list-full" | "clear";
+    operation:
+      | "save"
+      | "load"
+      | "has"
+      | "list"
+      | "list-full"
+      | "clear"
+      | "next-phase";
     name: string;
     step?: string;
     data?: string;

--- a/src/tools/savepoint_manager.py
+++ b/src/tools/savepoint_manager.py
@@ -134,16 +134,126 @@ def cmd_clear(name: str) -> None:
     print(json.dumps({"status": "cleared"}, indent=2, default=str))
 
 
+# Canonical phase order — must match the Savepoint Strategy table in
+# .opencode/agents/story-orchestrator.md. If the pipeline phases change,
+# update both files together.
+CANONICAL_PHASES: list[str] = [
+    "init",
+    "outline_complete",
+    "arc_analysis_complete",
+    "characters_complete",
+    "settings_complete",
+    "wiki_populated",
+    # chapter_{N}_complete handled separately (loop)
+    "story_complete",
+    "final_edit_complete",
+]
+
+PHASE_NEXT_DESCRIPTOR: dict[str, str] = {
+    "": "Phase 1 (init)",
+    "init": "Phase 2 (outline)",
+    "outline_complete": "Phase 2.5 (arc analysis)",
+    "arc_analysis_complete": "Phase 3 (approval) then Phase 4 (wiki init) then Phase 5 (characters & settings)",
+    "characters_complete": "Phase 5 (settings)",
+    "settings_complete": "Phase 6 (wiki population)",
+    "wiki_populated": "Phase 7 (chapter expansion + per-chapter loop, starting at chapter 1)",
+    "story_complete": "Phase 9 (final edit, if enabled)",
+    "final_edit_complete": "complete — no further phases",
+}
+
+
+def cmd_next_phase(name: str) -> None:
+    """Determine the next pipeline phase to run based on existing savepoints.
+
+    Walks the canonical phase order and returns the highest-completed savepoint
+    (gaps tolerated — a missing intermediate savepoint does not block detection
+    of later ones). Detects per-chapter savepoints (`chapter_{N}_complete`)
+    and reports the highest chapter number completed.
+    """
+    story_dir = _validate_story_name(name)
+    if not story_dir.exists():
+        print(f"Error: story not found: {name}", file=sys.stderr)
+        sys.exit(1)
+
+    repo = _make_repo(name)
+    names = asyncio.run(repo.list_savepoint_names())
+    name_set = set(names)
+
+    # Find highest completed canonical phase (gaps tolerated)
+    last_canonical = ""
+    last_canonical_index = -1
+    for idx, phase in enumerate(CANONICAL_PHASES):
+        if phase in name_set:
+            last_canonical = phase
+            last_canonical_index = idx
+
+    # Detect per-chapter savepoints (chapter_{N}_complete)
+    chapter_numbers: list[int] = []
+    for sp_name in names:
+        if sp_name.startswith("chapter_") and sp_name.endswith("_complete"):
+            middle = sp_name[len("chapter_") : -len("_complete")]
+            if middle.isdigit():
+                chapter_numbers.append(int(middle))
+    last_chapter = max(chapter_numbers) if chapter_numbers else 0
+
+    # Determine resume target
+    # Per-chapter savepoints sit between wiki_populated and story_complete.
+    # If any chapter savepoint exists, it is more recent than wiki_populated
+    # but less recent than story_complete.
+    if (
+        "story_complete" in name_set
+        or "final_edit_complete" in name_set
+    ):
+        last_completed = last_canonical
+        next_phase = PHASE_NEXT_DESCRIPTOR.get(last_canonical, "unknown")
+    elif last_chapter > 0:
+        last_completed = f"chapter_{last_chapter}_complete"
+        next_phase = (
+            f"Phase 7 — chapter {last_chapter + 1}"
+            if last_chapter > 0
+            else "Phase 7 — chapter 1"
+        )
+    else:
+        last_completed = last_canonical
+        next_phase = PHASE_NEXT_DESCRIPTOR.get(last_canonical, "unknown")
+
+    # Identify gaps in the canonical sequence below the highest completed phase
+    missing_below_top: list[str] = []
+    if last_canonical_index >= 0:
+        for phase in CANONICAL_PHASES[:last_canonical_index]:
+            if phase not in name_set:
+                missing_below_top.append(phase)
+
+    result = {
+        "last_completed": last_completed,
+        "next_phase": next_phase,
+        "last_canonical": last_canonical,
+        "last_chapter_complete": last_chapter,
+        "missing_below_top": missing_below_top,
+        "all_savepoints": names,
+    }
+    print(json.dumps(result, indent=2))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Manage story savepoints.")
     parser.add_argument(
         "--operation",
         required=True,
-        choices=["save", "load", "has", "list", "list-full", "clear"],
+        choices=[
+            "save",
+            "load",
+            "has",
+            "list",
+            "list-full",
+            "clear",
+            "next-phase",
+        ],
         help=(
             "Operation to perform. "
             "'list' returns names only (fast); "
-            "'list-full' returns names + data (can be large)"
+            "'list-full' returns names + data (can be large); "
+            "'next-phase' returns the deterministic resume target."
         ),
     )
     parser.add_argument("--name", required=True, help="Story name")
@@ -188,6 +298,9 @@ def main() -> None:
 
     elif args.operation == "clear":
         cmd_clear(args.name)
+
+    elif args.operation == "next-phase":
+        cmd_next_phase(args.name)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_savepoint_manager_tool.py
+++ b/tests/unit/test_savepoint_manager_tool.py
@@ -333,3 +333,124 @@ def test_clear_nonexistent_story(tmp_path: Path) -> None:
     )
     assert result.returncode == 1
     assert "not initialized" in result.stderr or "not found" in result.stderr
+
+
+# --- next-phase operation (issue #148) -----------------------------------
+
+
+def _save(stories_dir: Path, name: str, step: str, data: str = '"x"') -> None:
+    result = _run_tool(
+        "--operation",
+        "save",
+        "--name",
+        name,
+        "--step",
+        step,
+        "--data",
+        data,
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 0, f"save {step} failed: {result.stderr}"
+
+
+def _next_phase(stories_dir: Path, name: str) -> dict:
+    result = _run_tool(
+        "--operation",
+        "next-phase",
+        "--name",
+        name,
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 0, f"next-phase failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def test_next_phase_empty_story(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == ""
+    assert out["last_canonical"] == ""
+    assert out["last_chapter_complete"] == 0
+    assert "Phase 1" in out["next_phase"]
+
+
+def test_next_phase_only_init(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    _save(stories_dir, name, "init")
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == "init"
+    assert "Phase 2" in out["next_phase"]
+    assert out["missing_below_top"] == []
+
+
+def test_next_phase_tolerates_gaps(story_env: tuple[Path, str]) -> None:
+    """outline_complete missing but characters_complete present — picks highest."""
+    stories_dir, name = story_env
+    _save(stories_dir, name, "init")
+    _save(stories_dir, name, "arc_analysis_complete")
+    _save(stories_dir, name, "characters_complete")
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == "characters_complete"
+    assert "Phase 5" in out["next_phase"]
+    assert "outline_complete" in out["missing_below_top"]
+
+
+def test_next_phase_settings_complete(story_env: tuple[Path, str]) -> None:
+    """The exact scenario from issue #148: characters + settings present."""
+    stories_dir, name = story_env
+    _save(stories_dir, name, "init")
+    _save(stories_dir, name, "arc_analysis_complete")
+    _save(stories_dir, name, "characters_complete")
+    _save(stories_dir, name, "settings_complete")
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == "settings_complete"
+    assert "Phase 6" in out["next_phase"]
+
+
+def test_next_phase_chapter_loop(story_env: tuple[Path, str]) -> None:
+    """chapter_3_complete + chapter_5_complete → highest is 5."""
+    stories_dir, name = story_env
+    _save(stories_dir, name, "init")
+    _save(stories_dir, name, "wiki_populated")
+    _save(stories_dir, name, "chapter_1_complete")
+    _save(stories_dir, name, "chapter_3_complete")
+    _save(stories_dir, name, "chapter_5_complete")
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == "chapter_5_complete"
+    assert out["last_chapter_complete"] == 5
+    assert "chapter 6" in out["next_phase"]
+
+
+def test_next_phase_story_complete(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    _save(stories_dir, name, "init")
+    _save(stories_dir, name, "wiki_populated")
+    _save(stories_dir, name, "chapter_1_complete")
+    _save(stories_dir, name, "story_complete")
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == "story_complete"
+    assert "Phase 9" in out["next_phase"]
+
+
+def test_next_phase_final_edit_complete(story_env: tuple[Path, str]) -> None:
+    stories_dir, name = story_env
+    _save(stories_dir, name, "init")
+    _save(stories_dir, name, "wiki_populated")
+    _save(stories_dir, name, "story_complete")
+    _save(stories_dir, name, "final_edit_complete")
+    out = _next_phase(stories_dir, name)
+    assert out["last_completed"] == "final_edit_complete"
+    assert "complete" in out["next_phase"].lower()
+
+
+def test_next_phase_nonexistent_story(tmp_path: Path) -> None:
+    stories_dir = tmp_path / "stories"
+    stories_dir.mkdir()
+    result = _run_tool(
+        "--operation",
+        "next-phase",
+        "--name",
+        "no-such-story",
+        stories_dir=stories_dir,
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
Closes #148

## Summary

Introduces a deterministic `next-phase` operation on `savepoint-mgr` and rewrites `/continue` to use it. The agent no longer reasons about savepoint order from an alphabetically-sorted list — the tool walks the canonical phase order and returns the highest-completed phase plus the next phase descriptor. Also reconciles the longstanding ownership conflict between the SKILL and the `character-sheet-generator` subagent.

## Verification on the affected story

```
$ python3 src/tools/savepoint_manager.py --operation next-phase --name the-silence-between-stars
{
  "last_completed": "settings_complete",
  "next_phase": "Phase 6 (wiki population)",
  "missing_below_top": ["outline_complete"],
  ...
}
```

Previously this story resumed from Phase 2.5 (`arc_analysis_complete`). Now correctly resumes from Phase 6.

## Changes

- [x] `src/tools/savepoint_manager.py` — new `next-phase` operation + `CANONICAL_PHASES` list + `PHASE_NEXT_DESCRIPTOR` map
- [x] `.opencode/tools/savepoint-mgr.ts` — wrapper exposes new op
- [x] `.opencode/commands/continue.md` — calls `next-phase` directly; removed agent-side reasoning
- [x] `.opencode/skills/story-pipeline/SKILL.md` — "Savepoint Ownership" now documents the `character-sheet-generator` exception explicitly with a maintenance note
- [x] 8 new unit tests (empty story, gap tolerance, chapter loop, story completion, final edit, error handling)
- [x] All tests pass: 378 unit + 30 vitest
- [x] Lint + mypy clean on changed Python files

## Defects addressed

1. **Authority conflict** — SKILL forbade subagent savepoint creation but `character-sheet-generator` and orchestrator both said the subagent owns them. Resolved by carving an explicit, documented exception in the SKILL.
2. **Non-deterministic resume** — `/continue` now calls `savepoint-mgr next-phase` and follows its output. No agent reasoning required.
3. **Phase savepoint gaps** — `next-phase` tolerates gaps and reports them in `missing_below_top` so the agent can warn but not block.