### PR TITLE
docs: fix documentation drift — ADR-007 status, README wiki claims, stale Textual version hint

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: code-review
+description: Use when reviewing local changes, PRs, review reports, or synthesized multi-model findings. Prioritizes bugs, regressions, missing tests, security issues, and stale agent/skill instructions.
+---
+
+# Code Review
+
+Review like a maintainer. Findings first, ordered by severity, with file and line references. Summaries come after findings.
+
+## Review Sources
+
+1. Inspect `git status --short` and changed files.
+2. Compare against `development` when reviewing a branch.
+3. Load `project-memory` and query `conventions` for relevant gotchas.
+4. Read the implementation and tests, not only the diff, when behavior depends on surrounding code.
+5. For PR review, fetch existing PR context if available.
+
+## What To Prioritize
+
+- correctness regressions
+- security and path traversal risks
+- boundary validation gaps
+- data loss or corrupt-state paths
+- missing or weak tests for changed behavior
+- stale docs, agent instructions, skill files, and workflow references
+- mismatches between CLI flags, tool schemas, and Python implementation
+
+## Local Review Checklist
+
+Read `references/checklist.md` for the detailed repo checklist. Use it especially when reviewing agent/skill files or tool interfaces.
+
+## Synthesis
+
+If given multiple raw review reports:
+
+1. Normalize duplicate findings.
+2. Verify claims against the current files.
+3. Classify as unanimous, majority, or singular.
+4. Downgrade unverified structural claims.
+5. Exclude out-of-diff issues from required fixes unless they block the changed behavior.
+
+Write synthesized reports to `.github/notes/reviews/YYYY-MM-DD-prN-synthesis.md` when requested.

--- a/.agents/skills/code-review/references/checklist.md
+++ b/.agents/skills/code-review/references/checklist.md
@@ -1,0 +1,40 @@
+# Review Checklist
+
+## Code
+
+- Validate all external inputs at boundaries.
+- Preserve clean architecture dependency direction.
+- Avoid ad hoc string parsing where a structured parser exists.
+- Do not call CLI `cmd_*` functions from application code if they can `sys.exit()`.
+- Preserve exception causes when wrapping errors.
+- Check savepoint resume paths perform required state writes.
+
+## Tests
+
+- Tests should assert meaningful values, not only counts.
+- CLI validation tests should assert exit code and stderr fragment.
+- LLM JSON parsing should test invalid JSON, non-dict roots, null sections, and mixed list items when relevant.
+- When disk writes are added, existing tests must patch base paths.
+- New test files should cover production-used subjects, not orphaned helpers.
+
+## Docs And Instructions
+
+- Sweep for stale references after renames, deletions, or architecture changes.
+- Verify markdown links resolve.
+- Keep summary tables synchronized with body text.
+- Keep numbered workflow steps contiguous.
+- Update `AGENTS.md`, `.github/copilot-instructions.md`, `docs/manual.md`, and `docs/tools.md` when architecture terms change.
+
+## Agent And Skill Files
+
+- Tool names must match actual Codex or project tools.
+- Copilot-only tool names must not be presented as Codex-callable.
+- Avoid stale `.opencode` and TypeScript wrapper references in Python-native workflow docs unless discussing historical context.
+- When a skill references a detailed file, ensure that file exists.
+
+## False Positive Filters
+
+- Ignore `.vscode/` findings for committed-secret review if the file is gitignored and not in the diff.
+- Treat out-of-diff violations as follow-up issues unless the PR relies on that behavior.
+- Verify "companion file not updated" claims by reading the companion file.
+- Verify annotation-like comments exist in actual files before treating them as source defects.

--- a/.agents/skills/documentation-maintenance/SKILL.md
+++ b/.agents/skills/documentation-maintenance/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: documentation-maintenance
+description: Use when updating docs, README content, ADRs, planning docs, or durable project notes after implementation or architecture changes.
+---
+
+# Documentation Maintenance
+
+Update existing docs before creating new ones. Documentation must describe implemented behavior, not intended behavior.
+
+## Workflow
+
+1. Load `project-memory`.
+2. Read the issue, PR, diff, or implementation files that define the actual behavior.
+3. Find existing docs with `rg`.
+4. Update docs and indexes together.
+5. Verify paths, links, commands, examples, and behavior claims against the repo.
+6. Run relevant markdown and code validation where available.
+7. Add `.github/notes/` entries for gotchas or architectural learnings that should be remembered.
+
+## Companion Sweeps
+
+For architecture changes, ADRs, layer renames, tool changes, or workflow changes, sweep:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `docs/manual.md`
+- `docs/tools.md`
+- `.github/notes/architecture.md`
+- `.github/notes/gotchas.md`
+- `.agents/skills/`
+- `.github/agents/` if the Copilot system remains in use
+
+## Rules
+
+- No placeholder sections.
+- No broken markdown links.
+- No stale `.opencode` or TypeScript wrapper claims unless explicitly historical.
+- Tables must match body prose.
+- README updates are required for user-visible CLI, workflow, or setup changes.

--- a/.agents/skills/github-workflow/SKILL.md
+++ b/.agents/skills/github-workflow/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: github-workflow
+description: Use when asked to work on a GitHub issue, create or update a PR, address review feedback, publish local changes, run the repository development lifecycle, or coordinate implementation through Codex.
+---
+
+# GitHub Workflow
+
+This is the Codex-native replacement for the Copilot Orchestrator workflow. It preserves the repo's GitHub-auditable lifecycle while using Codex tools and local git.
+
+## Core Rules
+
+1. Work locally first. Edit files in the workspace, run verification locally, then commit and push with git.
+2. Never use remote file-write APIs to create source changes.
+3. Never use `--no-verify`.
+4. Never mark tests skipped to get a green suite.
+5. Protect user work: inspect `git status --short` before edits and do not revert unrelated changes.
+6. Use one issue per implementation session unless the user explicitly asks for planning or triage only.
+
+## Normal Lifecycle
+
+1. Resolve repo identity from `.github/notes/repo.md`.
+2. Locate or create one GitHub issue unless the user only asked for read-only status, summary, or review inspection.
+3. Create or check out a branch from `development`.
+4. Gather memory with the `project-memory` skill.
+5. Plan the change and identify files, tests, and risks.
+6. Implement locally.
+7. Run focused lint, formatting, type checks, and tests.
+8. Update docs or notes when behavior, architecture, CLI, or workflows changed.
+9. Review the diff.
+10. Commit, push, and open or update the PR.
+
+## Codex Delegation
+
+Codex subagents are optional and follow Codex rules: spawn them only when the user explicitly permits subagents, delegation, or parallel agent work. When permitted, use bounded roles:
+
+- `worker`: implementation in a disjoint file set.
+- `explorer`: focused codebase question.
+- local main agent: git operations, final integration, verification, and user communication.
+
+Do not mimic Copilot's automatic nested agent dispatch when Codex policy does not allow it.
+
+## Tool Mapping
+
+Read `references/tool-mapping.md` before using GitHub, Chroma, Tavily, or Context7 from this workflow.
+
+## Output
+
+When done, report:
+
+- issue and branch
+- files changed
+- verification run and result
+- PR link or why no PR was created
+- any residual risk or blocked step

--- a/.agents/skills/github-workflow/references/tool-mapping.md
+++ b/.agents/skills/github-workflow/references/tool-mapping.md
@@ -1,0 +1,50 @@
+# Tool Mapping
+
+Copilot instructions in `.github/agents/` use tool names that are not Codex tool names. Translate them before acting.
+
+## GitHub
+
+Preferred in this environment:
+
+- GitHub plugin/app tools exposed as `mcp__codex_apps__github.*` when available.
+- `gh` CLI for operations not exposed by the connector, especially comments, branch/PR operations, workflow logs, and review thread details.
+- Local `git` for branch, commit, merge, and push operations.
+
+Do not assume Copilot names such as `github/issue_read`, `github/issue_write`, or `github/create_branch` exist in Codex.
+
+## ChromaDB
+
+Use `mcp__chroma__`:
+
+- `chroma_query_documents`
+- `chroma_get_documents`
+- `chroma_add_documents`
+- `chroma_update_documents`
+- `chroma_get_collection_count`
+
+## Web Research
+
+Use `mcp__tavily__`:
+
+- `tavily_search`
+- `tavily_extract`
+- `tavily_crawl`
+
+Use `mcp__context7__` for library docs after resolving a library ID when that resolver is available. If only `get_library_docs` is exposed and no exact ID is known, use official docs via web search instead.
+
+## Files
+
+Use `rg` and `rg --files` for search. Use `apply_patch` for manual edits.
+
+## Verification Commands
+
+Project defaults:
+
+```bash
+ruff check --fix .
+ruff format .
+mypy src/
+pytest
+```
+
+Prefer focused commands for narrow changes, but run broader checks when shared behavior changes.

--- a/.agents/skills/planning-workflow/SKILL.md
+++ b/.agents/skills/planning-workflow/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: planning-workflow
+description: Use when turning a feature idea, vague request, architecture change, or planning document task into a concrete PRD, ADR, task breakdown, or implementation plan for this repository.
+---
+
+# Planning Workflow
+
+Plan before implementation when the user asks for planning, the scope is unclear, or the change spans architecture, workflow, or multiple modules.
+
+## Process
+
+1. Load `project-memory`.
+2. Clarify the problem, users, success criteria, non-goals, dependencies, and risks.
+3. Research the current codebase with `rg`, file reads, and focused Chroma queries.
+4. Check GitHub issues and prior planning docs when relevant.
+5. Produce a concrete plan with affected files, tests, docs, and validation commands.
+6. Record durable discoveries in `.github/notes/` if they will matter later.
+
+## Planning Artifacts
+
+Use `docs/planning/<slug>/prd.md` for product requirements.
+Use `docs/planning/<slug>/tasks.md` for task breakdowns.
+Use `docs/planning/adr/NNN-<slug>.md` for architecture decisions.
+
+Templates live in `references/templates.md`.
+
+## Guardrails
+
+- Do not write production code while acting only as planner.
+- Prefer existing repo patterns over new abstractions.
+- Separate "must ship now" from follow-up ideas.
+- Verify every path and link included in a plan.
+- Explicitly call out stale Copilot/OpenCode assumptions when a plan touches agent infrastructure.

--- a/.agents/skills/planning-workflow/references/templates.md
+++ b/.agents/skills/planning-workflow/references/templates.md
@@ -1,0 +1,77 @@
+# Planning Templates
+
+## PRD
+
+```markdown
+# PRD: <Feature Name>
+
+> One-sentence summary.
+
+**Date:** YYYY-MM-DD
+**Status:** Draft
+
+## Problem Statement
+
+## Goals
+
+## Non-Goals
+
+## User Stories
+
+## Proposed Solution
+
+## Acceptance Criteria
+
+## Risks
+
+## Open Questions
+
+## Related
+```
+
+## Task Breakdown
+
+```markdown
+# Task Breakdown: <Feature Name>
+
+> Implements [PRD](./prd.md)
+
+**Date:** YYYY-MM-DD
+
+## Tasks
+
+### Task 1: <Short Title>
+
+**Type:** backend | docs | workflow | infrastructure
+**Estimated scope:** small | medium | large
+**Dependencies:** none
+
+**Description:**
+
+**Acceptance Criteria:**
+
+- [ ] Specific, testable outcome
+
+**Key Files:**
+
+- `path/to/file.py` — expected change
+```
+
+## ADR
+
+```markdown
+# ADR NNN: <Decision>
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Superseded
+
+## Context
+
+## Decision
+
+## Consequences
+
+## Alternatives Considered
+
+## Follow-up Work
+```

--- a/.agents/skills/project-memory/SKILL.md
+++ b/.agents/skills/project-memory/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: project-memory
+description: Use when planning, implementing, reviewing, documenting, or reflecting in this repository and prior project knowledge may matter. Loads the Codex-native memory protocol for .github/notes and ChromaDB recall.
+---
+
+# Project Memory
+
+Use this skill before substantive repository work. The authoritative memory store is `.github/notes/`; ChromaDB is a derived semantic index.
+
+## Start Of Task
+
+1. Read `.github/notes/README.md` for note conventions if the task may create or update knowledge.
+2. Read topic files relevant to the task: commonly `architecture.md`, `gotchas.md`, `deferred.md`, and `repo.md`.
+3. Query ChromaDB before planning, implementing, testing, reviewing, or documenting.
+4. Treat Chroma hits as pointers. Verify important claims against files in the repo before acting.
+
+## Chroma Queries
+
+Use `mcp__chroma__` tools when available:
+
+```text
+conventions: gotchas, patterns, architecture notes
+reflections: active agent-system improvement notes
+audits: audit findings and health reports
+codebase: feature docs, ADRs, skills, module facts
+tests: test patterns and fixtures
+```
+
+For detailed schemas, ID conventions, and examples, read `references/chromadb.md`.
+
+## Writing Memory
+
+1. Write new durable knowledge to `.github/notes/` first.
+2. Include `Date`, `Source`, and enough context for a future agent to trust the note.
+3. Add or update the matching ChromaDB document after the note exists.
+4. Do not store secrets, transient logs, or unverified guesses as durable memory.
+
+## Scope
+
+This skill is for project memory and recall only. Use task-specific skills for GitHub workflow, planning, testing, reviewing, documentation, or web research.

--- a/.agents/skills/project-memory/references/chromadb.md
+++ b/.agents/skills/project-memory/references/chromadb.md
@@ -1,0 +1,70 @@
+# ChromaDB Reference
+
+The repo uses ChromaDB as a derived semantic index over `.github/notes/` and selected docs. Markdown files are authoritative.
+
+## Collections
+
+| Collection | Purpose | Typical Query Time |
+| --- | --- | --- |
+| `conventions` | Gotchas, patterns, architecture, domain notes | planning, implementation, review |
+| `reflections` | Agent-system improvement notes | reflection, workflow edits |
+| `audits` | Audit reports and findings | planning, review, architecture work |
+| `codebase` | Feature docs, ADRs, skills, modules | planning, documentation |
+| `tests` | Test patterns, fixtures, failure learnings | test writing and review |
+
+## Standard Queries
+
+Before planning:
+
+```json
+{
+  "collection_name": "conventions",
+  "query_texts": ["<feature or fix description>"],
+  "n_results": 10
+}
+```
+
+Before implementation:
+
+```json
+{
+  "collection_name": "conventions",
+  "query_texts": ["<task description>"],
+  "n_results": 10,
+  "where": {
+    "$or": [
+      {"category": {"$eq": "gotcha"}},
+      {"category": {"$eq": "pattern"}}
+    ]
+  }
+}
+```
+
+Before tests:
+
+```json
+{
+  "collection_name": "tests",
+  "query_texts": ["<test domain>"],
+  "n_results": 5
+}
+```
+
+Before documentation:
+
+```json
+{
+  "collection_name": "codebase",
+  "query_texts": ["<feature name>"],
+  "n_results": 5
+}
+```
+
+## Write Pattern
+
+1. Add or update the Markdown source in `.github/notes/`.
+2. Use stable IDs.
+3. Include `source_file` metadata.
+4. Use `chroma_add_documents` for new IDs and `chroma_update_documents` for existing IDs.
+
+Never delete from `conventions` or `reflections` as part of normal task work. Update or supersede instead.

--- a/.agents/skills/test-verification/SKILL.md
+++ b/.agents/skills/test-verification/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: test-verification
+description: Use when writing, updating, or evaluating tests for this repository, especially after implementation changes or when validating CLI/tool behavior.
+---
+
+# Test Verification
+
+Tests verify implemented behavior. They should be meaningful, isolated, and aligned with existing patterns.
+
+## Workflow
+
+1. Load `project-memory` and query the `tests` collection.
+2. Read nearby tests before adding new ones.
+3. Prefer extending existing test files over creating isolated new files.
+4. Write focused tests for the changed behavior.
+5. Run the smallest useful test command first, then broader checks as risk increases.
+
+## Assertions
+
+- Assert specific expected values, not only non-empty results.
+- Keep expected constants independent from production constants when pinning contract values.
+- For argparse validation, assert `returncode == 2` and useful stderr.
+- For LLM JSON parsing, cover invalid JSON, valid non-dict JSON, null sections, and mixed list items when relevant.
+- For disk-writing code, patch storage roots and avoid real story data.
+
+## Handoff
+
+Report test files changed, test cases added, commands run, and any pre-existing failures.

--- a/.agents/skills/web-research/SKILL.md
+++ b/.agents/skills/web-research/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: web-research
+description: Use when current external information, official documentation, web search, content extraction, or library/API research is needed for this repository.
+---
+
+# Web Research
+
+Use web research when facts may have changed, the user asks to look something up, or external docs are needed.
+
+## Source Preference
+
+1. Official documentation and primary sources.
+2. Release notes and source repositories.
+3. Maintainer discussions or issues.
+4. Secondary summaries only as leads, not authority.
+
+## Tools
+
+Use `mcp__tavily__` when available:
+
+- `tavily_search` for broad discovery.
+- `tavily_extract` for known URLs.
+- `tavily_crawl` for related docs pages.
+
+Use Context7 for library docs when an exact library ID is known or can be resolved by available tools. For OpenAI product/API questions, use official OpenAI docs only.
+
+## Output
+
+Summarize findings with source links. Distinguish source facts from inference. Do not paste long copyrighted text.

--- a/.github/notes/reviews/2026-04-26-pr204-claude-raw.md
+++ b/.github/notes/reviews/2026-04-26-pr204-claude-raw.md
@@ -1,0 +1,96 @@
+# Code Review Report — PR #204 (docs/issue-189-fix-documentation-drift)
+
+**Reviewer:** Claude Sonnet 4.6
+**Date:** 2026-04-26
+**Branch:** `docs/issue-189-fix-documentation-drift`
+**Commit:** `431adc5 docs: fix documentation drift — ADR-007 status, README wiki claims, Textual version hint (#189)`
+
+---
+
+## Review Summary
+
+This PR addresses documentation drift across four files: ADR-007 status promotion, README wiki/ChromaDB disclaimers, tasks.md Task 4 checkbox updates, and a Textual version hint in the CLI error path. Two of the four changes are correct and well-executed. However, the PR introduces two significant problems: a test broken by the `main.py` change, and README disclaimers that describe a wiki persistence gap that was already closed by PR #195 — directly contradicting the acknowledgement of that fix already present in `docs/features/wiki-maintainer.md`.
+
+**Files Reviewed:** 4
+**Findings:** 2 Critical, 1 Warning, 0 Suggestions
+
+---
+
+## Findings
+
+### Critical Findings
+
+```
+[C-01] README wiki persistence disclaimer is factually inaccurate — issue #183 is already resolved
+Category: Documentation
+Severity: Critical
+File: README.md
+Lines: 205, 216
+Description: The PR adds two notes asserting that wiki page persistence "is not yet wired
+end-to-end" and that "wiki embedding depends on the wiki persistence layer tracked in
+issue #183." Both statements are incorrect. Issue #183 / PR #195 already completed the
+wiki persistence work. The full call chain is operational:
+  WikiMaintainerAgent.run()
+    → update_wiki_from_chapter()   (src/tools/wiki_extract.py)
+    → run_batch()                  (src/tools/wiki_update.py)
+    → _atomic_write() per page     (writes markdown files to disk)
+    → _upsert_to_chromadb()        (embeds each page into ChromaDB)
+
+This is confirmed by docs/features/wiki-maintainer.md (line 11), which states:
+  "Issue #183 completes the post-chapter persistence path. [...] That makes ADR 004's
+  structured wiki pages and ADR 005's retrieval-ready detail levels operational during
+  the live chapter loop rather than design-only."
+
+Adding these disclaimers post-resolution contradicts the existing feature documentation
+and would mislead users into thinking the wiki system is non-functional.
+Suggestion: Remove both added notes from README.md. If there is a remaining gap distinct
+from what PR #195 addressed, open a new issue and reference that instead.
+```
+
+```
+[C-02] Test expects stale Textual version string — will fail after main.py change
+Category: Testing
+Severity: Critical
+File: tests/unit/test_cli_main.py
+Lines: 192-193
+Description: The test test_missing_textual_reports_install_instruction asserts that the
+CLI error message contains:
+  "  pip install 'textual>=0.85.0,<1.0.0'\n\n"
+But src/presentation/cli/main.py was updated by this PR to emit:
+  "  pip install 'textual>=6.0,<7.0'\n"
+The test will fail because the assertion checks for the old version constraint. The PR
+updated the source but not the corresponding test.
+Suggestion: Update line 193 in tests/unit/test_cli_main.py to:
+  "  pip install 'textual>=6.0,<7.0'\n\n"
+```
+
+---
+
+### Warning Findings
+
+```
+[W-01] ADR-007 implementation status is self-contradictory about Task 8
+Category: Documentation
+Severity: Warning
+File: docs/planning/adr/007-python-native-orchestration.md
+Lines: 66–75 (new Implementation Status section)
+Description: The added section opens with "Tasks 1–9 and Task 12 are complete." It then
+immediately lists "Task 8 (Textual TUI) — in progress" under tasks that remain open.
+Claiming Task 8 is both complete (as part of "Tasks 1–9") and in progress is a direct
+contradiction. Verification: tasks.md shows Task 8 has no "Status: implemented" field,
+and all six acceptance-criteria checkboxes for Task 8 remain unchecked ([ ]).
+Suggestion: Change the opening sentence to "Tasks 1–7, 9, and 12 are complete." to
+exclude Task 8 explicitly.
+```
+
+---
+
+## Overall Assessment
+
+The PR is not ready to merge in its current form. Two changes require fixes before merge:
+
+1. **C-02 will break CI.** The test `test_missing_textual_reports_install_instruction` asserts the old version string. This is a straightforward one-line fix.
+
+2. **C-01 introduces false documentation.** The README wiki disclaimer describes a problem (wiki persistence not wired) that was solved in a prior merged PR (#195). The existing `docs/features/wiki-maintainer.md` already correctly documents the completed state; the new README notes contradict it. These notes should be removed rather than corrected, because the state they describe does not exist in the codebase.
+
+The remaining changes are correct: the ADR-007 status promotion from "Proposed" to "Accepted" is appropriate given the level of implementation, the Textual version update in `main.py` is consistent with `requirements.txt` and `pyproject.toml`, and the Task 4 checkbox updates accurately reflect the implementation delivered in PR #170. The W-01 contradiction in the ADR status section is a low-effort fix that prevents reader confusion.

--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,9 @@ SavePoints/*
 .opencode/cache/
 .opencode/logs/
 
+# Codex runtime marker
+.codex
+
 # Chromadb local data
 .chromadb/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,20 @@ Story generation agent prompt files are defined in `prompts/agents/` and loaded 
 
 Story generation skills are defined in `prompts/skills/`. The `story-pipeline` skill provides the pipeline reference (phases, quality gates, savepoints, config settings).
 
+### Codex Workflow Skills
+
+Codex-native development workflows live in `.agents/skills/`. These are the canonical workflow instructions for Codex sessions in this repository:
+
+- `project-memory` — `.github/notes/` and ChromaDB recall protocol
+- `github-workflow` — issue/branch/implementation/verification/PR lifecycle
+- `planning-workflow` — PRDs, ADRs, task breakdowns, and implementation plans
+- `code-review` — local and PR review process, including synthesis guidance
+- `test-verification` — test-writing and verification rules
+- `documentation-maintenance` — docs, ADR, README, and companion-file updates
+- `web-research` — current external research with Tavily, Context7, and primary sources
+
+Older VS Code/GitHub Copilot agent definitions remain under `.github/agents/` for reference and Copilot use. Do not treat their `tools:` frontmatter or `github/...` tool names as directly callable by Codex; translate through the Codex workflow skills first.
+
 ### Storage
 
 - Stories are stored in `stories/<name>/` directories with JSON state files

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ The progressive wiki memory system maintains structured story knowledge using ma
 
 The wiki is automatically updated after each scene by the wiki-maintainer agent, ensuring consistent story state throughout generation.
 
+> **Note:** Wiki page persistence is currently in progress. The `WikiMaintainerAgent` generates wiki content but persistent storage is not yet wired end-to-end. Full implementation is tracked in issue #183.
+
 ## 🔍 ChromaDB RAG
 
 Semantic search for context retrieval using ChromaDB vector collections:
@@ -210,6 +212,8 @@ Semantic search for context retrieval using ChromaDB vector collections:
 - **Wiki Embedding**: Wiki pages are automatically embedded when created or updated
 - **Hybrid Retrieval**: Combines entity matching, metadata filtering, semantic search, and wikilink traversal
 - **Context Assembly**: The `wiki-snapshot` tool assembles token-budgeted context for each scene using detail levels L1/L2/L3
+
+*Wiki embedding depends on the wiki persistence layer tracked in issue #183. Other ChromaDB retrieval features (entity matching, metadata filtering, context assembly) are fully operational.*
 
 ## 🔧 Development
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,6 @@ The progressive wiki memory system maintains structured story knowledge using ma
 
 The wiki is automatically updated after each scene by the wiki-maintainer agent, ensuring consistent story state throughout generation.
 
-> **Note:** Wiki page persistence is currently in progress. The `WikiMaintainerAgent` generates wiki content but persistent storage is not yet wired end-to-end. Full implementation is tracked in issue #183.
-
 ## 🔍 ChromaDB RAG
 
 Semantic search for context retrieval using ChromaDB vector collections:
@@ -212,8 +210,6 @@ Semantic search for context retrieval using ChromaDB vector collections:
 - **Wiki Embedding**: Wiki pages are automatically embedded when created or updated
 - **Hybrid Retrieval**: Combines entity matching, metadata filtering, semantic search, and wikilink traversal
 - **Context Assembly**: The `wiki-snapshot` tool assembles token-budgeted context for each scene using detail levels L1/L2/L3
-
-*Wiki embedding depends on the wiki persistence layer tracked in issue #183. Other ChromaDB retrieval features (entity matching, metadata filtering, context assembly) are fully operational.*
 
 ## 🔧 Development
 

--- a/docs/planning/adr/007-python-native-orchestration.md
+++ b/docs/planning/adr/007-python-native-orchestration.md
@@ -66,7 +66,7 @@ A formal architecture review (issue #188) examined the gap and issued [ADR 008](
 
 ## Implementation Status (2026-04-26)
 
-Tasks 1–9 and Task 12 are complete. The following tasks remain open and are tracked as separate GitHub issues:
+Tasks 1–7, 9, and 12 are complete. The following tasks remain open and are tracked as separate GitHub issues:
 
 - **Task 8** (Textual TUI) — in progress
 - **Task 10** (documentation sweep) — tracked in issue #189

--- a/docs/planning/adr/007-python-native-orchestration.md
+++ b/docs/planning/adr/007-python-native-orchestration.md
@@ -1,7 +1,7 @@
 # ADR 007: Python-Native Orchestration and TUI (Supersedes ADR 001)
 
 **Date:** 2026-04-24
-**Status:** Proposed — supersedes [ADR 001](./001-hybrid-agent-tool-architecture.md)
+**Status:** Accepted — supersedes [ADR 001](./001-hybrid-agent-tool-architecture.md)
 
 ## Context
 
@@ -63,3 +63,13 @@ ADRs 002–006 remain in force. Context window management, ChromaDB retrieval, p
 During the Python-native migration, all orchestrator agents were implemented to call `provider.stream_text()` directly rather than routing through `src/application/services/`. This diverged from the intent stated in Decision point 5 above (*"the Python orchestrator imports and calls `src/application/services/*.py` directly, in-process"*).
 
 A formal architecture review (issue #188) examined the gap and issued [ADR 008](./008-retire-application-services-layer.md), which formally retires the services layer as dead code. The exception is `critique_parser.py`, which has active callers in `src/tools/critique_runner.py` and is retained.
+
+## Implementation Status (2026-04-26)
+
+Tasks 1–9 and Task 12 are complete. The following tasks remain open and are tracked as separate GitHub issues:
+
+- **Task 8** (Textual TUI) — in progress
+- **Task 10** (documentation sweep) — tracked in issue #189
+- **Task 11** (end-to-end integration test) — tracked separately
+
+The core Python-native runtime (provider, prompt loader, pipeline handoffs, approval gates, token streaming, orchestrator, CLI, and TypeScript cleanup) is fully operational.

--- a/docs/planning/python-native-migration/tasks.md
+++ b/docs/planning/python-native-migration/tasks.md
@@ -96,6 +96,8 @@ Create `src/application/pipeline/handoffs.py` with dataclasses/Pydantic models r
 **Estimated scope:** small
 **Dependencies:** Task 3
 
+**Status:** implemented in Issue #160 / PR #170
+
 **Description:**
 
 Create `src/presentation/pipeline_primitives.py`. Implement:
@@ -108,12 +110,12 @@ All three primitives are transport-agnostic — the TUI and headless runner both
 
 **Acceptance Criteria:**
 
-- [ ] `ApprovalGate.await_decision()` blocks until `.resolve()` is called and returns the provided decision
-- [ ] `NullApprovalGate` returns `APPROVE` immediately without blocking
-- [ ] `TokenStreamBus` forwards all emitted deltas in order to the consumer
-- [ ] `WikiContextBus` forwards all emitted events in order to the consumer
-- [ ] Closing any bus terminates its async iterator cleanly
-- [ ] Unit tests cover: single-consumer, null gate, close-before-consume, close-mid-consume, wiki event emit
+- [x] `ApprovalGate.await_decision()` blocks until `.resolve()` is called and returns the provided decision
+- [x] `NullApprovalGate` returns `APPROVE` immediately without blocking
+- [x] `TokenStreamBus` forwards all emitted deltas in order to the consumer
+- [x] `WikiContextBus` forwards all emitted events in order to the consumer
+- [x] Closing any bus terminates its async iterator cleanly
+- [x] Unit tests cover: single-consumer, null gate, close-before-consume, close-mid-consume, wiki event emit
 
 **Key Files:**
 

--- a/src/presentation/cli/main.py
+++ b/src/presentation/cli/main.py
@@ -21,7 +21,7 @@ def _cmd_tui(story: str, *, resume: bool = False, savepoint: str | None = None) 
     except ImportError:
         print(
             "textual is not installed. Install it with:\n"
-            "  pip install 'textual>=0.85.0,<1.0.0'\n",
+            "  pip install 'textual>=6.0,<7.0'\n",
             file=sys.stderr,
         )
         raise SystemExit(1)

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -190,7 +190,7 @@ class TestCmdTui:
         assert exc_info.value.code == 1
         assert capsys.readouterr().err == (
             "textual is not installed. Install it with:\n"
-            "  pip install 'textual>=0.85.0,<1.0.0'\n\n"
+            "  pip install 'textual>=6.0,<7.0'\n\n"
         )
 
 


### PR DESCRIPTION
## Summary

Fix documentation drift from issue #189 and carry the Codex workflow port that happened on this branch after the original Copilot work. The original README wiki caveat was removed after local review because issue #183 / PR #195 already completed wiki persistence, so the README wiki claims are currently accurate.

## Closes
Closes #189

## Changes
- [x] `ADR-007` status updated from `Proposed` to `Accepted`
- [x] `ADR-007` Implementation Status addendum added with completed tasks and remaining follow-ups
- [x] Stale Textual install hint in `src/presentation/cli/main.py` corrected: `>=0.85.0,<1.0.0` -> `>=6.0,<7.0`
- [x] Corresponding CLI unit test updated for the new Textual version hint
- [x] Task 4 (pipeline primitives) in `docs/planning/python-native-migration/tasks.md` marked implemented (Issue #160 / PR #170)
- [x] Local review findings addressed: removed false README wiki-persistence caveats and fixed ADR Task 8 contradiction
- [x] Codex-native workflow skills added under `.agents/skills/` and documented in `AGENTS.md`
- [x] Empty Codex runtime marker `.codex` removed from version control and ignored

## Verification
- `ruff check --fix .` — pass
- `ruff format .` — pass, 154 files unchanged
- `mypy src/` — pass, no issues found
- `pytest tests/unit/test_cli_main.py -v` — pass, 18 passed
- `pytest` — blocked by pre-existing missing environment dependencies during collection: `openai` and `textual` outside `.venv`, then `aiohttp` inside `.venv`

## Notes
- `gh` defaults to the upstream repo (`datacrystals/AIStoryWriter`) in this checkout; PR commands were run with `--repo logicalor/llm-story-writer`.
- GitHub currently reports this PR as mergeable and has no status checks configured.