### PR TITLE
chore: declare aiohttp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "llm-story-writer"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
+	"aiohttp>=3.9.0",
 	"httpx>=0.25.0",
 	"openai>=1.0",
 	"pyyaml>=6.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Core dependencies
+aiohttp>=3.9.0
 requests>=2.25.0
 openai>=1.0.0
 

--- a/src/presentation/tui/app.py
+++ b/src/presentation/tui/app.py
@@ -90,7 +90,7 @@ class StoryWriterApp(App[None]):
 
     BINDINGS = [
         # Manual save shortcut removed; phase savepoints are automatic.
-        Binding("ctrl+w", "toggle_wiki", "Toggle wiki panel"),
+        Binding("ctrl+w", "toggle_wiki", "Toggle wiki panel", priority=True),
         Binding("ctrl+c", "request_quit", "Cancel", show=True),
     ]
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -170,7 +170,7 @@ class TestPipelineCompletion:
                 app._on_pipeline_complete("error")
 
                 assert app.sub_title == "Failed - error"
-                assert app.query_one("#phase-assembly").renderable == "- assembly"
+                assert str(app.query_one("#phase-assembly").render()) == "- assembly"
 
 
 class TestQuitAction:


### PR DESCRIPTION
## Summary
- Declare aiohttp as a direct dependency in both pyproject.toml and requirements.txt because the embedding provider imports it directly.
- Confirm pytest defaults are already limited to tests/unit via pyproject.toml.
- Keep TUI unit tests compatible with Textual 6 by making the wiki toggle binding priority and using the current Label render API.

Closes #190

## Verification
- uv run python -c "import aiohttp; print(aiohttp.__version__)"
- uv run ruff check --fix .
- uv run ruff format .
- uv run mypy src/
- uv run pytest tests/unit/test_tui.py -q
- uv run pytest