### PR TITLE
fix: backfill chapter files on resume

### DIFF
--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -116,6 +116,18 @@ def _write_chapter_file(story_dir: Path, chapter_number: int, content: str) -> N
     )
 
 
+def _backfill_missing_chapter_files(
+    story_dir: Path, approved_chapters: list[ChapterDraft]
+) -> None:
+    """Write persisted approved chapters that are absent from disk."""
+    chapters_dir = story_dir / "chapters"
+    for draft in approved_chapters:
+        chapter_path = chapters_dir / f"chapter_{draft.chapter_number}.md"
+        if chapter_path.exists():
+            continue
+        _write_chapter_file(story_dir, draft.chapter_number, draft.content)
+
+
 def _chapter_numbers(
     outline_result: OutlineResult | None, settings: GenerationSettings
 ) -> list[int]:
@@ -448,6 +460,7 @@ async def _continue_pipeline(
             )
 
         chapter_numbers = _chapter_numbers(outline_result, settings)
+        _backfill_missing_chapter_files(story_dir, state.approved_chapters)
         next_chapter = len(state.approved_chapters) + 1
         if "chapter-loop" not in state.completed_phases:
             chapter_agent = ChapterWriterAgent(
@@ -629,6 +642,10 @@ async def resume_pipeline(
             f"Savepoint '{savepoint_name}' not found in story '{story_name}'. "
             f"Available savepoints: {state.savepoints}"
         )
+
+    _backfill_missing_chapter_files(
+        STORIES_DIR / state.story_name, state.approved_chapters
+    )
 
     if state.status == "complete":
         bus.close()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -73,6 +73,19 @@ def _chapter_draft() -> ChapterDraft:
     )
 
 
+def _two_chapter_outline_result() -> OutlineResult:
+    return OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[
+            {"chapter_number": 1, "title": "Chapter 1", "summary": "Intro"},
+            {"chapter_number": 2, "title": "Chapter 2", "summary": "Turn"},
+        ],
+        summary="Story summary",
+        genre="science fiction",
+        themes=["memory"],
+    )
+
+
 def _wiki_batch() -> WikiUpdateBatch:
     return WikiUpdateBatch(
         story_name="test-story",
@@ -402,6 +415,89 @@ async def test_resume_pipeline_from_savepoint(tmp_path: Path) -> None:
     assert state.status == "complete"
     assert "chapter-loop" in state.completed_phases
     assert any(savepoint.startswith("chapter-") for savepoint in state.savepoints)
+
+
+@pytest.mark.asyncio
+async def test_resume_pipeline_backfills_missing_chapter_files(tmp_path: Path) -> None:
+    provider = MagicMock()
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    chapter_one = ChapterDraft(
+        story_name="test-story",
+        chapter_number=1,
+        title="Chapter 1",
+        content="Existing approved content",
+        word_count=3,
+    )
+    chapter_two = ChapterDraft(
+        story_name="test-story",
+        chapter_number=2,
+        title="Chapter 2",
+        content="Missing approved content",
+        word_count=3,
+    )
+    partial_state = PipelineState(
+        story_name="test-story",
+        current_phase="complete",
+        completed_phases=[
+            "init",
+            "outline",
+            "narrative-arc",
+            "characters",
+            "settings",
+            "chapter-loop",
+            "final-edit",
+            "assembly",
+        ],
+        outline_result=_two_chapter_outline_result(),
+        approved_chapters=[chapter_one, chapter_two],
+        status="complete",
+        savepoints=[
+            "init",
+            "outline",
+            "arc_analysis_complete",
+            "characters",
+            "settings",
+            "chapter-loop",
+            "final_edit_complete",
+            "assembly",
+            "complete",
+        ],
+    )
+
+    def fake_savepoint_path(story_name: str) -> Path:
+        return tmp_path / story_name / "savepoints" / "pipeline_state.json"
+
+    existing_chapter_path = tmp_path / "test-story" / "chapters" / "chapter_1.md"
+    existing_chapter_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_chapter_path.write_text("Keep this chapter file\n", encoding="utf-8")
+
+    with (
+        patch(
+            "presentation.orchestrator._savepoint_path", side_effect=fake_savepoint_path
+        ),
+        patch("presentation.orchestrator.STORIES_DIR", tmp_path),
+        patch("tools._io.STORIES_DIR", tmp_path),
+    ):
+        await _write_savepoint(partial_state)
+
+        state = await resume_pipeline(
+            "test-story",
+            None,
+            NullApprovalGate(),
+            bus,
+            wiki_bus,
+            config=_config(),
+            provider=provider,
+        )
+
+    assert state.status == "complete"
+    assert (
+        existing_chapter_path.read_text(encoding="utf-8") == "Keep this chapter file\n"
+    )
+    assert (tmp_path / "test-story" / "chapters" / "chapter_2.md").read_text(
+        encoding="utf-8"
+    ) == "Missing approved content"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an idempotent chapter-file backfill for persisted approved chapters during resume
- run the backfill before returning already-complete pipeline states
- cover missing-file backfill and existing-file preservation in orchestrator tests

Closes #193

## Verification
- ruff check --fix .
- ruff format .
- pytest tests/unit/test_orchestrator.py -v
- pytest (520 passed, 1 warning)
- mypy src/ (fails in existing OpenAI provider typing after installing declared requirements: openai_async_provider.py has OpenAI 2.x chat completion type errors)
