### PR TITLE
Surface all parsed consistency findings from the orchestrator

### DIFF
--- a/.github/notes/reviews/2026-04-27-pr219-glm-raw.md
+++ b/.github/notes/reviews/2026-04-27-pr219-glm-raw.md
@@ -1,0 +1,94 @@
+# Code Review Report — GLM (Raw)
+
+**Branch:** `feat/issue-213-surface-consistency-findings`
+**Commit:** `a9a1528 feat(orchestrator): surface non-critical consistency findings (#213)`
+**Reviewer:** GLM 5.1
+**Date:** 2026-04-27
+
+---
+
+## Review Summary
+
+This PR adds an `elif` branch to the orchestrator's consistency-check output logic so that non-critical findings (warnings/info) are emitted to the token stream even when `consistency_result["passed"]` is `True`. Previously, only the `not passed` path emitted issues; the `passed=True` path silently discarded them. A new test verifies the emitted output. The change is small, focused, and correct. One minor duplication concern and one test-coverage gap noted below.
+
+**Files Reviewed:** 2
+**Findings:** 0 Critical, 1 Warning, 2 Suggestions
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] Duplicated issue-emission loop in both branches
+Category: Style
+Severity: Warning
+File: src/presentation/orchestrator.py
+Lines: 511-513, 519-521
+Description: The `for issue in consistency_result["issues"]` loop and its body
+  (`await bus.emit(f"  [{issue['severity'].upper()}] {issue['description']}\n")`)
+  are identical in both the `if not passed` and `elif issues` branches. The only
+  difference between the two branches is the header message ("issues found" vs
+  "warnings/info found"). This duplication is not a bug, but it means any future
+  change to the issue-formatting logic must be applied in two places.
+Suggestion: Extract the loop into a helper or restructure to emit the header
+  conditionally then loop once:
+
+  ```python
+  if consistency_result["issues"]:
+      header = (
+          f"\n[Consistency] Chapter {chapter_number} — issues found:\n"
+          if not consistency_result["passed"]
+          else f"\n[Consistency] Chapter {chapter_number} — warnings/info found:\n"
+      )
+      await bus.emit(header)
+      for issue in consistency_result["issues"]:
+          await bus.emit(
+              f"  [{issue['severity'].upper()}] {issue['description']}\n"
+          )
+  ```
+
+  This preserves the distinct header wording while eliminating the duplicated loop.
+```
+
+### Suggestions
+
+```
+[S-01] No test for the `passed=False` + issues emission path
+Category: Testing
+Severity: Suggestion
+File: tests/unit/test_orchestrator.py
+Lines: general
+Description: The new test covers `passed=True` with issues. All existing tests
+  use `{"issues": [], "passed": True}` — none test the `passed=False` path with
+  issues present. While the `not passed` branch is pre-existing code (not
+  introduced by this PR), the PR's focus on consistency-check output makes this
+  a natural moment to add coverage for the other branch. This is out of scope
+  for the PR's stated purpose but worth noting.
+Suggestion: Consider adding a test in a follow-up that sets `passed=False` with
+  issues and asserts the "issues found" header appears in emitted output.
+```
+
+```
+[S-02] Test does not verify absence of the wrong header
+Category: Testing
+Severity: Suggestion
+File: tests/unit/test_orchestrator.py
+Lines: 1409
+Description: The test asserts the "warnings/info found" header is present but
+  does not assert that the "issues found" header is absent. A regression that
+  emits both headers would still pass. Adding a negative assertion strengthens
+  the test.
+Suggestion: Add:
+
+  ```python
+  assert "[Consistency] Chapter 1 — issues found:" not in emitted
+  ```
+```
+
+---
+
+## Overall Assessment
+
+The code is ready for merge. The change is minimal, well-targeted, and correctly addresses issue #213 — non-critical consistency findings are now surfaced to the user instead of being silently discarded. The test follows existing patterns in the file and validates the core behavior. The one Warning (duplicated loop) is a maintainability concern, not a correctness issue, and could be addressed in a follow-up if desired. No security, performance, or architectural concerns apply to this change.

--- a/.github/notes/reviews/2026-04-27-pr219-kimi-raw.md
+++ b/.github/notes/reviews/2026-04-27-pr219-kimi-raw.md
@@ -1,0 +1,49 @@
+# Code Review Report — PR #219
+
+**Branch:** `feat/issue-213-surface-consistency-findings`
+**Commit:** `a9a1528` — `feat(orchestrator): surface non-critical consistency findings (#213)`
+**Review Date:** 2026-04-27
+**Reviewer:** Kimi (Reviewer Sub-agent)
+
+---
+
+## Review Summary
+
+This PR adds an `elif` branch in `src/presentation/orchestrator.py` so that non-critical consistency findings (`passed=True` but `issues` non-empty) are emitted to `TokenStreamBus` alongside the existing critical-finding path. A single focused unit test verifies the new behavior. The change is small (2 files, ~70 lines), correct, and follows existing patterns.
+
+**Files Reviewed:** 2  
+**Findings:** 0 Critical, 0 Warning, 2 Suggestion
+
+---
+
+## Findings
+
+### Suggestions
+
+```
+[S-01] Missing documentation for new warning-emission path
+Category: Documentation
+Severity: Suggestion
+File: docs/features/story-orchestrator.md
+Lines: 130
+Description: The documentation accurately describes the existing behavior for `passed=False` ("emits a `[Consistency] Chapter N — issues found:` header"). However, it does not mention the new behavior introduced by this PR: when `passed=True` but `issues` is non-empty, the orchestrator now emits `[Consistency] Chapter N — warnings/info found:`. This omission means the documented contract is incomplete for readers trying to understand the full consistency-checker integration.
+Suggestion: Add a sentence after line 130 describing the new path, e.g. "When `passed` is `true` but `issues` is non-empty, it emits a `[Consistency] Chapter N — warnings/info found:` header instead, and still continues with persistence."
+```
+
+```
+[S-02] Pre-existing `passed=False` emission path lacks unit-test coverage
+Category: Testing
+Severity: Suggestion
+File: tests/unit/test_orchestrator.py
+Lines: general
+Description: The test suite contains no test that verifies the `TokenStreamBus` output when `consistency_result["passed"]` is `False` and issues are present. The new test added in this PR (`test_consistency_warnings_emitted_even_when_passed_true`) provides excellent coverage for the new branch, but the sibling critical-failure branch remains untested. Adding a matching test for the `passed=False` path would ensure both branches are protected from future regressions.
+Suggestion: Add a new test (or extend the existing one with a parameterized second case) that mocks `consistency_cls.return_value.run` to return `{"issues": [...], "passed": False}` and asserts that `[Consistency] Chapter 1 — issues found:` appears in the emitted stream.
+```
+
+---
+
+## Overall Assessment
+
+The code is **ready for merge** with no blockers. The logic change is minimal, correctly placed, and preserves all existing behavior. The new unit test uses the same mocking and patching conventions as the rest of the file and asserts on the exact emitted strings. The two Suggestions are minor: one is a documentation completeness gap, and the other is a pre-existing test-coverage gap that would benefit from being addressed while the area is already under change.
+
+No security, performance, or correctness concerns were identified.

--- a/.github/notes/reviews/2026-04-27-pr219-qwen-raw.md
+++ b/.github/notes/reviews/2026-04-27-pr219-qwen-raw.md
@@ -1,0 +1,89 @@
+# Code Review — PR #219: Surface Non-Critical Consistency Findings
+
+**Branch:** `feat/issue-213-surface-consistency-findings`
+**Commit:** `a9a1528 feat(orchestrator): surface non-critical consistency findings (#213)`
+**Reviewer:** Qwen (Reviewer mode)
+**Date:** 2026-04-27
+
+---
+
+## Review Summary
+
+Small, focused change that adds an `elif` branch to emit consistency warnings/info to the token stream when `passed=True` but non-critical issues exist. Previously these were silently discarded. One test added covering the new branch. No correctness, security, or convention issues found.
+
+**Files Reviewed:** 2
+**Findings:** 0 Critical, 0 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Suggestions
+
+[S-01] Missing test for `passed=False` with issues (existing gap, not introduced by this PR)
+Category: Testing
+Severity: Suggestion
+File: tests/unit/test_orchestrator.py
+Lines: general
+Description: The test file has no test that exercises the `if not consistency_result["passed"]` branch (lines 507–512 in orchestrator.py). All existing tests mock consistency with `"passed": True`. This is a pre-existing gap, not caused by this PR, but worth noting since the failed-path is the more critical code path (it gates chapter approval).
+Suggestion: Add a test that sets `"passed": False` with critical issues and verifies both the emitted tokens and that the chapter is still appended to `state.approved_chapters` (current behaviour — the chapter is appended regardless of pass/fail, which may itself be worth reviewing as a separate concern).
+
+---
+
+## Phase-by-Phase Review
+
+### Phase 1 — Structural Review
+
+- **Commit message:** Follows convention (`feat(orchestrator): ...`), references issue #213. Clear.
+- **Branch name:** `feat/issue-213-surface-consistency-findings` — follows convention.
+- **Scope:** 2 files, ~20 lines of production code + ~65 lines of test. Small, focused.
+- **No unrelated changes:** All changes relate to the stated purpose.
+- **No file moves/renames, no agent/skill edits, no shell snippets.** All structural checks pass.
+
+### Phase 2 — Code Review
+
+**`src/presentation/orchestrator.py` (lines 515–522):**
+
+The added `elif` branch is correct:
+- Condition `consistency_result["issues"]` is truthy when the list is non-empty — correct for detecting warnings/info.
+- The `elif` ensures mutual exclusivity with the `if not passed` branch — a result cannot fire both blocks. This is correct because `passed=False` implies critical issues exist and should be shown; `passed=True` with issues means only non-critical findings.
+- Output format matches the existing failed-path format (`[SEVERITY] description`).
+- No import changes needed — all referenced names already in scope.
+- No asyncio coordination issues — `bus.emit()` calls are already awaited.
+
+**Return contract verification:** `_extract_consistency_result()` in `consistency_checker.py` always returns `{"issues": list, "passed": bool}`. The `issues` list can contain items with severity `"warning"` or `"info"` (from `timeline_issues`, `trait_drift`, `semantic_findings` with non-critical severity, `cross_chapter_findings`). The `passed` flag is driven solely by `has_critical_findings`. So `passed=True` with non-empty `issues` is a valid and expected state — the new branch correctly handles it.
+
+### Phase 3 — Frontend Review
+
+Not applicable — CLI-only project, no frontend changes.
+
+### Phase 4 — Security Review
+
+- No user input handling changes.
+- No file path construction changes.
+- No credential or sensitive data exposure.
+- No security issues.
+
+### Phase 5 — Testing Review
+
+- **New test added:** `test_consistency_warnings_emitted_even_when_passed_true` — covers the new `elif` branch.
+- **Test quality:** Good. Mocks `ConsistencyCheckerAgent.run` to return `{"passed": True, "issues": [...]}` with a warning-severity issue. Asserts both the header message and the formatted issue line appear in the emitted token stream. Also asserts `state.status == "complete"`.
+- **Test conventions:** Follows project patterns — `@pytest.mark.asyncio`, `tmp_path` fixture, `patch()` context managers, `TokenStreamBus` / `WikiContextBus` usage consistent with existing tests.
+- **No skipped tests.**
+- **Pre-existing gap noted as S-01 above.**
+
+### Phase 6 — Performance Review
+
+Not applicable — trivial string emission, no queries or expensive operations.
+
+### Phase 7 — Documentation Review
+
+- No documentation changes in this PR.
+- No docblocks needed for a 6-line inline addition.
+- No ADR or README updates required for this scope of change.
+
+---
+
+## Overall Assessment
+
+**Ready for merge.** The change is correct, minimal, and well-tested. It fills a genuine gap where non-critical consistency findings (warnings, info-level semantic issues, trait drift, timeline issues) were silently discarded when `passed=True`. The test adequately covers the new branch. No blocking issues found.

--- a/.github/notes/reviews/2026-04-27-pr219-synthesis.md
+++ b/.github/notes/reviews/2026-04-27-pr219-synthesis.md
@@ -1,0 +1,146 @@
+## Synthesized Code Review — 2026-04-27
+
+**Review Type:** Multi-model synthesis (Qwen + Kimi + GLM)
+**Branch:** `feat/issue-213-surface-consistency-findings`
+**Commit:** `a9a1528 feat(orchestrator): surface non-critical consistency findings (#213)`
+**Model Agreement Score:** 8/10
+**Overall Assessment:** Clean — ready for merge with minor follow-up suggestions
+
+---
+
+### Synthesis Overview
+
+This PR adds a single `elif` branch in `src/presentation/orchestrator.py` (lines 515–522) to emit non-critical consistency findings (warnings/info) to the token stream when `passed=True` but `issues` is non-empty. Previously these were silently discarded. One unit test was added covering the new branch. All three models agree the change is correct, minimal, and ready for merge. Disagreement is limited to whether duplicated loop logic warrants a Warning (GLM) or Suggestion (Qwen/Kimi), and whether a documentation gap (Kimi) is in scope.
+
+---
+
+### Individual Report Summaries
+
+| Model | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count | Suggestion Count |
+|-------|-------------------|--------------------|----------------|---------------|------------------|
+| Qwen | Ready for merge. Correct, minimal, well-tested. | Noted pre-existing `passed=False` test gap as Suggestion only. | 0 | 0 | 1 |
+| Kimi | Ready for merge. No blockers. | Flagged missing docs in `docs/features/story-orchestrator.md` line 130. | 0 | 0 | 2 |
+| GLM | Ready for merge. Minor maintainability concern. | Raised duplicated `for` loop as Warning; suggested negative assertion in test. | 0 | 1 | 2 |
+
+---
+
+### Consensus Findings
+
+#### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-S-01] Missing test coverage for passed=False + issues emission path
+Severity: Suggestion
+Category: Testing
+File: tests/unit/test_orchestrator.py
+Lines: general
+Detail: All three models note that no test exercises the `if not consistency_result["passed"]` branch (lines 507–512 in orchestrator.py). Every existing test mocks consistency with `"passed": True`. The new test added in this PR covers the `passed=True` + issues path, leaving the critical-failure branch unprotected. Qwen and GLM explicitly flag this; Kimi also notes it as S-02. This is a pre-existing gap, not introduced by the PR, but the area is already under change.
+Models: Qwen ✓ Kimi ✓ GLM ✓
+Note: All three models report this, but classify it as Suggestion (not Warning or Critical), reflecting consensus that it is pre-existing and not a merge blocker.
+Suggestion: Add a parameterized test case or separate test that mocks `{"issues": [...], "passed": False}` and asserts the `[Consistency] Chapter N — issues found:` header appears in the emitted stream.
+```
+
+```
+[M-S-02] Test does not assert absence of wrong header
+Severity: Suggestion
+Category: Testing
+File: tests/unit/test_orchestrator.py
+Lines: 1409
+Detail: GLM and Kimi note that the new test asserts the "warnings/info found" header is present but does not verify the "issues found" header is absent. A regression that emitted both headers would still pass. Qwen does not mention this, likely because the mutual exclusivity of `if`/`elif` is structurally obvious in the source.
+Models: Qwen ✗ Kimi ✓ GLM ✓
+Dissenting view: Qwen did not raise this; the `if`/`elif` structure makes dual-header emission impossible under normal Python control flow, so the risk is low.
+Suggestion: Add `assert "[Consistency] Chapter 1 — issues found:" not in emitted` to the new test for defense-in-depth.
+```
+
+#### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-W-01] Duplicated issue-emission loop in both branches
+Severity: Warning (GLM) / Suggestion (implied by Qwen/Kimi silence)
+Category: Style
+File: src/presentation/orchestrator.py
+Lines: 511–513, 519–521
+Detail: GLM flags that the `for issue in consistency_result["issues"]` loop and its body are identical in both the `if not passed` and `elif issues` branches. The only difference is the header message. GLM suggests extracting the loop or restructuring to emit the header conditionally then loop once. Qwen and Kimi do not mention this, likely because the duplication is only two lines and the branches are adjacent and visually obvious.
+Model: GLM
+Assessment: The duplication is real but trivial (2 lines). Restructuring would reduce the line count slightly but is not a correctness or maintainability concern at this scale. The current form is arguably more readable because each branch is self-contained. Treat as low-priority Suggestion.
+Suggestion: If desired, refactor to a single loop with a conditional header assignment, but this is not required for merge.
+```
+
+```
+[S-D-01] Missing documentation for new warning-emission path
+Severity: Suggestion
+Category: Documentation
+File: docs/features/story-orchestrator.md
+Lines: 130
+Detail: Kimi notes that the documentation describes the `passed=False` behavior ("emits a `[Consistency] Chapter N — issues found:` header") but does not mention the new `passed=True` + issues path. This leaves the documented contract incomplete.
+Model: Kimi
+Assessment: Genuine but minor gap. The docs describe the critical path; adding one sentence for the new non-critical path would improve completeness. Not a merge blocker.
+Suggestion: Add a sentence after line 130 describing the new path: "When `passed` is `true` but `issues` is non-empty, it emits a `[Consistency] Chapter N — warnings/info found:` header instead, and still continues with persistence."
+```
+
+---
+
+### Divergence Analysis
+
+```
+[D-01] Topic: Severity of duplicated loop logic
+Qwen says: No finding raised. The change is correct and minimal; no issues found.
+Kimi says: No finding raised. The change is correct and minimal; no issues found.
+GLM says: Warning [W-01] — duplicated loop is a maintainability concern that should be refactored.
+Assessment: The duplication is two lines of identical loop body in adjacent branches. While DRY is a valid principle, enforcing it here provides minimal benefit and the current structure is readable. GLM's Warning is overly strong for this context. Qwen and Kimi's silence is the better judgment — this is not a meaningful maintainability risk.
+Resolution: Downgrade GLM's [W-01] to Suggestion severity. Do not require refactoring before merge.
+```
+
+```
+[D-02] Topic: Whether documentation gap is in scope
+Qwen says: No documentation changes needed for a 6-line inline addition. No ADR or README updates required for this scope.
+Kimi says: Documentation gap in docs/features/story-orchestrator.md line 130 should be addressed — the new path is not documented.
+GLM says: No documentation finding raised.
+Assessment: The documentation file describes the orchestrator's consistency-checker integration. The new branch changes observable behavior (new header emitted). Updating the docs is a legitimate completeness concern, but the PR is small and focused. Kimi's finding is valid but minor. Qwen/GLM's view that docs are out of scope for a 6-line change is also reasonable.
+Resolution: Treat as Singular Suggestion. Not a merge blocker. Can be addressed in a follow-up or as part of the same PR if convenient.
+```
+
+---
+
+### Recommended Actions (Prioritized)
+
+1. **[M-S-02]** ★★☆ Add negative assertion to new test: `assert "[Consistency] Chapter 1 — issues found:" not in emitted` (Suggestion — 2/3 models agree)
+2. **[M-S-01]** ★★☆ Add test coverage for `passed=False` + issues path (Suggestion — all models agree, pre-existing gap)
+3. **[S-W-01]** ★☆☆ Consider refactoring duplicated loop into single conditional header + loop (Suggestion — GLM only, low priority)
+4. **[S-D-01]** ★☆☆ Update `docs/features/story-orchestrator.md` line 130 to document the new `passed=True` + issues path (Suggestion — Kimi only)
+
+---
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 1¹         |
+| ★★☆ Majority      | 0        | 0       | 1          |
+| ★☆☆ Singular      | 0        | 0²       | 2          |
+
+¹ [M-S-01] is unanimously reported but all models classify it as Suggestion, not a higher severity.
+² GLM's [W-01] downgraded to Suggestion per divergence analysis.
+
+---
+
+### Key Findings
+
+- **[M-S-01]** Pre-existing `passed=False` test gap noted by all three models (★★★ unanimous Suggestion)
+- **[M-S-02]** Missing negative assertion in new test (★★☆ majority Suggestion)
+- **[S-W-01]** Duplicated loop body flagged by GLM only; downgraded to Suggestion (★☆☆)
+- **[S-D-01]** Documentation gap flagged by Kimi only (★☆☆)
+
+---
+
+### Divergences
+
+- **[D-01]** GLM rated duplicated loop as Warning; Qwen/Kimi did not mention it. Downgraded to Suggestion.
+- **[D-02]** Kimi flagged documentation gap; Qwen/GLM considered docs out of scope for this small change. Retained as Singular Suggestion.
+
+---
+
+### Actions Required
+
+- Findings requiring fixes: **0** — no Critical or Warning findings
+- Findings deferred / follow-up: **4** — all Suggestions, none blocking merge

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -512,6 +512,14 @@ async def _continue_pipeline(
                         await bus.emit(
                             f"  [{issue['severity'].upper()}] {issue['description']}\n"
                         )
+                elif consistency_result["issues"]:
+                    await bus.emit(
+                        f"\n[Consistency] Chapter {chapter_number} — warnings/info found:\n"
+                    )
+                    for issue in consistency_result["issues"]:
+                        await bus.emit(
+                            f"  [{issue['severity'].upper()}] {issue['description']}\n"
+                        )
                 state.approved_chapters.append(draft)
                 _write_chapter_file(story_dir, chapter_number, draft.content)
                 wiki_batch = await wiki_agent.run(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1343,3 +1343,68 @@ async def test_wiki_init_error_raises_story_generation_error(
                 config=_config(),
                 provider=provider,
             )
+
+
+@pytest.mark.asyncio
+async def test_consistency_warnings_emitted_even_when_passed_true(
+    tmp_path: Path,
+) -> None:
+    provider = MagicMock()
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+
+    def fake_savepoint_path(story_name: str) -> Path:
+        return tmp_path / story_name / "savepoints" / "pipeline_state.json"
+
+    with (
+        patch(
+            "presentation.orchestrator._savepoint_path", side_effect=fake_savepoint_path
+        ),
+        patch("presentation.orchestrator.STORIES_DIR", tmp_path),
+        patch("tools._io.STORIES_DIR", tmp_path),
+        patch("presentation.orchestrator.OutlinePlannerAgent") as outline_cls,
+        patch("presentation.orchestrator.ChapterWriterAgent") as chapter_cls,
+        patch("presentation.orchestrator.WikiMaintainerAgent") as wiki_cls,
+        patch("presentation.orchestrator.ConsistencyCheckerAgent") as consistency_cls,
+        patch(
+            "presentation.orchestrator._generate_character_sheets",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "presentation.orchestrator._generate_setting_sheets",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        outline_cls.return_value.run = AsyncMock(return_value=_outline_result())
+        chapter_cls.return_value.run = AsyncMock(return_value=_chapter_draft())
+        wiki_cls.return_value.run = AsyncMock(return_value=_wiki_batch())
+        consistency_cls.return_value.run = AsyncMock(
+            return_value={
+                "issues": [
+                    {
+                        "type": "semantic",
+                        "description": "Minor name inconsistency",
+                        "severity": "warning",
+                    }
+                ],
+                "passed": True,
+            }
+        )
+
+        state = await run_pipeline(
+            "test-story",
+            NullApprovalGate(),
+            bus,
+            wiki_bus,
+            config=_config(),
+            provider=provider,
+        )
+
+    tokens: list[str] = []
+    async for token in bus:
+        tokens.append(token)
+    emitted = "".join(tokens)
+
+    assert state.status == "complete"
+    assert "[Consistency] Chapter 1 — warnings/info found:" in emitted
+    assert "[WARNING] Minor name inconsistency" in emitted


### PR DESCRIPTION
## Summary
Non-critical consistency findings (warnings/info) from the `ConsistencyCheckerAgent` are now surfaced to the token stream bus even when `passed=True`. Previously, the orchestrator only emitted findings when `passed=False`, silently dropping non-critical issues.

## Closes
Closes #213

## Changes
- [x] Implementation complete
- [x] All tests passing (verified)
- [x] Linting clean

## Plan
- **Affected areas**: Python domain logic (`src/presentation/orchestrator.py`)
- **Implementation**: Added `elif consistency_result["issues"]` branch in the chapter loop to emit warnings/info findings with a distinct header.
- **Verification tests**: `tests/unit/test_orchestrator.py::test_consistency_warnings_emitted_even_when_passed_true` — verifies a warning-level finding is emitted to the bus while the pipeline completes normally.

## Acceptance Criteria
- [x] Non-critical consistency findings are visible to operators or downstream workflow consumers.
- [x] Critical findings still fail/block according to existing semantics.
- [x] Unit tests cover at least one non-critical finding that remains visible while the result passes.
