### PR TITLE
Migration Task 2: Configure OpenRouter provider and confirm model IDs

### DIFF
--- a/.github/notes/opencode-provider-mapping.md
+++ b/.github/notes/opencode-provider-mapping.md
@@ -1,5 +1,8 @@
 # OpenRouter Provider Mapping
 
+**Date:** 2026-04-29
+**Source:** Coder — issue #226 / PR #235
+
 Confirmed OpenRouter model slugs and corresponding Opencode model identifiers for the three models used across the 24 migrated agents.
 
 ## Model ID Reference

--- a/.github/notes/opencode-provider-mapping.md
+++ b/.github/notes/opencode-provider-mapping.md
@@ -1,0 +1,41 @@
+# OpenRouter Provider Mapping
+
+Confirmed OpenRouter model slugs and corresponding Opencode model identifiers for the three models used across the 24 migrated agents.
+
+## Model ID Reference
+
+| Copilot display name | OpenRouter slug | Opencode model ID |
+|---|---|---|
+| `MoonshotAI: Kimi K2.6 (openrouter)` | `moonshotai/kimi-k2.6` | `openrouter/moonshotai/kimi-k2.6` |
+| `Qwen: Qwen3.6 Plus (openrouter)` | `qwen/qwen3.6-plus` | `openrouter/qwen/qwen3.6-plus` |
+| `Z.ai: GLM 5.1 (openrouter)` | `z-ai/glm-5.1` | `openrouter/z-ai/glm-5.1` |
+
+## Authentication
+
+OpenRouter is a first-class provider in Opencode. Authentication uses `OPENROUTER_API_KEY` from the environment or credentials stored via the `/connect` command.
+
+Do **not** set `baseURL` in `opencode.json` for the `openrouter` provider — it is resolved natively by Opencode.
+
+## Verification
+
+Slugs confirmed against [openrouter.ai/models](https://openrouter.ai/models) on 2026-04-29.
+
+To verify each model resolves without error, run:
+
+```bash
+OPENROUTER_API_KEY=<your-key> opencode run "hello" --model openrouter/moonshotai/kimi-k2.6
+OPENROUTER_API_KEY=<your-key> opencode run "hello" --model openrouter/qwen/qwen3.6-plus
+OPENROUTER_API_KEY=<your-key> opencode run "hello" --model openrouter/z-ai/glm-5.1
+```
+
+> **Note:** `OPENROUTER_API_KEY` was not available in the CI/development environment at implementation time. Each developer must verify locally after setting their key.
+
+## Usage in Agent Frontmatter
+
+When writing agent `.md` files in `.opencode/agents/`, reference models using the `model:` frontmatter field:
+
+```yaml
+---
+model: openrouter/moonshotai/kimi-k2.6
+---
+```

--- a/.github/notes/reviews/2026-04-29-pr235-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr235-claude-raw.md
@@ -1,0 +1,102 @@
+# Code Review Report — PR #235
+**Branch:** `feat/issue-226-configure-openrouter-provider`
+**Date:** 2026-04-29
+**Reviewer:** Claude Sonnet 4.6 (raw)
+**Report path:** `.github/notes/reviews/2026-04-29-pr235-claude-raw.md`
+
+---
+
+## Review Summary
+
+This PR delivers OpenRouter provider configuration for the Opencode agent runtime and the associated documentation. The scope is narrow and well-bounded: one `opencode.json` configuration change, one new feature doc, updates to two existing docs, and one new internal reference note. No Python source code, no tests, and no agent or skill instruction files are modified.
+
+The primary finding is a documentation accuracy issue in the `opencode-runtime.md` feature doc, where the JSON example purporting to represent the checked-in `opencode.json` omits the pre-existing `mcp.chroma` block. A developer using this example to reconstruct or validate the file would silently produce a config that drops the ChromaDB MCP integration. All referenced files (ADR 009, tasks doc, provider mapping note) exist on disk and resolve correctly from their link contexts.
+
+**Files Reviewed:** 5
+**Findings:** 0 Critical, 1 Warning, 2 Suggestions
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] opencode-runtime.md JSON example omits pre-existing mcp.chroma block
+Category: Documentation
+Severity: Warning
+File: docs/features/opencode-runtime.md
+Lines: 18-44 (Project-Level Configuration code block)
+Description: The doc introduces the JSON block with "The checked-in `opencode.json` keeps
+project runtime settings minimal:" and then shows a JSON object that includes "$schema",
+"model", "instructions", "plugin", and "provider" — but omits the pre-existing "mcp.chroma"
+entry entirely. The closing prose says "This file does not contain Tavily or Context7
+entries" (true), but makes no mention of the chroma MCP block that is in the actual file.
+A developer reading this section as a reference to the checked-in config would not know
+about the chroma MCP entry. If they reconstruct or reset the file from this example, they
+silently drop the ChromaDB MCP integration without any error. This is a documentation
+accuracy defect of the "code example drift" category (checklist item: "Code matches docs").
+Suggestion: Either (a) add the mcp.chroma block to the example with a comment noting it is
+pre-existing and unrelated to OpenRouter setup, e.g.:
+  "mcp": {
+    "chroma": { ... }  // pre-existing — ChromaDB MCP integration, unchanged
+  }
+or (b) change the framing to make the partial nature of the excerpt explicit:
+  "The following excerpt shows the OpenRouter-related additions in opencode.json:"
+Option (b) is lighter and less likely to drift.
+```
+
+---
+
+### Suggestions
+
+```
+[S-01] Provider mapping note missing trailing newline
+Category: Style
+Severity: Suggestion
+File: .github/notes/opencode-provider-mapping.md
+Lines: 41 (end of file)
+Description: The file ends without a POSIX trailing newline. The diff shows
+`\ No newline at end of file`. This is a minor convention issue for Markdown files in this
+repository. The ruff formatter enforces it for Python files; the same POSIX convention
+applies to Markdown.
+Suggestion: Add a blank line at the end of the file.
+```
+
+```
+[S-02] Model IDs not live-verified — note only confirms slug format
+Category: Documentation
+Severity: Suggestion
+File: .github/notes/opencode-provider-mapping.md, docs/features/opencode-runtime.md
+Lines: general
+Description: Both files note that `OPENROUTER_API_KEY` was not available at implementation
+time and that each developer must verify locally. The model slugs
+`moonshotai/kimi-k2.6`, `qwen/qwen3.6-plus`, and `z-ai/glm-5.1` were confirmed against
+the openrouter.ai/models listing on 2026-04-29, but no live `opencode run` invocation was
+executed to confirm model resolution end-to-end. The documentation accurately discloses
+this gap. This is informational — the disclosure is present and appropriate.
+Suggestion: Once a developer with `OPENROUTER_API_KEY` available runs the three
+verification commands from the note, update the verification section to reflect confirmed
+live resolution, e.g. "Verified live: 2026-04-29 by <author>." This closes the disclosure
+gap and provides a dated record that the models are operational.
+```
+
+---
+
+## Phase Completion Record
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| 1 — Structural | Pass | Commit messages follow convention, reference issue #226; branch name follows convention; scope appropriate (docs + config only, ~175 lines added); no agent/skill numbered-step lists modified; no file relocations; no stale counts |
+| 2 — Code Review | Pass | `opencode.json` change is correct: no hardcoded credentials, no baseURL for openrouter, provider block format valid; no Python source changes; N/A checks skipped (no Python, no TS wrappers, no agent instructions, no async code) |
+| 3 — Frontend | N/A | No frontend changes |
+| 4 — Security | Pass | No credentials committed; API key references are placeholder strings only (`<your-key>`); `opencode.json` does not expose or proxy credentials; no input validation surface introduced |
+| 5 — Testing | N/A | No Python source changes; configuration and documentation only; no test gap |
+| 6 — Performance | N/A | No code changes |
+| 7 — Documentation | Warning | W-01 above; all relative links verified on disk; referenced ADR 009 (`docs/planning/adr/009-opencode-as-primary-agent-runtime.md`) and tasks doc (`docs/planning/copilot-to-opencode-migration/tasks.md`) both exist; `docs/README.md` duplicate OpenAI Async Provider line confirmed as diff rendering artifact — single entry in actual file |
+
+---
+
+## Overall Assessment
+
+The PR is ready to merge with one recommendation: address [W-01] before or alongside merge by clarifying that the JSON snippet in `docs/features/opencode-runtime.md` is an excerpt, not a complete copy of the file, to prevent the `mcp.chroma` block from being inadvertently dropped by developers using the docs as a reference. The `opencode.json` change itself is clean and correctly structured. Documentation is accurate where it makes factual claims, and the provider mapping note appropriately discloses that live model verification is pending developer-local confirmation.

--- a/.github/notes/reviews/2026-04-29-pr235-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr235-gemini-raw.md
@@ -1,0 +1,26 @@
+# Code Review Report — PR #235
+
+## Summary
+The review package includes updates to the OpenRouter/Opencode runtime configurations and documentation. No source code has changed, only `.md` files and `.json` configs. 
+
+## Phase 1: Security & Credentials
+- **Finding:** No hardcoded API keys or credentials were added. The documentation correctly notes that `OPENROUTER_API_KEY` and other sensitive configurations are isolated to user-level configurations.
+- **Status:** PASS
+
+## Phase 2: Correctness & Logic
+- **Finding:** `opencode.json` correctly maps the OpenRouter models under the `provider.openrouter.models` key. The schema points to `https://opencode.ai/config.json` correctly, and models map to specific IDs correctly. 
+- **Status:** PASS
+
+## Phase 3: Testing Coverage
+- **Finding:** The changes are purely configuration and documentation. No Python code changes require test coverage.
+- **Status:** PASS
+
+## Phase 4: Conventions
+- **Finding:** `.json` structure is valid. The `docs/` and `.github/notes/` paths match project conventions for auxiliary reference tracking.
+- **Status:** PASS
+
+## Suggestions (Out-of-Scope)
+- *None specific to this configuration update.*
+
+## Conclusion
+**APPROVED.** The changes adhere to system conventions and introduce no regression risks.

--- a/.github/notes/reviews/2026-04-29-pr235-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr235-gpt-raw.md
@@ -1,0 +1,42 @@
+# Code Review Report
+
+## Review Summary
+
+This PR updates the repository-level Opencode runtime configuration, adds a provider-mapping note, and documents the new OpenRouter-backed setup. The changes are small and mostly documentation-focused, but the branch still leaves one repository note out of convention and ships a runtime-config change without any automated validation beyond manual local checks.
+
+**Files Reviewed:** 5
+**Findings:** 0 Critical, 2 Warning, 1 Suggestion
+
+## Findings
+
+### Warning Findings
+
+[W-01] New project note omits required provenance metadata
+Category: Documentation
+Severity: Warning
+File: .github/notes/opencode-provider-mapping.md
+Lines: 1-41
+Description: New files under `.github/notes/` are expected to include `Date` and `Source` metadata so future agents can assess freshness and trustworthiness. The new provider-mapping note contains useful reference data, but it does not include either field, which violates the repository note convention documented in `.github/notes/README.md` and makes the note harder to audit later.
+Suggestion: Add a short metadata block near the top of the file, for example `**Date:** 2026-04-29` and `**Source:** Reviewer/Documenter — PR #235`, before the content body.
+
+[W-02] Runtime-config change has no automated verification path
+Category: Testing
+Severity: Warning
+File: opencode.json
+Lines: 1-27
+Description: This PR changes the default Opencode model and introduces a new `provider.openrouter.models` registry, which is real runtime behavior rather than prose-only documentation. The review package and new docs explicitly state that verification was limited to manual local checks because `OPENROUTER_API_KEY` was unavailable, but the branch does not add any automated validation to catch malformed JSON, schema drift, or mistyped model identifiers before merge. That leaves the repository vulnerable to a silent config regression that will only surface when a developer tries to run Opencode.
+Suggestion: Add a lightweight automated check for `opencode.json`, such as a CI or test step that parses the file and asserts the expected default model and registered OpenRouter keys, or an Opencode config validation command if the CLI provides one.
+
+### Suggestions
+
+[S-01] Features index still contains a duplicate entry
+Category: Documentation
+Severity: Suggestion
+File: docs/README.md
+Lines: 50-53
+Description: The `Features` list now includes the new Opencode runtime entry, but the surrounding section still contains the `OpenAI Async Provider` bullet twice. This does not break behavior, but it makes the index look stale and reduces confidence that the feature registry is curated.
+Suggestion: Remove the duplicate `OpenAI Async Provider` bullet so each feature appears once.
+
+## Overall Assessment
+
+The branch is low-risk and generally aligned with the intended OpenRouter migration work, but it is not completely clean yet. Main concerns are process quality rather than implementation logic: one new `.github/notes/` artifact does not follow the repository metadata convention, and the runtime config change lacks any automated verification, so regressions in `opencode.json` would be caught only at manual runtime. No security issues were identified in the supplied changes.

--- a/.github/notes/reviews/2026-04-29-pr235-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr235-synthesis.md
@@ -1,0 +1,221 @@
+# Synthesized Review Report — PR #235
+
+**Branch:** `feat/issue-226-configure-openrouter-provider`
+**Date:** 2026-04-29
+**Review Type:** Multi-model synthesis (Claude Sonnet 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Raw reports:**
+- `.github/notes/reviews/2026-04-29-pr235-claude-raw.md`
+- `.github/notes/reviews/2026-04-29-pr235-gpt-raw.md`
+- `.github/notes/reviews/2026-04-29-pr235-gemini-raw.md`
+
+---
+
+## Synthesis Overview
+
+PR #235 is a narrow, documentation-and-configuration-only change that configures OpenRouter as the Opencode provider and records the confirmed model slug mappings. No Python source code, tests, or agent instruction files are touched. The three models diverged substantially in their findings: Gemini found nothing to flag and approved unconditionally, Claude identified one genuine documentation accuracy defect and two lower-priority style notes, and GPT identified two process concerns plus one finding that is a confirmed false positive. No finding achieved majority consensus, let alone unanimity. The highest-confidence actionable finding is Claude's documentation drift issue — the `opencode-runtime.md` JSON example omits the pre-existing `mcp.chroma` block from the checked-in file, which was independently verified against the actual `opencode.json` on disk.
+
+**Model Agreement Score:** 3/10 — Gemini approved with zero findings; Claude and GPT each raised issues but on largely non-overlapping concerns; one GPT suggestion is a verified false positive.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count | Suggestion Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- | ---------------- |
+| Claude | Ready to merge; address W-01 before/alongside | Documentation accuracy (mcp.chroma omission); style (trailing newline); live-verification disclosure | 0 | 1 | 2 |
+| GPT    | Not completely clean; two warnings need addressing | Repository note metadata convention; automated config validation; (one false-positive duplicate entry) | 0 | 2 | 1 |
+| Gemini | Approved unconditionally | None identified | 0 | 0 | 0 |
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+None.
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+None.
+
+> **Note on partial overlap — verification gap:** Claude [S-02] and GPT [W-02] both identify the absence of live end-to-end verification for the OpenRouter model IDs and `opencode.json` config. However, they disagree significantly on severity and remedy: Claude treats the existing disclosure as adequate (Suggestion/Informational), while GPT elevates this to a Warning and calls for added CI automation. Gemini found no issue at all. Given the 1/3 support for the Warning framing and the PR's purely docs/config scope, this overlap does not qualify as a Majority finding. See Divergence [D-02].
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] opencode-runtime.md JSON example omits pre-existing mcp.chroma block
+Severity: Warning
+Category: Documentation
+File: docs/features/opencode-runtime.md
+Lines: 18–44 (Project-Level Configuration code block)
+Detail: The doc introduces the JSON block as "The checked-in opencode.json keeps project
+runtime settings minimal:" and shows the schema, model, instructions, plugin, and provider
+keys — but omits the mcp.chroma entry that exists in the actual committed opencode.json.
+The closing prose adds "This file does not contain Tavily or Context7 entries" (true), but
+makes no mention of the chroma MCP block. A developer using this excerpt to reconstruct or
+validate the file would silently drop the ChromaDB MCP integration. This was independently
+verified: the actual opencode.json on disk includes a complete mcp.chroma block
+(type: local, command: uvx chroma-mcp, data-dir: .chromadb, enabled: true) absent from
+the doc example.
+Model: Claude ✓ (GPT ✗, Gemini ✗)
+Assessment: Confirmed valid. The omission is verifiable on disk and constitutes a
+"code example drift" defect that could cause a real regression if a developer resets
+the file from the documentation.
+Suggestion: Either (a) add the mcp.chroma block to the example with a clarifying comment
+("// pre-existing — ChromaDB MCP integration, unchanged"), or (b) reframe the excerpt
+label to make the partial nature explicit: "The following excerpt shows the OpenRouter-
+related additions:" Option (b) is lighter and less prone to future drift.
+```
+
+```
+[S-I-02] opencode-provider-mapping.md missing required Date and Source metadata
+Severity: Warning
+Category: Documentation
+File: .github/notes/opencode-provider-mapping.md
+Lines: 1–10 (file header)
+Detail: The .github/notes/README.md convention (lines 63–64) requires every note file to
+include **Date:** YYYY-MM-DD and **Source:** [agent name] — issue #N / PR #N so agents can
+assess freshness and trustworthiness. The new provider-mapping note carries no such header.
+The content itself is accurate and well-structured, but the missing provenance metadata
+violates the established convention and reduces auditability.
+Model: GPT ✓ (Claude ✗, Gemini ✗)
+Assessment: Confirmed valid. The convention is documented, and the file is missing both
+required fields. Straightforward to fix.
+Suggestion: Add a short metadata block near the top of the file:
+  **Date:** 2026-04-29
+  **Source:** OpenRouter Provider Configuration — issue #226 / PR #235
+```
+
+```
+[S-I-03] No automated validation path for opencode.json changes
+Severity: Warning
+Category: Testing
+File: opencode.json
+Lines: 1–27
+Detail: The PR changes the default Opencode model and adds a provider.openrouter.models
+registry — runtime behavior rather than prose-only documentation. No automated check (CI
+step, schema validation, or test assertion) guards against malformed JSON, schema drift, or
+typos in model identifiers. Regressions would surface only when a developer manually runs
+Opencode.
+Model: GPT ✓ (Claude ✗, Gemini ✗)
+Assessment: Legitimate concern in principle; low immediate risk given the narrow scope and
+the fact that JSON parse errors would be caught on first use. The PR is documentation/config
+only and does not introduce new execution surfaces. Claude and Gemini both assessed the
+change as low-risk without noting this gap. Treat as a deferred improvement rather than a
+merge blocker.
+Suggestion: Add a lightweight CI step (e.g., python -c "import json; json.load(open('opencode.json'))") 
+or a pytest fixture that asserts the expected default model key and registered provider
+entries. File as a follow-up issue rather than blocking this PR.
+```
+
+```
+[S-I-04] opencode-provider-mapping.md missing POSIX trailing newline
+Severity: Suggestion
+Category: Style
+File: .github/notes/opencode-provider-mapping.md
+Lines: 41 (end of file)
+Detail: The file ends without a trailing newline. The diff shows "\ No newline at end of
+file". Minor POSIX convention issue for Markdown files in this repository.
+Model: Claude ✓ (GPT ✗, Gemini ✗)
+Assessment: Valid minor style issue. Trivially fixable alongside [S-I-02].
+Suggestion: Add a blank line at end of file.
+```
+
+```
+[S-I-05] Model IDs confirmed by slug lookup only — live invocation pending
+Severity: Suggestion
+Category: Documentation
+File: .github/notes/opencode-provider-mapping.md, docs/features/opencode-runtime.md
+Lines: general
+Detail: The three OpenRouter model slugs were confirmed against openrouter.ai/models on
+2026-04-29 but no live opencode run invocation was executed to confirm end-to-end model
+resolution. The documentation accurately discloses this gap ("OPENROUTER_API_KEY was not
+available at implementation time"). This is informational — the disclosure is present
+and appropriate.
+Model: Claude ✓ (GPT addresses via W-02; Gemini ✗)
+Assessment: Valid informational note. The disclosure is adequate for a configuration-only
+PR; no action is required before merge. The note should be updated once a developer
+performs live verification.
+Suggestion: After running the three verification commands from the note, update the
+Verification section to add: "Verified live: YYYY-MM-DD by <author>."
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Duplicate OpenAI Async Provider entry in docs/README.md
+GPT says: The Features list in docs/README.md contains the OpenAI Async Provider bullet
+twice (S-01, Warning/Suggestion). Should be deduplicated.
+Claude says: The apparent duplicate is a diff rendering artifact — single entry in the
+actual file (Phase 7 note in the raw report, explicitly ruled out as a real defect).
+Gemini says: Silent — no finding raised.
+Verification: Reviewed docs/README.md directly. The "OpenAI Async Provider" entry appears
+exactly once in the Features list. The actual file contains no duplicate.
+Assessment: GPT's finding is a confirmed FALSE POSITIVE. The duplicate was visible in the
+diff view but does not exist in the committed file. Claude is correct.
+Resolution: EXCLUDED from consensus findings. No action required.
+```
+
+```
+[D-02] Topic: Severity of live-verification gap for model IDs / opencode.json
+Claude says: The documentation discloses the gap clearly; this is informational — a
+Suggestion to update the note once a developer verifies live. The disclosure is
+adequate and no action is required before merge (S-02).
+GPT says: This rises to Warning severity — the PR ships runtime config without
+automated validation, leaving the repository vulnerable to silent regression (W-02).
+Gemini says: PASS — no issue identified.
+Assessment: 2/3 models do not treat this as a Warning. The PR is configuration-only with
+no new execution surface, and the documentation explicitly discloses the verification gap.
+Claude and Gemini's framing is proportionate. GPT's W-02 is a legitimate process concern
+but overstated as a merge blocker for a low-risk config PR. Treated as a deferred
+Suggestion ([S-I-03]) rather than a merge-blocking Warning.
+Resolution: Downgraded to Suggestion in Consensus Findings. Deferred to follow-up.
+```
+
+```
+[D-03] Topic: Overall merge readiness
+Claude says: Ready to merge; address W-01 (documentation drift) before or alongside merge.
+GPT says: Not completely clean — two warnings should be addressed before merge.
+Gemini says: Approved unconditionally.
+Assessment: 2/3 models consider the PR approvable. The one genuine merge-adjacent concern
+(documentation drift, [S-I-01]) is Claude's, not GPT's additional warnings. The PR's
+narrow docs/config-only scope supports Claude and Gemini's more lenient reading.
+Resolution: PR is mergeable with [S-I-01] and [S-I-02] addressed (both are small edits).
+[S-I-03] and [S-I-04] can follow in the same commit or a separate pass.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [S-I-01] ★☆☆ Fix: Clarify that the JSON block in opencode-runtime.md is an excerpt,
+   not a complete copy, to prevent mcp.chroma from being silently dropped
+   (Warning — singular, but independently verified; small edit, low effort)
+
+2. [S-I-02] ★☆☆ Fix: Add Date and Source metadata to opencode-provider-mapping.md
+   (Warning — singular, convention verified in .github/notes/README.md; trivial edit)
+
+3. [S-I-04] ★☆☆ Fix: Add trailing newline to opencode-provider-mapping.md
+   (Suggestion — singular, can be bundled with action #2 at zero extra cost)
+
+4. [S-I-03] ★☆☆ Consider: Add lightweight automated JSON validation for opencode.json
+   (Suggestion — singular; deferred to follow-up issue, not a merge blocker)
+
+5. [S-I-05] ★☆☆ Deferred: Update verification note once live model resolution confirmed
+   (Suggestion — informational; no action required before merge)
+```
+
+**False positives excluded:** GPT S-01 (duplicate OpenAI Async Provider entry in docs/README.md — confirmed absent from actual file).
+
+---
+
+## Summary
+
+Actions 1–3 are small, co-located edits (all touching `docs/features/opencode-runtime.md` and `.github/notes/opencode-provider-mapping.md`) that can be resolved in a single follow-up commit before or alongside merge. Action 4 is a low-priority deferred item. The `opencode.json` change itself is clean: no hardcoded credentials, correct schema reference, correct provider block structure, and the chroma MCP block is preserved in the committed file despite being absent from the documentation example.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ The active runtime is intentionally small and Python-native:
 - **Interactive Textual TUI**: `src/presentation/tui/app.py` adds `StoryWriterApp`, a three-panel terminal UI with live token streaming, wiki context, and approval gates launched through `story-writer tui`
 - **Repository cleanup**: the temporary `legacy/` archive, duplicate root helper scripts, and obsolete root markdown summaries were removed after migration cleanup, so current documentation should point only to active files under `docs/`, `prompts/`, `src/`, and `tests/`
 
+The repository also carries a project-level Opencode configuration for migration work. That agent runtime uses OpenRouter model IDs in `opencode.json`, while developer-specific OpenRouter credentials plus Tavily and Context7 MCP entries stay in user-level Opencode config. See [Opencode Runtime Configuration](./features/opencode-runtime.md).
+
 See [Legacy Dependency Cleanup](./features/legacy-dependency-cleanup.md) for the full before/after summary and maintenance guidance.
 
 ## Tools
@@ -48,6 +50,7 @@ See [Legacy Dependency Cleanup](./features/legacy-dependency-cleanup.md) for the
 
 ## Features
 
+- [Opencode Runtime Configuration](./features/opencode-runtime.md) — Project-level OpenRouter model registry plus developer-local OpenRouter, Tavily, and Context7 setup for migration tasks
 - [OpenAI Async Provider](./features/openai-async-provider.md) — AsyncOpenAI-backed streaming `ModelProvider`, dependency requirements, and migration relationship to the existing sync provider
 - [Python-Native Foundation](./features/python-native-foundation.md) — Agent prompt relocation, frontmatter-stripping loader, typed pipeline handoff dataclasses, and the `story-writer` CLI packaging/dispatch path for Issues #158, #161, and #162
 - [Pipeline Primitives](./features/pipeline-primitives.md) — Transport-agnostic approval gates plus token and wiki context event buses for the Python-native orchestrator

--- a/docs/features/opencode-runtime.md
+++ b/docs/features/opencode-runtime.md
@@ -60,7 +60,7 @@ Task 2 confirmed these OpenRouter model slugs and Opencode model identifiers:
 | `Qwen: Qwen3.6 Plus` | `qwen/qwen3.6-plus` | `openrouter/qwen/qwen3.6-plus` |
 | `Z.ai: GLM 5.1` | `z-ai/glm-5.1` | `openrouter/z-ai/glm-5.1` |
 
-The canonical mapping note lives in `../../.github/notes/opencode-provider-mapping.md`.
+The canonical mapping note lives in [../../.github/notes/opencode-provider-mapping.md](../../.github/notes/opencode-provider-mapping.md).
 
 ## User-Level MCP Servers
 

--- a/docs/features/opencode-runtime.md
+++ b/docs/features/opencode-runtime.md
@@ -13,7 +13,7 @@ User-specific credentials and user-level MCP servers still stay outside the repo
 
 ## Project-Level Configuration
 
-The checked-in `opencode.json` keeps project runtime settings minimal:
+The checked-in `opencode.json` contents in full:
 
 ```json
 {
@@ -34,6 +34,13 @@ The checked-in `opencode.json` keeps project runtime settings minimal:
           "name": "Z.ai: GLM 5.1"
         }
       }
+    }
+  },
+  "mcp": {
+    "chroma": {
+      "type": "local",
+      "command": ["uvx", "chroma-mcp", "--client-type", "persistent", "--data-dir", ".chromadb"],
+      "enabled": true
     }
   }
 }

--- a/docs/features/opencode-runtime.md
+++ b/docs/features/opencode-runtime.md
@@ -1,16 +1,72 @@
 # Opencode Runtime Configuration
 
-User-level setup required for full agentic capability in this project. These entries go in `~/.config/opencode/opencode.json` (or the platform equivalent) — **not** in the project-level `opencode.json`.
+> Project-level and user-level Opencode setup required for the OpenRouter-backed agent runtime introduced by migration Task 2.
 
-## MCP Servers
+## Overview
 
-### Tavily (Web Search)
+This repository now ships a project-level `opencode.json` that selects OpenRouter as the default Opencode provider surface for agent work. The checked-in file does two things only:
 
-Provides web search capability to agents via the `tavily-mcp` server.
+- sets the default model to `openrouter/moonshotai/kimi-k2.6`
+- registers three named OpenRouter models under `provider.openrouter.models`
 
-**Prerequisites:** A [Tavily API key](https://app.tavily.com/).
+User-specific credentials and user-level MCP servers still stay outside the repository. Add those entries to `~/.config/opencode/opencode.json` and authenticate OpenRouter locally.
 
-Add to `~/.config/opencode/opencode.json`:
+## Project-Level Configuration
+
+The checked-in `opencode.json` keeps project runtime settings minimal:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "openrouter/moonshotai/kimi-k2.6",
+  "instructions": ["AGENTS.md"],
+  "plugin": ["opencode-rules@latest"],
+  "provider": {
+    "openrouter": {
+      "models": {
+        "moonshotai/kimi-k2.6": {
+          "name": "MoonshotAI: Kimi K2.6"
+        },
+        "qwen/qwen3.6-plus": {
+          "name": "Qwen: Qwen3.6 Plus"
+        },
+        "z-ai/glm-5.1": {
+          "name": "Z.ai: GLM 5.1"
+        }
+      }
+    }
+  }
+}
+```
+
+This file does not contain Tavily or Context7 entries. Those MCP servers remain developer-local by design.
+
+## OpenRouter Authentication
+
+Authenticate Opencode against OpenRouter in one of these supported ways:
+
+1. Set `OPENROUTER_API_KEY` in your shell profile before launching Opencode.
+2. Run `/connect` inside an Opencode session, choose `OpenRouter`, and paste your API key.
+
+Opencode stores `/connect` credentials in `~/.local/share/opencode/auth.json`. The checked-in `opencode.json` does not hardcode `baseURL` or credentials; Opencode resolves the native `openrouter` provider itself.
+
+## Confirmed Model IDs
+
+Task 2 confirmed these OpenRouter model slugs and Opencode model identifiers:
+
+| Display name | OpenRouter slug | Opencode model ID |
+|---|---|---|
+| `MoonshotAI: Kimi K2.6` | `moonshotai/kimi-k2.6` | `openrouter/moonshotai/kimi-k2.6` |
+| `Qwen: Qwen3.6 Plus` | `qwen/qwen3.6-plus` | `openrouter/qwen/qwen3.6-plus` |
+| `Z.ai: GLM 5.1` | `z-ai/glm-5.1` | `openrouter/z-ai/glm-5.1` |
+
+The canonical mapping note lives in `../../.github/notes/opencode-provider-mapping.md`.
+
+## User-Level MCP Servers
+
+### Tavily
+
+Add Tavily only to your personal Opencode config. It is not committed to the repository.
 
 ```json
 {
@@ -27,11 +83,9 @@ Add to `~/.config/opencode/opencode.json`:
 }
 ```
 
-### Context7 (Library Documentation)
+### Context7
 
-Provides up-to-date library documentation lookup via the `@upstash/context7-mcp` server.
-
-Add to `~/.config/opencode/opencode.json`:
+Add Context7 only to your personal Opencode config.
 
 ```json
 {
@@ -45,13 +99,22 @@ Add to `~/.config/opencode/opencode.json`:
 }
 ```
 
-## OpenRouter
+Both snippets belong in `~/.config/opencode/opencode.json`, not the repository root.
 
-Authentication for the OpenRouter provider (used for Kimi K2.6, Qwen3.6 Plus, and GLM 5.1) can be set via:
+## Verification
 
-1. **Environment variable** — set `OPENROUTER_API_KEY` in your shell profile.
-2. **TUI connect command** — run `/connect` inside an Opencode session, search for "OpenRouter", and paste your API key.
+Once `OPENROUTER_API_KEY` is available, verify model resolution locally:
 
-Your API key is stored at `~/.local/share/opencode/auth.json` after using `/connect`.
+```bash
+opencode run "hello" --model openrouter/moonshotai/kimi-k2.6
+opencode run "hello" --model openrouter/qwen/qwen3.6-plus
+opencode run "hello" --model openrouter/z-ai/glm-5.1
+```
 
-> This file is a stub. Task 10 of the Copilot-to-Opencode migration will expand it with full runtime validation instructions and dual-run configuration.
+If you rely on Tavily, verify that `TAVILY_API_KEY` is exported before starting Opencode.
+
+## Related
+
+- [Documentation Index](../README.md)
+- [ADR 009: Opencode as Primary Agent Runtime](../planning/adr/009-opencode-as-primary-agent-runtime.md)
+- [Migration Tasks](../planning/copilot-to-opencode-migration/tasks.md)

--- a/docs/features/opencode-runtime.md
+++ b/docs/features/opencode-runtime.md
@@ -1,0 +1,57 @@
+# Opencode Runtime Configuration
+
+User-level setup required for full agentic capability in this project. These entries go in `~/.config/opencode/opencode.json` (or the platform equivalent) — **not** in the project-level `opencode.json`.
+
+## MCP Servers
+
+### Tavily (Web Search)
+
+Provides web search capability to agents via the `tavily-mcp` server.
+
+**Prerequisites:** A [Tavily API key](https://app.tavily.com/).
+
+Add to `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "mcp": {
+    "tavily": {
+      "type": "local",
+      "command": ["npx", "-y", "tavily-mcp@latest"],
+      "env": {
+        "TAVILY_API_KEY": "<your-tavily-api-key>"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+### Context7 (Library Documentation)
+
+Provides up-to-date library documentation lookup via the `@upstash/context7-mcp` server.
+
+Add to `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "mcp": {
+    "context7": {
+      "type": "local",
+      "command": ["npx", "-y", "@upstash/context7-mcp@latest"],
+      "enabled": true
+    }
+  }
+}
+```
+
+## OpenRouter
+
+Authentication for the OpenRouter provider (used for Kimi K2.6, Qwen3.6 Plus, and GLM 5.1) can be set via:
+
+1. **Environment variable** — set `OPENROUTER_API_KEY` in your shell profile.
+2. **TUI connect command** — run `/connect` inside an Opencode session, search for "OpenRouter", and paste your API key.
+
+Your API key is stored at `~/.local/share/opencode/auth.json` after using `/connect`.
+
+> This file is a stub. Task 10 of the Copilot-to-Opencode migration will expand it with full runtime validation instructions and dual-run configuration.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -133,6 +133,12 @@ models:
 
 The `openai-compat://` prefix routes to the configured OpenAI-compatible API. Override `model_api_base` in `infrastructure:` to change the endpoint (default: `http://127.0.0.1:1234/v1`).
 
+### 3.4 Opencode Agent Runtime Setup
+
+The Python story-generation runtime above is separate from the Opencode agent runtime used for the Copilot-to-Opencode migration work. That migration config lives in the repository root `opencode.json`, where the default model is now `openrouter/moonshotai/kimi-k2.6` and the OpenRouter provider registry includes Kimi K2.6, Qwen3.6 Plus, and GLM 5.1.
+
+Developer-local credentials and user-level MCP servers are not committed to the repository. Configure `OPENROUTER_API_KEY`, Tavily, and Context7 in your personal Opencode config instead. See [Opencode Runtime Configuration](./features/opencode-runtime.md) for the exact setup and confirmed model IDs.
+
 ---
 
 ## 4. Configuration

--- a/opencode.json
+++ b/opencode.json
@@ -1,7 +1,23 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "openrouter/moonshotai/kimi-k2.6",
   "instructions": ["AGENTS.md"],
   "plugin": ["opencode-rules@latest"],
+  "provider": {
+    "openrouter": {
+      "models": {
+        "moonshotai/kimi-k2.6": {
+          "name": "MoonshotAI: Kimi K2.6"
+        },
+        "qwen/qwen3.6-plus": {
+          "name": "Qwen: Qwen3.6 Plus"
+        },
+        "z-ai/glm-5.1": {
+          "name": "Z.ai: GLM 5.1"
+        }
+      }
+    }
+  },
   "mcp": {
     "chroma": {
       "type": "local",


### PR DESCRIPTION
## Summary

Configures Opencode to use OpenRouter as the default provider and registers the three confirmed model IDs used across the 24 migrated agents. Creates the provider mapping note consumed by Tasks 4–8 and stubs the runtime configuration documentation.

## Closes

Closes #226

## Changes

- [x] `opencode.json` — added `"model"` default and `"provider.openrouter"` block with all three models
- [x] `.github/notes/opencode-provider-mapping.md` — records confirmed Opencode model IDs (consumed by Tasks 4–8)
- [x] `docs/features/opencode-runtime.md` — stub for user-level Tavily/Context7/OpenRouter setup (Task 10 finalises)
- [x] All pre-existing tests passing (3 pre-existing failures on `development` unchanged)
- [x] Linting clean

## Plan

### Summary

Configures Opencode with the OpenRouter provider block and registers three confirmed model slugs: `moonshotai/kimi-k2.6`, `qwen/qwen3.6-plus`, and `z-ai/glm-5.1`. Slugs verified against openrouter.ai/models on 2026-04-29. Creates the `.github/notes/opencode-provider-mapping.md` reference file (input to Tasks 4–8) and the `docs/features/opencode-runtime.md` stub.

### Affected Areas

Config: `opencode.json` — OpenRouter provider config; ChromaDB schema change: no.

### Task Checklist

- [x] `opencode.json` — add default model + provider.openrouter block
- [x] `.github/notes/opencode-provider-mapping.md` — create with slug/ID table
- [x] `docs/features/opencode-runtime.md` — create stub

### Risks & Edge Cases

- `OPENROUTER_API_KEY` not available at CI time — verification commands documented but not executed; developers must verify locally
- Model slug format: `z-ai` (hyphen) not `z.ai` (dot) — confirmed from openrouter.ai