### PR TITLE
feat(opencode): add chromadb rules file for opencode-rules plugin (Migration Task 3)

### DIFF
--- a/.github/notes/reviews/2026-04-29-pr236-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr236-claude-raw.md
@@ -1,0 +1,88 @@
+# Code Review Report — PR #236 (feat/issue-227-chromadb-opencode-rules)
+
+**Reviewer:** Claude (Sonnet 4.6)
+**Date:** 2026-04-29
+**Branch:** `feat/issue-227-chromadb-opencode-rules`
+**Against:** `development`
+
+---
+
+## Review Summary
+
+This PR adds a single file — `.opencode/rules/chromadb.md` — which ports the existing `.github/instructions/chromadb.instructions.md` reference into the opencode-rules plugin format. The content is a verbatim copy of the VS Code instruction file with an added YAML frontmatter block. The content itself is correct and complete. One meaningful finding was identified: the `globs` pattern restricts rule loading to Python source files only, which excludes the primary consumers (agent and skill Markdown files) where ChromaDB query and write patterns are most frequently invoked.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 1 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] `globs` pattern excludes primary consumers of the ChromaDB reference
+Category: Correctness
+Severity: Warning
+File: .opencode/rules/chromadb.md
+Lines: 2
+Description: The frontmatter declares `globs: ["src/**/*.py"]`, which restricts rule
+loading to Python source files. The ChromaDB reference — particularly the Standard
+Query Patterns, Standard Write Pattern, Standard Read Pattern, and collection metadata
+schemas — is primarily consumed when agents or developers are editing opencode agent
+and skill files (`.opencode/agents/*.md`, `.opencode/skills/**/*.md`). Those paths
+do not match `src/**/*.py`, so the rule is not loaded in the most common scenario
+where it is needed.
+
+The VS Code counterpart (`.github/instructions/chromadb.instructions.md`) has no
+`applyTo` frontmatter and therefore applies to all files in every context.
+
+The `opencode-rules@latest` plugin is confirmed active in `opencode.json`.
+
+Suggestion: Broaden the globs to include agent and skill files, or remove the
+restriction to apply the rule globally. For example:
+
+  globs: ["src/**/*.py", ".opencode/agents/**/*.md", ".opencode/skills/**/*.md"]
+
+or, if global coverage is acceptable:
+
+  (omit globs entirely — opencode-rules applies the rule to all files by default
+   when the globs key is absent)
+```
+
+---
+
+### Suggestions
+
+```
+[S-01] Verbatim duplication of `.github/instructions/chromadb.instructions.md`
+         without a sync mechanism
+Category: Documentation
+Severity: Suggestion
+File: .opencode/rules/chromadb.md
+Lines: general
+Description: The body of the new file is a verbatim copy of the existing VS Code
+instruction file. There is no comment, README entry, or automation to keep the two
+in sync. If the canonical instruction file is updated (new collection added, query
+pattern changed, metadata schema extended), the opencode rules file will silently
+diverge. The risk is low while the file is new, but grows with every future change
+to the source.
+
+Suggestion: Add a comment at the top of the file noting its canonical source and
+the expectation that it mirrors `.github/instructions/chromadb.instructions.md`,
+e.g.:
+
+  <!-- Source: .github/instructions/chromadb.instructions.md — keep in sync -->
+
+Alternatively, consider whether a single source of truth is achievable via an
+opencode-rules `include:` or `extends:` mechanism if the plugin supports it.
+This is out of scope for this PR; recording here as a future maintenance note.
+```
+
+---
+
+## Overall Assessment
+
+The PR is clean in structure and commit quality. The content added is accurate and complete — it faithfully mirrors the authoritative ChromaDB reference. One actionable finding exists (W-01): the `globs` restriction to `src/**/*.py` means the rule will not be active when agents edit their own workflow files, which is the scenario where ChromaDB call patterns are most relevant. This should be fixed before merge by broadening the glob list. The duplication concern (S-01) is a maintenance note for the future, not a blocker.
+
+**Merge recommendation:** Fix W-01 (update `globs`), then merge.

--- a/.github/notes/reviews/2026-04-29-pr236-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr236-gemini-raw.md
@@ -1,0 +1,30 @@
+### Review Summary
+
+The PR introduces `.opencode/rules/chromadb.md` to provide ChromaDB capability rules for the `opencode-rules` plugin. Overall the scoped intention is sound, but the entire content is a verbatim copy of `.github/instructions/chromadb.instructions.md` without removing the original or updating its 20+ references across the workspace agents, resulting in a dual-source synchronization hazard.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 1 Warning, 0 Suggestion
+
+### Findings
+
+#### Critical Findings
+
+*None.*
+
+#### Warning Findings
+
+[W-01] Documentation Duplication and Synchronization Risk
+Category: Documentation
+Severity: Warning
+File: .opencode/rules/chromadb.md
+Lines: general
+Description: The newly added rule file is a verbatim copy of the existing `.github/instructions/chromadb.instructions.md`. Because the original file was not deleted, there are now two identical authoritative sources for ChromaDB instructions. Currently, over 20 agent instruction files in the workspace (e.g. `coder.agent.md`, `test-writer.agent.md`) explicitly point to `.github/instructions/chromadb.instructions.md`. Leaving duplicate files creates a high risk of divergence—if one is updated later, the other will fall out of sync, causing agents in different environments (Copilot vs OpenCode) to behave differently.
+Suggestion: Either move the file to `.opencode/rules/` entirely and use `grep` to update all references to the new path across the `.github/agents-*/` directories, or (if supported by the `opencode-rules` plugin) replace the duplicate content with a symlink to the original file.
+
+#### Suggestions
+
+*None.*
+
+### Overall Assessment
+
+The PR successfully layers in the necessary documentation for the OpenCode environment, but the documentation duplication presents a risk of divergence. The codebase relies heavily on single sources of truth. The PR is not ready for merge until the duplicate file situation is resolved by either unifying the file paths or setting up a symlink.

--- a/.github/notes/reviews/2026-04-29-pr236-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr236-gpt-raw.md
@@ -1,0 +1,32 @@
+# Code Review Report
+
+## Review Summary
+
+This PR adds a single Opencode rule file, `.opencode/rules/chromadb.md`, by porting the existing ChromaDB instruction body into the `opencode-rules` plugin format. The branch name, commit message, and scope all align with repository conventions, and the rule scope matches the migration task's stated acceptance criteria (`src/**/*.py` only). No correctness, security, or merge-blocking convention issues were identified in the submitted change.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 0 Warning, 1 Suggestion
+
+## Findings
+
+### Critical Findings
+
+None.
+
+### Warning Findings
+
+None.
+
+### Suggestions
+
+[S-01] Add a parity check for the duplicated ChromaDB rule body
+Category: Documentation
+Severity: Suggestion
+File: .opencode/rules/chromadb.md
+Lines: general
+Description: This file intentionally duplicates the body of `.github/instructions/chromadb.instructions.md`. The current PR content appears correct, but the duplication creates a future maintenance risk: later edits to the Copilot instruction can silently diverge from the Opencode rule, leaving the two runtimes with different ChromaDB guidance. This is not a defect in the current change, but it is a predictable follow-on risk introduced by the new mirrored file.
+Suggestion: As a follow-up, add a lightweight parity check or documented maintenance step that compares `.opencode/rules/chromadb.md` against `.github/instructions/chromadb.instructions.md` while ignoring the frontmatter difference. A small test, script, or CI check would catch drift early.
+
+## Overall Assessment
+
+This change is ready for merge. It is small, targeted, and consistent with the migration plan and the existing `opencode.json` plugin registration. The main residual risk is future content drift between the Copilot instruction file and this new Opencode rule file, because the same guidance now exists in two locations and the review package does not include an automated parity safeguard.

--- a/.github/notes/reviews/2026-04-29-pr236-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr236-synthesis.md
@@ -1,0 +1,214 @@
+# Synthesized Review Report — PR #236 (`feat/issue-227-chromadb-opencode-rules`)
+
+**Reviewer:** Synthesizing Reviewer
+**Date:** 2026-04-29
+**Branch:** `feat/issue-227-chromadb-opencode-rules`
+**Against:** `development`
+**Raw reports:** [claude-raw](2026-04-29-pr236-claude-raw.md) · [gpt-raw](2026-04-29-pr236-gpt-raw.md) · [gemini-raw](2026-04-29-pr236-gemini-raw.md)
+
+---
+
+## Synthesis Overview
+
+This PR adds a single file — `.opencode/rules/chromadb.md` — which ports the existing `.github/instructions/chromadb.instructions.md` content into the `opencode-rules` plugin format, with a YAML frontmatter block scoping it to `src/**/*.py`. All three reviewers agreed on the change's correctness and the absence of any security or critical defects. The dominant finding across all three models is the future content-drift risk introduced by maintaining two copies of the same instruction body without a synchronisation mechanism. One divergence exists on the severity and proposed remediation of that risk; a second divergence concerns whether the `globs` pattern is too narrow, where only one model raised a concern.
+
+**Model Agreement Score:** 7/10 — strong alignment on the core duplication risk, but meaningful divergence on severity classification and remediation approach, plus a split on the `globs` finding.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment     | Unique Focus Areas                   | Critical Count | Warning Count |
+| ------ | ---------------------- | ------------------------------------ | -------------- | ------------- |
+| Claude | Fix W-01, then merge   | `globs` scope excludes agent/skill files | 0          | 1             |
+| GPT    | Ready to merge         | Parity check / CI safeguard          | 0              | 0             |
+| Gemini | Not ready — resolve duplication first | Delete original, update 20+ refs | 0    | 1             |
+
+**Claude** was the only model to flag the `globs: ["src/**/*.py"]` restriction as a defect, and provided a concrete broadened pattern. Its duplication finding was rated Suggestion with a lightweight fix (add a sync comment or investigate `extends:` support).
+
+**GPT** explicitly approved the `globs` pattern as matching the migration task's stated acceptance criteria, found no warnings, and assessed the PR as merge-ready. It echoed the duplication risk as a Suggestion, recommending a future parity check or CI guard.
+
+**Gemini** elevated the duplication risk to Warning and proposed the most invasive remediation: delete the original file and update all 20+ cross-references in `.github/agents-copilot/` and `.github/agents-openrouter/`. It did not raise the `globs` concern at all.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+```
+[U-S-01] Content duplication between `.opencode/rules/chromadb.md` and
+         `.github/instructions/chromadb.instructions.md` lacks a sync mechanism
+Severity: Suggestion  (see divergence D-01 — Gemini rated Warning; 2/3 rate Suggestion)
+Category: Documentation / Maintenance
+File: .opencode/rules/chromadb.md
+Lines: general
+Detail: The new file is a verbatim copy of the existing VS Code instruction file.
+        Because the original was not removed, two identical authoritative copies of
+        the ChromaDB reference now exist. Future edits to either file can silently
+        diverge, causing the Copilot/VS Code environment and the OpenCode environment
+        to operate from different guidance. This is not a defect in the current change
+        but is a predictable follow-on maintenance risk.
+        Verified: the grep search confirms 20+ references across
+        `.github/agents-copilot/` and `.github/agents-openrouter/` continue to point
+        at the original path, confirming both copies are active in separate runtimes.
+Models: Claude ✓ GPT ✓ Gemini ✓
+Suggestion: Add a sync-source comment at the top of the opencode rules file:
+            <!-- Source: .github/instructions/chromadb.instructions.md — keep in sync -->
+            As a longer-term option, introduce a CI parity check (diff the two bodies
+            after stripping frontmatter) to catch drift automatically. Gemini's
+            suggestion to delete the original is not appropriate — see D-01.
+```
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+None.
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] `globs: ["src/**/*.py"]` excludes future opencode agent and skill files
+Severity: Suggestion (Claude rated Warning — see D-02)
+Category: Correctness / Design
+File: .opencode/rules/chromadb.md
+Lines: 2
+Detail: The `globs` pattern restricts rule loading to Python source files.
+        The ChromaDB reference — collection schemas, ID conventions, read/write
+        patterns — is primarily relevant when agents perform embeddings or queries,
+        which in the OpenCode environment would occur inside agent/skill Markdown
+        files under `.opencode/agents/` and `.opencode/skills/`.
+        As of this PR, `.opencode/agents/` contains only `.gitkeep` (empty).
+        Therefore, there are currently no files the broader glob would match.
+        This is a forward-looking concern, not a current bug.
+        GPT explicitly approved the current `src/**/*.py` scope as meeting the
+        migration task's acceptance criteria.
+Model: Claude
+Assessment: Genuine future concern, but not a current defect. The `.opencode/agents/`
+            directory is empty; no agent files yet exist in the OpenCode environment.
+            The `globs` pattern is correct for the current scope of the migration.
+            When agent files are added to `.opencode/agents/`, the glob should be
+            broadened. Downgraded from Claude's Warning to Suggestion because the
+            consumer files do not yet exist.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Severity and remediation for the duplication risk
+
+Claude says:  Suggestion — add a sync-source comment; explore `extends:` support in
+              the opencode-rules plugin; low risk while the file is new.
+GPT says:     Suggestion — add a parity check or lightweight CI guard for future
+              divergence; the current content is correct.
+Gemini says:  Warning — delete the original `.github/instructions/chromadb.instructions.md`
+              and update all 20+ cross-references across `.github/agents-*` directories
+              to point at the new path; the PR is not merge-ready until resolved.
+
+Assessment:   Claude and GPT are correct; Gemini's remediation is a false direction.
+              The 20+ references in `.github/agents-copilot/` and
+              `.github/agents-openrouter/` correctly point at the Copilot/VS Code path
+              because those agents operate in the Copilot environment — they should
+              never reference an OpenCode-specific path. The two files serve distinct
+              runtimes and must both exist. Deleting the original would silently break
+              ChromaDB guidance for every Copilot and OpenRouter agent in the repository.
+              Gemini's reasoning mischaracterises the dual-runtime architecture as a
+              defect; it is the intended design.
+              Severity is correctly Suggestion (2/3 models). Gemini's Warning elevation
+              is caused by the same flawed premise.
+
+Resolution:   Treat as [U-S-01] at Suggestion severity. Gemini's delete-and-repoint
+              suggestion excluded. Lightweight sync comment is the appropriate fix.
+```
+
+```
+[D-02] Topic: Whether the `globs: ["src/**/*.py"]` restriction is a defect
+
+Claude says:  Warning — excludes the primary consumers (agent/skill Markdown files);
+              should be broadened to include `.opencode/agents/**/*.md` and
+              `.opencode/skills/**/*.md`, or dropped entirely.
+GPT says:     No finding — the scope explicitly matches the migration task's
+              stated acceptance criteria; no defect.
+Gemini says:  No finding — not raised.
+
+Assessment:   Claude's concern is technically sound as a forward-looking design note,
+              but is not a current defect. Verified: `.opencode/agents/` contains only
+              `.gitkeep`; no agent files exist yet in the OpenCode environment. There
+              are currently no `.opencode/agents/*.md` or `.opencode/skills/**/*.md`
+              files for the rule to be loaded against. GPT's acceptance based on current
+              state (and acceptance criteria) is accurate for this PR's scope.
+              2/3 models found no issue here; this is a low-confidence finding.
+
+Resolution:   Treat as [S-I-01] at Suggestion severity. Defer broadening the glob
+              to the PR that introduces the first `.opencode/agents/*.md` file.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [U-S-01] ★★★ Consider: Add sync-source comment to .opencode/rules/chromadb.md
+                            (Suggestion — all models agree, lightweight fix)
+
+2. [S-I-01] ★☆☆ Note: Broaden `globs` when first `.opencode/agents/*.md` is added
+                         (Suggestion — Claude only; no current consumers affected)
+```
+
+---
+
+## Merge Recommendation
+
+**Merge-ready with optional cleanup.** Neither finding is a blocker.
+
+- [U-S-01] is a low-effort improvement (one-line comment) that reduces future maintenance risk. Recommended but not required for merge.
+- [S-I-01] should be addressed in a follow-on PR when the first OpenCode agent file is created; no action required now.
+- Gemini's suggestion to delete `.github/instructions/chromadb.instructions.md` and update 20+ cross-references is **rejected** — the two files serve separate runtimes and must coexist.
+- Gemini's "not ready for merge" assessment is based on a flawed premise; the correct assessment (Claude, GPT) is that the PR is ready.
+
+---
+
+## Review Notes Summary
+
+```markdown
+## Synthesized Code Review — 2026-04-29
+
+**Review Type:** Multi-model synthesis (Claude Sonnet 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** feat/issue-227-chromadb-opencode-rules
+**Model Agreement Score:** 7/10
+**Overall Assessment:** Clean (merge-ready with optional minor cleanup)
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 1          |
+| ★★☆ Majority      | 0        | 0       | 0          |
+| ★☆☆ Singular      | 0        | 0       | 1          |
+
+### Key Findings
+
+- [U-S-01] Duplication of ChromaDB instruction body across two runtimes without a sync
+           mechanism — lightweight fix (sync comment) recommended but not blocking (★★★)
+- [S-I-01] `globs: ["src/**/*.py"]` will exclude future `.opencode/agents/*.md` files;
+           defer action until first agent file is created (★☆☆, Claude only)
+
+### Divergences
+
+- [D-01] Severity and remediation of duplication risk: Gemini rated Warning and proposed
+         deleting the original file + updating 20+ cross-references. Rejected — the two
+         files serve separate runtimes (Copilot vs OpenCode). 2/3 correctly rate Suggestion.
+- [D-02] `globs` restriction: Claude (Warning) vs GPT/Gemini (no finding). Downgraded
+         to Suggestion — `.opencode/agents/` is currently empty; no current consumers affected.
+
+### Actions Required
+
+- Findings requiring fixes: 0 (blockers)
+- Findings recommended: 1 ([U-S-01] — add sync comment)
+- Findings deferred: 1 ([S-I-01] — address when first opencode agent file added)
+```

--- a/.opencode/rules/chromadb.md
+++ b/.opencode/rules/chromadb.md
@@ -1,6 +1,8 @@
 ---
 globs: ["src/**/*.py"]
 ---
+<!-- Source: .github/instructions/chromadb.instructions.md — keep in sync -->
+
 # ChromaDB — Agent Reference
 
 

--- a/.opencode/rules/chromadb.md
+++ b/.opencode/rules/chromadb.md
@@ -1,0 +1,249 @@
+---
+globs: ["src/**/*.py"]
+---
+# ChromaDB — Agent Reference
+
+
+ChromaDB is a **derived semantic index** over the authoritative Markdown knowledge base in `.github/notes/`. Never write to ChromaDB without first writing to the Markdown source.
+
+---
+
+## Collections
+
+| Collection | Scope | Source Files | Managed By |
+|------------|-------|-------------|------------|
+| **`conventions`** | Gotchas, patterns, architecture, domain | `gotchas.md`, `patterns.md`, `architecture.md`, `domain.md` | Orchestrator, Reflection |
+| **`reflections`** | Agent system improvement notes | `.github/notes/reflections/` | Reflection |
+| **`audits`** | Audit reports and findings | `.github/notes/audits/` | Contemplator, Synth Auditor, Auditor |
+| **`codebase`** | Feature docs, ADRs, skills, modules | `docs/`, `.github/skills/`, `docs/planning/adr/` | Documenter |
+| **`tests`** | Test patterns, fixtures, failure learnings | `docs/testing/`, test files | Test Writer |
+
+---
+
+## Metadata Schemas
+
+### `conventions`
+
+| Field | Type | Examples |
+|-------|------|---------|
+| `category` | string | `gotcha`, `pattern`, `architecture`, `domain` |
+| `source_file` | string | `.github/notes/gotchas.md` |
+| `severity` | string | `info`, `warning`, `critical` |
+| `tags` | string | `"tenancy,security,fillable"` |
+| `entry_number` | string | `"19"` |
+| `indexed_at` | string | `2026-03-18` |
+
+### `reflections`
+
+| Field | Type | Examples |
+|-------|------|---------|
+| `issue` | string | `"194"` |
+| `severity` | string | `minor`, `major` |
+| `category` | string | `agent`, `skill`, `instruction` |
+| `target` | string | `.github/skills/e2e-testing/SKILL.md` |
+| `status` | string | `active`, `archived` |
+| `date` | string | `2026-03-16` |
+| `source_file` | string | `.github/notes/reflections/issue-194-….md` |
+
+### `audits`
+
+| Field | Type | Examples |
+|-------|------|---------|
+| `audit_date` | string | `2026-03-10` |
+| `audit_type` | string | `solo`, `synthesis` |
+| `confidence` | string | `unanimous`, `supermajority`, `majority`, `singular` |
+| `domain` | string | `security`, `architecture`, `testing`, `permissions` |
+| `source_file` | string | `.github/notes/audits/2026-03-10-synthesis.md` |
+
+### `codebase`
+
+| Field | Type | Examples |
+|-------|------|---------|
+| `doc_type` | string | `feature`, `adr`, `skill`, `module`, `planning` |
+| `module` | string | `activities`, `core`, `tenancy`, `auth` |
+| `phase` | string | `phase-1`, `phase-2`, `interim` |
+| `source_file` | string | `docs/features/activities.md` |
+| `indexed_at` | string | `2026-03-18` |
+
+### `tests`
+
+| Field | Type | Examples |
+|-------|------|---------|
+| `test_type` | string | `unit`, `integration`, `e2e` |
+| `domain` | string | `auth`, `stories`, `generation`, `permissions` |
+| `fixture_type` | string | `user`, `story`, `chapter` |
+| `source_file` | string | `tests/unit/test_user_management.py` |
+| `indexed_at` | string | `2026-03-18` |
+
+---
+
+## Per-Story Collections
+
+Each story has a dedicated ChromaDB collection named `stories-{story_name}` (e.g. `stories-my-story`). These collections are created automatically by `rag-query` on first index.
+
+| Collection | Name Pattern | Managed By |
+|------------|-------------|------------|
+| **Per-story RAG** | `stories-{story_name}` | `rag-query` tool (story-orchestrator, wiki-maintainer) |
+
+### Per-Story Collection Metadata Schema
+
+| Field | Type | Examples |
+|-------|------|---------|
+| `story` | string | `"my-story"` |
+| `content_type` | string | `"outline"`, `"chapter"`, `"character"`, `"setting"`, `"wiki"`, `"recap"`, `"raw-chapter"` |
+| `doc_id` | string | `"outline"`, `"chapter-1"`, `"character-elena"`, `"chapter-3-raw"` |
+| `chapter_num` | integer | `1`, `3` (optional, for chapter-related content) |
+
+### Per-Story Document ID Conventions
+
+| Content Type | ID Pattern | Example |
+|-------------|------------|---------|
+| `outline` | `outline` | `outline` |
+| `chapter` | `chapter-{N}` | `chapter-1` |
+| `character` | `character-{slug}` | `character-elena` |
+| `setting` | `setting-{slug}` | `setting-northwood-village` |
+| `wiki` | `wiki-{slug}` | `wiki-elena-vasquez` |
+| `recap` | `recap-chapter-{N}` | `recap-chapter-3` |
+| `raw-chapter` | `chapter-{N}-raw` | `chapter-3-raw` |
+
+**`raw-chapter`** — full accepted chapter text embedded after Phase 7g acceptance. Used by `consistency-checker` for cross-chapter factual continuity analysis and by the `character-voice` critic mode for voice sample retrieval.
+
+---
+
+## Document ID Conventions
+
+IDs are stable and slugified. Re-indexing the same source produces the same IDs (upsert behaviour).
+
+| Collection | Pattern | Example |
+|------------|---------|---------|
+| conventions | `{category}-{slug}-NNN` | `gotcha-config-env-loading-011` |
+| conventions | `arch-{slug}` | `arch-clean-architecture-layers` |
+| conventions | `domain-{slug}` | `domain-story-generation-flow` |
+| reflections | `refl-issue-{N}-{slug}` | `refl-issue-194-e2e-session-reuse` |
+| audits | `audit-{date}-{type}-{domain}-NNN` | `audit-2026-03-10-synthesis-security-001` |
+| codebase | `{doc_type}-{module}-{slug}` | `feature-activities-rsvp-workflow` |
+| codebase | `adr-{number}-{slug}` | `adr-004-module-framework` |
+| codebase | `skill-{name}` | `skill-multi-tenancy` |
+| tests | `{test_type}-{domain}-{slug}` | `e2e-auth-login-flow` |
+| tests | `fixture-{slug}` | `fixture-e2e-tenant-seeding` |
+
+---
+
+## Standard Query Patterns
+
+Use these patterns to query ChromaDB before planning or implementing. Prefer reading from `.github/notes/` for structured data; use ChromaDB for semantic/fuzzy recall.
+
+### Before Planning (Orchestrator, Planner, Contemplator)
+
+```
+chroma_query_documents(collection_name="conventions", query_texts=["<feature or fix description>"], n_results=10)
+chroma_query_documents(collection_name="reflections", query_texts=["<feature domain>"], n_results=5, where={"status": {"$eq": "active"}})
+chroma_query_documents(collection_name="audits", query_texts=["<feature domain>"], n_results=5)
+```
+
+### Before Implementing (Coder)
+
+```
+chroma_query_documents(collection_name="conventions", query_texts=["<task description>"], n_results=10, where={"$or": [{"category": {"$eq": "gotcha"}}, {"category": {"$eq": "pattern"}}]})
+```
+
+### Before Writing Tests (Test Writer)
+
+```
+chroma_query_documents(collection_name="tests", query_texts=["<test domain>"], n_results=5)
+chroma_query_documents(collection_name="conventions", query_texts=["<feature name> test patterns"], n_results=5)
+```
+
+### Before Documenting (Documenter)
+
+```
+chroma_query_documents(collection_name="codebase", query_texts=["<feature name>"], n_results=5)
+```
+
+### After Writing to .github/notes/
+
+Always embed new knowledge into the appropriate ChromaDB collection using `chroma_add_documents`. See the ID conventions and metadata schemas above. Use `chroma_update_documents` for updates to existing entries.
+
+---
+
+## Standard Write Pattern
+
+After appending knowledge to `.github/notes/`:
+
+1. **Ensure collection exists** — `chroma_create_collection` (idempotent)
+2. **Embed** — `chroma_add_documents` with stable ID, metadata, and content
+3. **For updates** — `chroma_update_documents` with the same stable ID
+
+```
+chroma_add_documents:
+  collection_name: "conventions"
+  documents: ["Never put tenant_id in $fillable — BelongsToTenant auto-assigns it."]
+  metadatas: [{"category": "gotcha", "source_file": ".github/notes/gotchas.md", "severity": "critical", "tags": "tenancy,security,fillable", "entry_number": "19", "indexed_at": "2026-03-18"}]
+  ids: ["gotcha-tenant-id-not-fillable-019"]
+```
+
+**Constraints:**
+
+- Never write to ChromaDB without first writing to the Markdown source
+- Never delete from `conventions` or `reflections` — only update or add
+- Always include `source_file` in metadata for traceability
+- `indexed_at` = when the entry was last embedded, not when it was authored
+
+## Standard Read Pattern
+
+1. **Query semantically** — `chroma_query_documents` with natural-language description, `n_results: 10`
+2. **Filter by metadata** — use `where` clauses when the domain is known
+3. **Incorporate results** into the plan or implementation context
+
+```
+chroma_query_documents:
+  collection_name: "conventions"
+  query_texts: ["activity participant tenant scoping policy"]
+  n_results: 10
+  where: {"$or": [{"category": {"$eq": "gotcha"}}, {"category": {"$eq": "pattern"}}]}
+```
+
+## Query Operators
+
+**Metadata filters (`where`):**
+
+```json
+{"category": "gotcha"}
+{"$and": [{"category": {"$eq": "gotcha"}}, {"severity": {"$eq": "critical"}}]}
+{"$or": [{"category": {"$eq": "gotcha"}}, {"category": {"$eq": "pattern"}}]}
+```
+
+**Document content filters (`where_document`):**
+
+```json
+{"$contains": "tenant_id"}
+{"$not_contains": "deprecated"}
+```
+
+---
+
+## Chunk Granularity
+
+| Source | Granularity |
+|--------|------------|
+| `gotchas.md`, `patterns.md` | One document per numbered entry |
+| `architecture.md`, `domain.md` | One document per `##` heading |
+| `reflections/` | One document per reflection file |
+| `audits/` | One document per finding within an audit report |
+| `docs/` feature/skill files | One document per `##` section |
+| Test files | One document per test class summary |
+
+---
+
+## Bootstrapping
+
+To rebuild the index from scratch:
+
+1. Create all 5 collections — `chroma_create_collection` for each
+2. Index `conventions` — parse `gotchas.md` (by entry), `patterns.md` (by `##`), `architecture.md`, `domain.md`
+3. Index `reflections` — each file in `.github/notes/reflections/` and `archive/`
+4. Index `audits` — each audit report, split by finding
+5. Index `codebase` — `docs/features/*.md`, `docs/planning/adr/*.md`, `.github/skills/*/SKILL.md`
+6. Index `tests` — `docs/testing.md`, `docs/testing/*.md`, test class summaries
+
+To reindex a single collection: delete it, recreate it, re-run its bootstrap step.


### PR DESCRIPTION
## Summary

Creates `.opencode/rules/chromadb.md` — the `opencode-rules@latest` translation of the existing Copilot instruction file at `.github/instructions/chromadb.instructions.md`.

The only change is the frontmatter key: `applyTo:` (Copilot) → `globs:` (opencode-rules). Body content is identical.

## Closes

Closes #227

## Changes

- [x] `.opencode/rules/chromadb.md` created with `globs: ["src/**/*.py"]` frontmatter and identical body content
- [x] `.github/instructions/chromadb.instructions.md` unchanged
- [x] Linting clean

## Plan

**Summary:** Translate Copilot's `applyTo:` instruction file to the `opencode-rules@latest` `globs:` format. No production code changes.

**Affected Areas:** Config/agent rules only — new `.opencode/rules/chromadb.md` file.

**Task Checklist:**
- [x] `.opencode/rules/chromadb.md` — new, `globs: ["src/**/*.py"]`, body identical to source
- [x] `.github/instructions/chromadb.instructions.md` — unchanged

**Execution Order:** File creation → lint check → commit
