### PR TITLE
Migration Task 10: Document the Opencode runtime and dual-run policy

### DIFF
--- a/.github/notes/reviews/2026-04-29-pr246-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr246-claude-raw.md
@@ -1,0 +1,104 @@
+# Code Review Report — PR #246 (feat/issue-234-opencode-runtime-docs)
+
+**Reviewer:** Claude (Reviewer agent)
+**Date:** 2026-04-29
+**Branch:** `feat/issue-234-opencode-runtime-docs`
+**Commit:** `8b7d282`
+
+---
+
+## Review Summary
+
+This is a documentation-only PR adding the Opencode runtime installation guide, directory layout reference, opencode-rules plugin description, runtime directory inventory, dual-run policy, and agent migration mapping table to `docs/features/opencode-runtime.md`. Companion updates land in `AGENTS.md` (new Runtimes section) and `docs/README.md` (clarification on preserved agent directories). All file path references, agent counts, directory trees, and linked files verified against disk — the core content is accurate. One documentation inconsistency was found: the newly added Runtimes section in `AGENTS.md` creates an internal contradiction with a pre-existing paragraph in the same file that the PR did not update.
+
+**Files Reviewed:** 3
+**Findings:** 0 Critical, 1 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] AGENTS.md internal contradiction — Copilot agent directory
+Category: Documentation
+Severity: Warning
+File: AGENTS.md
+Lines: 37 (new), 59 (pre-existing)
+Description: The newly added Runtimes section (line 37) correctly states that
+GitHub Copilot agents live in `.github/agents-copilot/` and are invoked via
+`@agent-name` in VS Code Chat. The pre-existing Codex Workflow Skills section
+(line 59) still reads: "Older VS Code/GitHub Copilot agent definitions remain
+under `.github/agents/` for reference and Copilot use." Disk verification
+confirms `.github/agents/` now contains only a `_shared/` subdirectory — no
+agent files. A reader (or Codex agent) scanning AGENTS.md encounters two
+conflicting answers for the Copilot agent location within the same document.
+The PR introduced the new canonical statement but did not retire the stale one.
+Suggestion: Update line 59 to replace ".github/agents/" with
+".github/agents-copilot/" (and ".github/agents/_shared/" with
+".github/agents/_shared/" for the shared helpers — that path is still valid).
+Revised text could read: "Frozen VS Code/GitHub Copilot agent definitions are
+preserved in `.github/agents-copilot/`. The `_shared/` helpers used by the
+Copilot surface remain in `.github/agents/_shared/`. Do not treat their
+`tools:` frontmatter or `github/...` tool names as directly callable by
+Codex; translate through the Codex workflow skills first."
+```
+
+---
+
+### Suggestions
+
+```
+[S-01] Installation section npm package name not verifiable from repo
+Category: Documentation
+Severity: Suggestion
+File: docs/features/opencode-runtime.md
+Lines: Installation section (~line 50-66)
+Description: The install command uses `npm install -g opencode-ai`. The
+package name appears only in this new section; no prior docs in the repo
+reference this name for the global CLI. The `@opencode-ai/plugin` import
+seen in PR #145 review package content suggests the npm org is `opencode-ai`,
+which makes the package name plausible, but the CLI package name and the
+plugin scoped package are different things. If the correct global CLI package
+is simply `opencode` (not `opencode-ai`), this command silently installs the
+wrong package. The PR does not cite an official source for the package name.
+Suggestion: Verify `opencode-ai` is the correct npm package name for the
+Opencode CLI against https://opencode.ai or the official npm page before
+merge. If the package name is `opencode`, update both occurrences in the
+Installation section.
+```
+
+---
+
+## Verification Summary
+
+The following claims were verified against disk:
+
+| Claim | Result |
+|---|---|
+| `.opencode/agents/` contains 24 files | ✅ Confirmed (24 `.md` files, names match directory tree) |
+| `.github/agents-copilot/` contains 24 agent files | ✅ Confirmed (24 `.agent.md` + 1 `README.md` = 25 items; agent count correct) |
+| `.github/agents-openrouter/` exists | ✅ Confirmed (25 items) |
+| `.github/agents/` contains only `_shared/` | ✅ Confirmed |
+| `.opencode/rules/chromadb.md` exists with `globs: ["src/**/*.py"]` | ✅ Confirmed |
+| Inline sync comment present in `chromadb.md` | ✅ Confirmed |
+| `opencode.json` model matches docs (`openrouter/moonshotai/kimi-k2.6`) | ✅ Confirmed |
+| `opencode.json` plugin array contains `opencode-rules@latest` | ✅ Confirmed |
+| `opencode.json` provider models match table (kimi-k2.6, qwen3.6-plus, glm-5.1) | ✅ Confirmed |
+| `.github/notes/opencode-provider-mapping.md` exists (linked from docs) | ✅ Confirmed |
+| `docs/planning/adr/009-opencode-as-primary-agent-runtime.md` exists (linked) | ✅ Confirmed |
+| `docs/planning/copilot-to-opencode-migration/tasks.md` exists (linked) | ✅ Confirmed |
+| All 24 Copilot migration table filenames match `.github/agents-copilot/` disk contents | ✅ Confirmed |
+| All 24 Opencode migration table filenames match `.opencode/agents/` disk contents | ✅ Confirmed |
+| Commit message follows convention and references issue | ✅ Confirmed (`docs(opencode): ... (#234)`) |
+| Branch name follows convention | ✅ Confirmed (`feat/issue-234-opencode-runtime-docs`) |
+| No numbered step lists with gaps | ✅ N/A — no numbered workflow steps in changed files |
+| No security issues (no credentials, paths, or code in added content) | ✅ Confirmed |
+| No tests needed (docs-only change) | ✅ Confirmed |
+
+---
+
+## Overall Assessment
+
+The PR delivers accurate, well-organised documentation for the Opencode runtime. All file paths, agent counts, directory trees, linked ADRs, and note files were verified against disk and found correct. The `opencode.json` configuration block in the doc exactly matches the committed file. The one substantive finding (W-01) is a pre-existing stale paragraph in `AGENTS.md` that the PR's new Runtimes section now directly contradicts — a brief text update to line 59 is the only change needed before merge. S-01 (npm package name) is low risk given the `@opencode-ai/plugin` evidence but worth a spot-check. Neither finding blocks correctness of the documented behaviour; the PR is ready to merge after addressing W-01.

--- a/.github/notes/reviews/2026-04-29-pr246-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr246-gemini-raw.md
@@ -1,0 +1,22 @@
+### Review Summary
+
+The PR correctly documents the Opencode runtime layout, the dual-run policy, and provides a clear migration mapping matrix for all 24 agents. The documentation accurately reflects the current directory structures, file counts, and preserved artefacts. The changes conform to documentation conventions.
+
+**Files Reviewed:** 3
+**Findings:** 0 Critical, 0 Warning, 1 Suggestion
+
+### Findings
+
+#### Suggestions
+
+[S-01] Pre-existing broken link in docs/README.md
+Category: Documentation
+Severity: Suggestion
+File: docs/README.md
+Lines: general
+Description: An adjacent unchanged line in `docs/README.md` containing `[Legacy Dependency Cleanup](./features/legacy-dependent-cleanup.md)` points to a non-existent file due to a typo. The actual file on disk is `legacy-dependency-cleanup.md`.
+Suggestion: Update the link target to `./features/legacy-dependency-cleanup.md`. This is out of scope for the current PR, but could be fixed now or in a subsequent docs cleanup.
+
+### Overall Assessment
+
+The documentation is accurate, well-formatted, and ready for merge. The agent mappings precisely match the local workspace structure in both `.github/agents-copilot/` and `.opencode/agents/` (accounting for the 24 files with the correct omission of a base `reviewer` template on both sides). Good to go.

--- a/.github/notes/reviews/2026-04-29-pr246-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr246-gpt-raw.md
@@ -1,0 +1,18 @@
+# Code Review Report
+
+## Review Summary
+
+This PR is a documentation-only change covering the Opencode runtime, the migration-era directory layout, and the dual-run policy between Opencode and GitHub Copilot. I verified the concrete filesystem and configuration claims that matter for correctness: the preserved runtime directories exist, the agent inventories match the documented counts, `.opencode/rules/chromadb.md` exists with the documented scope, and `opencode.json` does include `opencode-rules@latest`.
+
+I did not find any correctness, security, testing, or convention defects in the submitted diff. One separate pre-existing `AGENTS.md` stale-reference fix was noted by the dispatcher as already corrected on disk but not yet committed; I am treating that as addressed/pending commit rather than an open finding against this PR.
+
+**Files Reviewed:** 3
+**Findings:** 0 Critical, 0 Warning, 0 Suggestion
+
+## Findings
+
+No findings.
+
+## Overall Assessment
+
+This change is ready for merge from a review perspective. Residual risk is low because the change is documentation-only and the factual claims added by the PR were spot-checked against the repository and npm registry: `opencode-ai` is a valid package that exposes the `opencode` CLI, the runtime directories and counts described in the new documentation are accurate, and the plugin/rule-file documentation matches the committed `opencode.json` and `.opencode/rules/chromadb.md`. The separate `AGENTS.md` stale-reference fix mentioned in the dispatch note should still be included in a follow-up commit before merge so the branch tip matches the already-corrected on-disk state.

--- a/.github/notes/reviews/2026-04-29-pr246-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr246-synthesis.md
@@ -1,0 +1,195 @@
+# Synthesized Review Report — PR #246 (feat/issue-234-opencode-runtime-docs)
+
+**Date:** 2026-04-29
+**Branch:** `feat/issue-234-opencode-runtime-docs`
+**Commit:** `8b7d282`
+**Synthesis model:** Claude Sonnet 4.6 (Synthesizing Reviewer)
+**Raw reports:**
+- `.github/notes/reviews/2026-04-29-pr246-claude-raw.md`
+- `.github/notes/reviews/2026-04-29-pr246-gpt-raw.md`
+- `.github/notes/reviews/2026-04-29-pr246-gemini-raw.md`
+
+---
+
+## Synthesis Overview
+
+PR #246 is a documentation-only change adding the Opencode runtime installation guide, directory layout reference, dual-run policy, and 24-agent migration mapping table to `docs/features/opencode-runtime.md`, with companion updates to `AGENTS.md` and `docs/README.md`. All three reviewers agreed the core content is accurate and the PR is substantially ready for merge. Agreement was high on the absence of correctness, security, testing, or convention defects. The one substantive finding concerns a stale paragraph in `AGENTS.md` that the PR's new Runtimes section now contradicts; Claude raised it formally, GPT acknowledged it but treated it as already corrected pending commit, and Gemini was silent on it. Both singular findings from Claude and Gemini were either refuted by another reviewer's verification (npm package name) or are confirmed false positives on disk (broken link claim).
+
+**Model Agreement Score:** 8/10 — the three reports reached identical conclusions on correctness and security; divergence was limited to severity classification of one stale-reference issue and two singular findings that did not survive cross-referencing.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment           | Unique Focus Areas                                 | Critical Count | Warning Count |
+| ------ | ---------------------------- | -------------------------------------------------- | -------------- | ------------- |
+| Claude | Ready after W-01 fix         | AGENTS.md internal contradiction; npm package name | 0              | 1             |
+| GPT    | Ready to merge               | npm registry verification; W-01 treated as pending | 0              | 0             |
+| Gemini | Ready to merge               | Broken link in docs/README.md (out of scope)       | 0              | 0             |
+
+**Claude** produced the most thorough verification table (18 spot-checks), formally reported the AGENTS.md contradiction as a Warning, and raised the npm package name as a Suggestion pending external verification.
+
+**GPT** performed the leanest review with zero findings. It was informed by the dispatcher that an AGENTS.md stale-reference fix had already been applied on disk but not yet committed, and chose to treat that as an addressed/pending matter rather than an open finding. It also independently verified the `opencode-ai` npm package, directly refuting Claude's S-01.
+
+**Gemini** found one Suggestion — a claimed broken link in `docs/README.md` — but on-disk verification confirms both occurrences of the link already use the correct spelling (`legacy-dependency-cleanup.md`) and the target file exists. This is a false positive.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+No unanimous findings. All three models agreed the PR contains no Critical defects and no correctness, security, or testing issues.
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-W-01] AGENTS.md stale-reference not yet committed
+Severity: Warning
+Category: Documentation
+File: AGENTS.md
+Lines: ~71 (Codex Workflow Skills section)
+Detail: The PR's new Runtimes section (lines ~37–43) canonically places GitHub
+Copilot agents in `.github/agents-copilot/`. The pre-existing Codex Workflow
+Skills paragraph at line ~71 initially still read `.github/agents/`, directly
+contradicting the new section within the same document. The on-disk file has
+since been corrected to `.github/agents-copilot/`, but GPT's review note states
+the fix had not yet been committed to the branch at review time. If the fix is
+absent from the branch tip, a reader scanning AGENTS.md encounters two
+conflicting answers for the Copilot agent location.
+Models: Claude ✓ (raised as Warning) | GPT ✓ (acknowledged substance;
+        classified as pending-commit rather than open finding) | Gemini ✗
+Dissenting view: GPT explicitly counted 0 findings on the grounds that the
+        correction was already present on disk and pending commit. Gemini did
+        not raise the issue. The underlying substance is agreed by two models;
+        the disagreement is purely about whether a fix-in-progress constitutes
+        an open finding against the PR.
+Suggestion: Confirm the AGENTS.md stale-reference fix (`.github/agents/` →
+        `.github/agents-copilot/` in the Codex Workflow Skills section) is
+        included in the branch before merge. The on-disk working copy already
+        carries the correct text — a `git add AGENTS.md && git commit --amend`
+        or follow-up commit is sufficient.
+```
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] Installation section npm package name (Claude only — refuted by GPT)
+Severity: Suggestion
+Category: Documentation
+File: docs/features/opencode-runtime.md
+Lines: ~50–66 (Installation section)
+Detail: Claude raised concern that `npm install -g opencode-ai` could install
+the wrong package if the correct CLI package name is simply `opencode`. GPT
+independently verified via the npm registry that `opencode-ai` is a valid
+package that exposes the Opencode CLI. This verification directly refutes the
+concern.
+Model: Claude
+Assessment: False positive. GPT's registry check confirms `opencode-ai` is
+        the correct package name. No action required.
+```
+
+```
+[S-I-02] Broken link in docs/README.md (Gemini only — false positive)
+Severity: Suggestion
+Category: Documentation
+File: docs/README.md
+Lines: 40, 57
+Detail: Gemini reported that docs/README.md contains a link to
+`./features/legacy-dependent-cleanup.md` (typo: "dependent" vs "dependency"),
+pointing to a non-existent file. On-disk verification shows both occurrences
+of the link already read `legacy-dependency-cleanup.md` (correct spelling),
+and the target file exists at that path.
+Model: Gemini
+Assessment: False positive — the claimed typo does not exist in the file.
+        Gemini appears to have hallucinated the incorrect spelling. No action
+        required.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] AGENTS.md stale reference — finding vs. pending-fix classification
+Claude says: Warning finding — line 59 of AGENTS.md reads `.github/agents/`
+        while the new Runtimes section says `.github/agents-copilot/`, creating
+        an internal contradiction that must be fixed before merge.
+GPT says:   Not an open finding — the dispatcher informed GPT the correction
+        was already made on disk but not yet committed; GPT treats it as
+        addressed/pending rather than a defect against the PR.
+Gemini says: Silent — did not raise the issue.
+Assessment: Claude is correct that the stale reference constitutes an
+        inconsistency that should be resolved before merge. GPT's 0-finding
+        classification is defensible if the fix genuinely lands in the branch
+        before the PR is merged, but it understates the risk if the commit is
+        forgotten. On-disk verification confirms the fix is present in the
+        working copy, supporting GPT's confidence that it will be committed.
+Resolution: Treat as M-W-01 (Majority Warning). Confirm the fix is committed
+        to the branch before merge.
+```
+
+```
+[D-02] npm package name for Opencode CLI
+Claude says: Suggestion — `opencode-ai` is unverified against an external
+        source; could be wrong package name.
+GPT says:   Verified — checked npm registry, `opencode-ai` is valid and
+        exposes the Opencode CLI.
+Gemini says: Silent — did not raise the issue.
+Assessment: GPT's verification resolves the concern. 2-vs-1 split is moot
+        because GPT directly checked the authoritative source. S-I-01 is a
+        false positive.
+Resolution: No action required. npm package name is confirmed correct.
+```
+
+```
+[D-03] docs/README.md broken link
+Claude says: Silent — did not raise the issue.
+GPT says:   Silent — did not raise the issue.
+Gemini says: Suggestion — link reads `legacy-dependent-cleanup.md` (typo),
+        file does not exist.
+Assessment: On-disk verification shows both link targets already read
+        `legacy-dependency-cleanup.md` (correct) and the file exists. Gemini's
+        claim is contradicted by the actual file contents. This is a
+        hallucinated finding.
+Resolution: False positive. S-I-02 excluded from action list.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [M-W-01] ★★☆ Fix: Confirm AGENTS.md stale-reference fix is committed to
+   branch before merge — Codex Workflow Skills paragraph should reference
+   `.github/agents-copilot/` not `.github/agents/`. Working-copy already
+   correct; needs `git add` + commit. (Warning — 2 models, Claude formal / GPT
+   acknowledged)
+
+2. [S-I-01] ★☆☆ No action — npm package name `opencode-ai` verified by GPT
+   against registry. (Suggestion from Claude, refuted)
+
+3. [S-I-02] ★☆☆ No action — broken-link claim is a false positive; link and
+   file both correct on disk. (Suggestion from Gemini, refuted by disk check)
+```
+
+**Merge readiness:** Ready to merge after confirming M-W-01 fix is committed. No Critical or unanimous Warning findings exist. All singular findings are either refuted or false positives.
+
+---
+
+## Review Notes Summary
+
+**Finding Counts by Consensus**
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 0          |
+| ★★☆ Majority      | 0        | 1       | 0          |
+| ★☆☆ Singular      | 0        | 0       | 2          |
+
+**Actions Required:** 1 (M-W-01 — confirm fix committed before merge)
+**Findings deferred / closed:** 2 (S-I-01 refuted, S-I-02 false positive)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Codex-native development workflows live in `.agents/skills/`. These are the cano
 - `documentation-maintenance` — docs, ADR, README, and companion-file updates
 - `web-research` — current external research with Tavily, Context7, and primary sources
 
-Older VS Code/GitHub Copilot agent definitions remain under `.github/agents/` for reference and Copilot use. Do not treat their `tools:` frontmatter or `github/...` tool names as directly callable by Codex; translate through the Codex workflow skills first.
+Older VS Code/GitHub Copilot agent definitions remain under `.github/agents-copilot/` for reference and Copilot use. Do not treat their `tools:` frontmatter or `github/...` tool names as directly callable by Codex; translate through the Codex workflow skills first.
 
 ### Storage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,15 @@ Story generation agent prompt files are defined in `prompts/agents/` and loaded 
 
 Migration work also uses Opencode agent files under `.opencode/agents/`. The migration inventory is now complete: 24 Markdown agent files covering `orchestrator-v3`, the specialist sub-agents, the reviewer family, the researcher family, the auditor family, and the standalone agents `pr-reviewer`, `planner`, `contemplator`, and `sprint-runner`. The researcher family depends on developer-local Tavily and Context7 MCP servers configured in `~/.config/opencode/opencode.json`; the checked-in `opencode.json` keeps only project-level runtime settings plus Chroma.
 
+### Runtimes
+
+Two agent runtimes are active during the migration transition period:
+
+- **Opencode** (active development surface): agents in `.opencode/agents/` invoked via `opencode run @agent-name`. Uses OpenRouter-backed models (Kimi K2.6, Qwen3.6 Plus, GLM 5.1) via the project-level `opencode.json`.
+- **GitHub Copilot** (preserved artefacts): agents in `.github/agents-copilot/` invoked via the `@agent-name` syntax in VS Code Chat. Uses native Copilot model selection.
+
+**Dual-run policy:** Any change to an agent's behaviour must be applied to both runtimes during the transition. The canonical source will be designated in a future decision. See [Opencode Runtime Configuration](docs/features/opencode-runtime.md) for the full dual-run policy and the agent migration mapping table.
+
 ### Skills
 
 Story generation skills are defined in `prompts/skills/`. The `story-pipeline` skill provides the pipeline reference (phases, quality gates, savepoints, config settings).

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ The active runtime is intentionally small and Python-native:
 - **Interactive Textual TUI**: `src/presentation/tui/app.py` adds `StoryWriterApp`, a three-panel terminal UI with live token streaming, wiki context, and approval gates launched through `story-writer tui`
 - **Repository cleanup**: the temporary `legacy/` archive, duplicate root helper scripts, and obsolete root markdown summaries were removed after migration cleanup, so current documentation should point only to active files under `docs/`, `prompts/`, `src/`, and `tests/`
 
-The repository also carries a project-level Opencode configuration for migration work. That agent runtime now has a full 24-agent migrated inventory in `.opencode/agents/`, uses OpenRouter model IDs in `opencode.json`, and keeps developer-specific OpenRouter credentials plus Tavily and Context7 MCP entries in user-level Opencode config. See [Opencode Runtime Configuration](./features/opencode-runtime.md).
+The repository also carries a project-level Opencode configuration for migration work. That agent runtime now has a full 24-agent migrated inventory in `.opencode/agents/`, uses OpenRouter model IDs in `opencode.json`, and keeps developer-specific OpenRouter credentials plus Tavily and Context7 MCP entries in user-level Opencode config. The original Copilot agent definitions are preserved in `.github/agents-copilot/` and the intermediate OpenRouter migration set in `.github/agents-openrouter/`; neither directory was deleted. See [Opencode Runtime Configuration](./features/opencode-runtime.md).
 
 See [Legacy Dependency Cleanup](./features/legacy-dependency-cleanup.md) for the full before/after summary and maintenance guidance.
 

--- a/docs/features/opencode-runtime.md
+++ b/docs/features/opencode-runtime.md
@@ -48,6 +48,59 @@ The checked-in `opencode.json` contents in full:
 
 This file does not contain Tavily or Context7 entries. Those MCP servers remain developer-local by design.
 
+## Installation
+
+Install Opencode globally before using the migrated agent runtime:
+
+```bash
+npm install -g opencode-ai
+```
+
+Then confirm the CLI is available:
+
+```bash
+opencode --version
+```
+
+If your environment uses a different Node.js package manager policy, install the same `opencode-ai` package through that tool and keep the `opencode` CLI on your `PATH`.
+
+## Directory Layout
+
+The repository keeps Opencode runtime files under `.opencode/`:
+
+```text
+.opencode/
+├── agents/                # Active Opencode agent runtime definitions
+│   ├── orchestrator-v3.md
+│   ├── browser.md
+│   ├── coder.md
+│   ├── documenter.md
+│   ├── reflection.md
+│   ├── test-writer.md
+│   ├── reviewer-kimi.md
+│   ├── reviewer-qwen.md
+│   ├── reviewer-glm.md
+│   ├── synthesizing-reviewer.md
+│   ├── pr-reviewer.md
+│   ├── researcher.md
+│   ├── researcher-kimi.md
+│   ├── researcher-qwen.md
+│   ├── researcher-glm.md
+│   ├── synthesizing-researcher.md
+│   ├── auditor.md
+│   ├── auditor-kimi.md
+│   ├── auditor-qwen.md
+│   ├── auditor-glm.md
+│   ├── synthesizing-auditor.md
+│   ├── planner.md
+│   ├── contemplator.md
+│   └── sprint-runner.md
+└── rules/                 # Plugin-loaded scoped instruction files
+    └── chromadb.md
+```
+
+`agents/` contains the active Opencode runtime agent definitions. `rules/` contains plugin-loaded scoped instruction files applied by `opencode-rules`.
+
 ## OpenRouter Authentication
 
 Authenticate Opencode against OpenRouter in one of these supported ways:
@@ -69,6 +122,12 @@ Task 2 confirmed these OpenRouter model slugs and Opencode model identifiers:
 
 The canonical mapping note lives in [../../.github/notes/opencode-provider-mapping.md](../../.github/notes/opencode-provider-mapping.md).
 
+## opencode-rules Plugin
+
+The project-level `opencode.json` includes `opencode-rules@latest` in its `plugin` array. That plugin reads Markdown files from `.opencode/rules/` and applies them as scoped instructions during Opencode runs.
+
+This repository currently ships one scoped rule file: `.opencode/rules/chromadb.md`. Its frontmatter declares `globs: ["src/**/*.py"]`, which reproduces the `applyTo` scoping previously carried by `.github/instructions/chromadb.instructions.md`. The rule file also includes an inline comment that it must stay in sync with the shared instructions source.
+
 ## Migrated Agent Inventory
 
 The Opencode runtime migration is now complete. `.opencode/agents/` contains exactly 24 Markdown agent files: the full migrated inventory from `.github/agents-openrouter/`, excluding that directory's README.
@@ -85,6 +144,57 @@ The Opencode runtime migration is now complete. `.opencode/agents/` contains exa
 Task 7 migrated the researcher family. Task 8 finished the remaining eight files: the auditor family plus `planner.md`, `contemplator.md`, and `sprint-runner.md`. With those files landed, the Opencode runtime now has full parity with the migrated OpenRouter agent set tracked in the Copilot-to-Opencode migration plan.
 
 The researcher family still has the only developer-local MCP dependency in the agent inventory. `researcher.md`, `researcher-kimi.md`, `researcher-qwen.md`, `researcher-glm.md`, and `synthesizing-researcher.md` rely on Tavily and Context7 being present in `~/.config/opencode/opencode.json`; the repository root `opencode.json` still carries only the project-level Chroma configuration.
+
+## Runtime Directories and Preserved Artefacts
+
+The repository keeps three runtime-era agent directories during the migration transition period:
+
+- `.opencode/agents/` is the active Opencode runtime. It contains 24 agent Markdown files with plain `.md` names and no `.agent.md` suffix.
+- `.github/agents-copilot/` is preserved as the frozen Copilot artefact set. It also contains 24 agent files, but uses the `.agent.md` extension required by the Copilot surface.
+- `.github/agents-openrouter/` is the intermediate OpenRouter migration set preserved from the migration path into Opencode.
+- `.github/agents/` now contains only `_shared/` helpers for the Copilot surface rather than a full runtime inventory.
+
+During the dual-run period, all three agent sets remain in the repository. None of these preserved directories were deleted.
+
+## Dual-Run Policy
+
+Both agent runtimes stay active during the migration transition period:
+
+- GitHub Copilot agents run from `.github/agents-copilot/` through VS Code Chat `@agent-name` invocation.
+- Opencode agents run from `.opencode/agents/` through `opencode run @agent-name`.
+
+Any change to agent behaviour or instructions must be applied to both runtimes during this period. The project has not yet designated the long-term canonical source; that decision will happen separately. Until then, duplicated updates prevent Copilot and Opencode agents from drifting apart while migration work continues.
+
+## Agent Migration Quick Reference
+
+This table gives the per-file mapping between preserved Copilot agent definitions and their active Opencode counterparts.
+
+| Agent Role | Copilot File (`.github/agents-copilot/`) | Opencode File (`.opencode/agents/`) |
+|---|---|---|
+| Orchestrator V3 | `orchestrator-v3.agent.md` | `orchestrator-v3.md` |
+| Browser | `browser.agent.md` | `browser.md` |
+| Coder | `coder.agent.md` | `coder.md` |
+| Documenter | `documenter.agent.md` | `documenter.md` |
+| Reflection | `reflection.agent.md` | `reflection.md` |
+| Test Writer | `test-writer.agent.md` | `test-writer.md` |
+| Reviewer (Claude → Kimi) | `reviewer-claude.agent.md` | `reviewer-kimi.md` |
+| Reviewer (Gemini → Qwen) | `reviewer-gemini.agent.md` | `reviewer-qwen.md` |
+| Reviewer (GPT → GLM) | `reviewer-gpt.agent.md` | `reviewer-glm.md` |
+| Synthesizing Reviewer | `synthesizing-reviewer.agent.md` | `synthesizing-reviewer.md` |
+| PR Reviewer | `pr-reviewer.agent.md` | `pr-reviewer.md` |
+| Researcher | `researcher.agent.md` | `researcher.md` |
+| Researcher (Claude → Kimi) | `researcher-claude.agent.md` | `researcher-kimi.md` |
+| Researcher (Gemini → Qwen) | `researcher-gemini.agent.md` | `researcher-qwen.md` |
+| Researcher (GPT → GLM) | `researcher-gpt.agent.md` | `researcher-glm.md` |
+| Synthesizing Researcher | `synthesizing-researcher.agent.md` | `synthesizing-researcher.md` |
+| Auditor | `auditor.agent.md` | `auditor.md` |
+| Auditor (Claude → Kimi) | `auditor-claude.agent.md` | `auditor-kimi.md` |
+| Auditor (Gemini → Qwen) | `auditor-gemini.agent.md` | `auditor-qwen.md` |
+| Auditor (GPT → GLM) | `auditor-gpt.agent.md` | `auditor-glm.md` |
+| Synthesizing Auditor | `synthesizing-auditor.agent.md` | `synthesizing-auditor.md` |
+| Planner | `planner.agent.md` | `planner.md` |
+| Contemplator | `contemplator.agent.md` | `contemplator.md` |
+| Sprint Runner | `sprint-runner.agent.md` | `sprint-runner.md` |
 
 ## User-Level MCP Servers
 


### PR DESCRIPTION
## Summary

Documents the Opencode runtime, dual-run policy, and the complete 24-agent Copilot-to-Opencode migration mapping.

## Closes
Closes #234

## Changes
- [x] `docs/features/opencode-runtime.md` — added Installation, Directory Layout, opencode-rules Plugin, Runtime Directories and Preserved Artefacts, Dual-Run Policy, and Agent Migration Quick Reference (24-row mapping table) sections
- [x] `docs/README.md` — added note that `.github/agents-copilot/` and `.github/agents-openrouter/` are preserved and were not deleted
- [x] `AGENTS.md` — added `### Runtimes` subsection with dual-run policy and link to the full runtime doc
- [x] All linting clean

## Plan

**Summary:** Documentation-only issue. `docs/features/opencode-runtime.md` existed but was missing six required sections. Two other files needed minor additions.

**Affected areas:** Documentation only. No code changes. ChromaDB schema change: no.

**Task checklist:**
- [x] `docs/features/opencode-runtime.md`: Installation, Directory Layout, opencode-rules Plugin, Runtime Directories, Dual-Run Policy, 24-agent mapping table
- [x] `docs/README.md`: preservation note in Runtime Stack paragraph
- [x] `AGENTS.md`: `### Runtimes` subsection