### PR TITLE
feat(opencode): add Researcher to permission.task.allow in orchestrator-v3

### DIFF
--- a/.github/agents-copilot/orchestrator-v3.agent.md
+++ b/.github/agents-copilot/orchestrator-v3.agent.md
@@ -5,6 +5,7 @@ model: Claude Sonnet 4.6 (copilot)
 agents:
   - Test Writer
   - Coder
+    - Researcher
   - Reviewer (Claude)
   - Reviewer (GPT)
   - Reviewer (Gemini)

--- a/.github/agents-openrouter/orchestrator-v3.agent.md
+++ b/.github/agents-openrouter/orchestrator-v3.agent.md
@@ -5,6 +5,7 @@ model: MoonshotAI: Kimi K2.6 (openrouter)
 agents:
   - Test Writer
   - Coder
+    - Researcher
   - Reviewer (Qwen)
   - Reviewer (Kimi)
   - Reviewer (GLM)

--- a/.github/notes/reviews/2026-04-29-pr247-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr247-claude-raw.md
@@ -1,0 +1,81 @@
+# Code Review Report — PR #247 (Claude)
+
+**Branch:** `feat/issue-238-researcher-permission-allow`
+**Commit:** `bd46398 feat(opencode): add Researcher to permission.task.allow in orchestrator-v3 (#238)`
+**Reviewed by:** Claude Sonnet 4.6
+**Date:** 2026-04-29
+
+---
+
+## Review Summary
+
+This PR makes a single-line change to the YAML frontmatter of `orchestrator-v3.md`, adding `"Researcher"` to the `permission.task.allow` list. The change is correct and targeted: the orchestrator body text has long instructed the agent to delegate codebase research to the Researcher subagent (Step 3b), but the permission block excluded Researcher, which would prevent dispatch at runtime. This PR resolves that gap. No critical issues or warnings were found. One minor pre-existing documentation inconsistency in `researcher.md` is flagged as a suggestion.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 0 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Critical Findings
+
+_None._
+
+### Warning Findings
+
+_None._
+
+### Suggestions
+
+```
+[S-01] researcher.md frontmatter description omits Orchestrator V3 as a caller
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/researcher.md
+Lines: 2
+Description: The YAML frontmatter description field reads "dispatched by the Planner
+  and Contemplator agents", but the body text at line 31 already correctly includes
+  Orchestrator: "dispatched by the Planner, Contemplator, or Orchestrator when they
+  need external information." The description field is therefore stale and inconsistent
+  with the body. Agents and humans scanning only the frontmatter get an incomplete
+  picture of who dispatches Researcher.
+  Note: This is a pre-existing defect not introduced by this PR. Out of scope for
+  this change — record for a follow-up.
+Suggestion: Update the description: field in researcher.md to match the body text:
+  "... or dispatched by the Planner, Contemplator, or Orchestrator when external
+  information is needed."
+```
+
+---
+
+## Phase Checklist Summary
+
+| Phase | Result | Notes |
+|-------|--------|-------|
+| 1 — Structural | ✅ Pass | Commit follows `feat(scope): description (#N)` convention. Branch follows `feat/issue-N-...` convention. 1-line change in 1 file. No unrelated changes. No numbered step gaps, no file relocations, no model-variant sync required (orchestrator has no model-specific siblings). |
+| 2 — Code | ✅ Pass | YAML array entry is correctly formatted. Insertion position (after Coder, before Reviewer variants) is consistent with the logical grouping: worker agents first, then reviewers, then other specialists. Allow-list entry `"Researcher"` matches the agent filename `researcher.md` converted to display-name form. Agent file confirmed present on disk at `.opencode/agents/researcher.md`. |
+| 3 — Frontend | N/A | No frontend changes. |
+| 4 — Security | ✅ Pass | Permission expansion is appropriate and intentional: the orchestrator body already instructed dispatch to Researcher; the missing permission was a runtime blocker, not a deliberate restriction. The Researcher agent itself has appropriate scoped permissions (MCP tools for web search/content extraction; no write access to code). |
+| 5 — Testing | ✅ Pass | No testable code changes. Agent permission configuration is not subject to unit testing. |
+| 6 — Performance | N/A | No performance implications. |
+| 7 — Documentation | ✅ Pass (with S-01 noted) | No documentation files were changed. Pre-existing stale description in `researcher.md` recorded as S-01 for follow-up. |
+
+---
+
+## Correctness Verification
+
+The following was verified through targeted reads:
+
+- `researcher.md` exists at `.opencode/agents/researcher.md` ✅
+- Researcher body text (line 31) already lists Orchestrator as a valid caller ✅
+- Orchestrator body text references Researcher dispatch at lines 69 and 247–255 ✅
+- Allow-list entry `"Researcher"` matches the derived display name for `researcher.md` ✅
+- `opencode.json` has no agent registration block — agent discovery is file-based; no registration gap ✅
+- No model-specific orchestrator variants exist that would require the same change ✅
+
+---
+
+## Overall Assessment
+
+The change is correct, minimal, and safe to merge. It closes a gap between the orchestrator's stated delegation intent (body text) and its enforced runtime permissions (YAML frontmatter), which would have caused Researcher dispatch to fail silently or be blocked at runtime. No tests, documentation updates, or companion file changes are required for this one-line permission fix. The single suggestion (S-01) is a pre-existing stale description in `researcher.md` that is out of scope for this PR and should be addressed in a follow-up.

--- a/.github/notes/reviews/2026-04-29-pr247-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr247-gemini-raw.md
@@ -1,0 +1,41 @@
+# Code Review Report
+
+### Review Summary
+
+The PR correctly adds the `Researcher` agent to the `task.allow` list in the Opencode orchestrator to enable research delegation. However, it completely misses the required parallel update for the GitHub Copilot runtime, violating the repository's dual-run policy.
+
+**Files Reviewed:** 1
+**Findings:** 1 Critical, 0 Warning, 0 Suggestion
+
+### Findings
+
+#### Critical Findings
+
+[C-01] Missing Dual-Run Update for Copilot Orchestrator
+Category: Correctness
+Severity: Critical
+File: .github/agents-copilot/orchestrator-v3.agent.md
+Lines: general (YAML frontmatter)
+Description: The PR updates the Opencode orchestrator (`.opencode/agents/orchestrator-v3.md`) to permit execution of the `Researcher` task, but fails to apply the mirrored change to the Copilot orchestrator (`.github/agents-copilot/orchestrator-v3.agent.md`). The project's dual-run policy requires that any changes to agent logic or permissions be applied to both runtimes simultaneously. This omission leaves the Copilot orchestrator unable to dispatch the Researcher subagent.
+Suggestion: Add `- Researcher` to the `agents:` array in `.github/agents-copilot/orchestrator-v3.agent.md`:
+```yaml
+agents:
+  - Test Writer
+  - Coder
+  - Researcher
+  - Reviewer (Claude)
+  - Reviewer (GPT)
+# ...
+```
+
+#### Warning Findings
+
+*(No warnings found)*
+
+#### Suggestions
+
+*(No suggestions found)*
+
+### Overall Assessment
+
+The branch is not ready for merge. While the single change made to the Opencode file is correct in isolation, the PR breaks the documented dual-run policy by omitting the identical configuration update to the Copilot orchestrator. The Copilot orchestrator file must be updated before merging.

--- a/.github/notes/reviews/2026-04-29-pr247-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr247-gpt-raw.md
@@ -1,0 +1,34 @@
+# Code Review Report
+
+## Review Summary
+
+This PR makes a narrowly scoped permissions change in [.opencode/agents/orchestrator-v3.md](/home/shaun/Code/llm-story-writer/.opencode/agents/orchestrator-v3.md), adding `Researcher` to the OpenCode orchestrator's task allow-list. The change fixes a real mismatch between the orchestrator body and its runtime permissions, but it is incomplete under the repository's dual-run policy because the companion GitHub/Copilot orchestrator definitions were not updated in the same PR.
+
+Files Reviewed: 1
+Findings: 0 Critical, 1 Warning, 1 Suggestion
+
+## Findings
+
+### Warning Findings
+
+[W-01] Researcher dispatch was enabled in only one runtime
+Category: Correctness
+Severity: Warning
+File: .opencode/agents/orchestrator-v3.md
+Lines: 38-41
+Description: This change adds `Researcher` to the OpenCode orchestrator's `permission.task.allow` list, which brings that file into line with its existing Step 3 instructions to delegate codebase research. However, the repository is still in dual-run mode, and the companion orchestrator definitions in `.github/agents-openrouter/orchestrator-v3.agent.md` and `.github/agents-copilot/orchestrator-v3.agent.md` still omit `Researcher` from their dispatchable agent lists while their body text also says Step 3 must delegate to `Researcher`. That leaves runtime-dependent behaviour: OpenCode can now perform the documented delegation path, while the GitHub/Copilot variants still cannot.
+Suggestion: Update the companion orchestrator definitions in both runtimes to include `Researcher` in their agent registries in the same PR, or explicitly document why the behaviour is intended to diverge during the migration window.
+
+### Suggestions
+
+[S-01] Frontmatter description still contradicts the live delegation model
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/orchestrator-v3.md
+Lines: 2
+Description: The description string still says the orchestrator "Performs planning, research, testing, and GitHub operations directly" and "Delegates only coding, documentation, database changes, and browser automation." The body of the file already says the opposite for research, and this PR now makes the `Researcher` delegation path executable. Leaving the description unchanged keeps the top-level contract misleading for humans and any tooling that surfaces frontmatter descriptions.
+Suggestion: Update the description text to match the actual workflow, for example by stating that the orchestrator performs planning, verification, and GitHub operations directly, while delegating research, implementation, tests, reviews, documentation, and browser automation.
+
+## Overall Assessment
+
+The OpenCode-side permission fix is directionally correct, but I would not merge it as-is because it introduces cross-runtime divergence in a workflow that the repository explicitly treats as dual-run during migration. After the companion orchestrator files are brought into sync, the remaining risk is low and limited to keeping the top-level description accurate.

--- a/.github/notes/reviews/2026-04-29-pr247-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr247-synthesis.md
@@ -1,0 +1,185 @@
+# Synthesized Code Review — PR #247
+
+**Branch:** `feat/issue-238-researcher-permission-allow`
+**Commit:** `bd46398 feat(opencode): add Researcher to permission.task.allow in orchestrator-v3 (#238)`
+**Review Type:** Multi-model synthesis (Claude Sonnet 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Synthesized by:** Claude Sonnet 4.6 (Synthesizing Reviewer)
+**Date:** 2026-04-29
+
+---
+
+## Synthesis Overview
+
+This PR makes a single-line change to `.opencode/agents/orchestrator-v3.md`, adding `"Researcher"` to the `permission.task.allow` list to close a gap between the orchestrator's documented delegation intent and its enforced runtime permissions. The three models reached substantially different conclusions: Claude found the PR clean and merge-ready, while GPT and Gemini both identified a genuine dual-run policy violation because the companion orchestrator definitions in `.github/agents-copilot/` and `.github/agents-openrouter/` were not updated in the same PR. This divergence was verified against the actual files — both companion `agents:` lists indeed omit `Researcher` despite their body text referencing Researcher delegation at Step 3. The highest-confidence finding is the dual-run violation (two of three models, independently verified); the remaining two findings are documentation suggestions from individual models that are valid but pre-existing.
+
+**Model Agreement Score:** 4/10 — The models agreed on the correctness of the single change made, but diverged significantly on whether the PR is complete: Claude declared it merge-ready, while GPT and Gemini both found blocking gaps in companion files.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- |
+| Claude | Clean — safe to merge | Verified opencode-side change thoroughly; checked researcher.md body text vs frontmatter | 0 | 0 |
+| GPT    | Not merge-ready — dual-run gap in both companion files | Dual-run policy compliance; description field contradiction in orchestrator-v3.md | 0 | 1 |
+| Gemini | Not merge-ready — Copilot companion missing | Dual-run policy compliance; focused specifically on Copilot runtime | 1 | 0 |
+
+**Claude** produced the most thorough correctness verification of the change itself — confirming the agent file's existence, the allow-list name format, the orchestrator body references, and the absence of model-specific variants — but did not check the companion runtime files against the dual-run policy. Its S-01 (stale researcher.md frontmatter) is a genuine pre-existing defect independently confirmed against the file.
+
+**GPT** correctly identified the dual-run gap and named both companion files. It also raised a standalone suggestion about the orchestrator-v3.md description field, which is a valid pre-existing inconsistency.
+
+**Gemini** identified the same dual-run violation but focused only on the Copilot companion file, classifying the finding as Critical. The openrouter companion was not mentioned. The severity assignment (Critical) is higher than GPT's (Warning); the synthesis resolves this to Warning — see D-01.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+_None._
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-W-01] Dual-run companion orchestrators not updated
+Severity: Warning
+Category: Correctness / Policy Compliance
+Files:
+  - .github/agents-copilot/orchestrator-v3.agent.md (agents: list, frontmatter)
+  - .github/agents-openrouter/orchestrator-v3.agent.md (agents: list, frontmatter)
+Detail: This PR adds `Researcher` to the `permission.task.allow` list in the OpenCode
+  orchestrator, correctly enabling the Researcher delegation path documented in the
+  orchestrator body text. However, the repository is in dual-run mode per AGENTS.md,
+  which requires any change to agent behaviour to be applied to both runtimes
+  simultaneously.
+
+  Both companion files reference Researcher delegation in their body text
+  ("Codebase research (Step 3) → Researcher (subagent)") but neither includes
+  `Researcher` in the YAML `agents:` list — meaning neither companion runtime can
+  actually dispatch Researcher at Step 3. The PR leaves this gap unresolved.
+
+  Verified against actual files on disk:
+  - .github/agents-copilot/orchestrator-v3.agent.md: agents list has no Researcher ✓
+  - .github/agents-openrouter/orchestrator-v3.agent.md: agents list has no Researcher ✓
+
+Models: Claude ✗ GPT ✓ Gemini ✓
+Dissenting view: Claude did not check the companion runtime files at all. Its review
+  scope was limited to the single changed file and its direct references. Claude's
+  silence is an omission, not a contradictory assertion — it does not undermine the
+  finding's validity.
+Suggestion: Add `- Researcher` to the `agents:` list in both companion files before
+  merging. Example for .github/agents-copilot/orchestrator-v3.agent.md:
+    agents:
+      - Test Writer
+      - Coder
+      - Researcher          ← add here
+      - Reviewer (Claude)
+      - ...
+  Apply the equivalent change to the openrouter variant.
+```
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] researcher.md frontmatter description omits Orchestrator V3 as a caller
+Severity: Suggestion
+Category: Documentation
+File: .opencode/agents/researcher.md
+Lines: 2
+Detail: The frontmatter description reads "dispatched by the Planner and Contemplator
+  agents", but the body text (line 31) already correctly states "dispatched by the
+  Planner, Contemplator, or Orchestrator when they need external information."
+  The description field is stale and gives an incomplete picture to anything that
+  surfaces only frontmatter. This is a pre-existing defect not introduced by this PR.
+Model: Claude
+Assessment: Genuine — verified against the actual file. The body text and frontmatter
+  are demonstrably inconsistent. Pre-existing and out of scope for this PR; valid
+  follow-up issue.
+```
+
+```
+[S-I-02] orchestrator-v3.md description field contradicts live delegation model
+Severity: Suggestion
+Category: Documentation
+File: .opencode/agents/orchestrator-v3.md (and both companion files, which have the
+  same description string)
+Lines: 2
+Detail: The YAML frontmatter description still reads "Performs planning, research,
+  testing, and GitHub operations directly. Delegates only coding, documentation,
+  database changes, and browser automation." This PR makes research a delegated
+  concern (via Researcher), but the description continues to claim the orchestrator
+  handles research directly. The same stale description appears in both companion
+  files. Pre-existing; this PR makes it more inaccurate but does not introduce it.
+Model: GPT
+Assessment: Genuine — verified against the actual opencode and both companion files.
+  The description is factually wrong after this PR. Pre-existing defect amplified
+  by this change. Valid follow-up; does not block merge.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Severity of dual-run policy violation
+Claude says: (silent — did not raise the finding)
+GPT says:    Warning — the gap is real but the body text already documents the
+             delegation intent; runtime-dependent behaviour during migration window.
+Gemini says: Critical — the Copilot orchestrator cannot dispatch Researcher; policy
+             violation must block merge.
+Assessment:  GPT's Warning severity is more appropriate. The companion files already
+             contain the Researcher delegation intent in their body text — the gap is
+             specifically in the `agents:` allow list. This is not a security defect
+             or correctness failure in the changed code itself; it is an incomplete
+             policy compliance change. The PR should not merge with the gap, but
+             Warning is the correct severity: the issue is bounded, the fix is clear,
+             and no existing functionality is broken.
+Resolution:  Treat as Warning (★★☆ M-W-01). Merge should be blocked until companion
+             files are updated, but the finding does not require architectural review
+             — only the two one-line `agents:` additions.
+```
+
+```
+[D-02] Scope of documentation inconsistency findings
+Claude says: researcher.md description field is stale (omits Orchestrator as caller).
+GPT says:    orchestrator-v3.md description field is stale (claims research is direct,
+             not delegated).
+Gemini says: (no documentation suggestions raised).
+Assessment:  Both findings are genuine and independently verified. They are not
+             contradictory — they concern different files. Claude caught the stale
+             caller list in researcher.md; GPT caught the stale capability claim in
+             the orchestrator's own description. Both are pre-existing. Neither blocks
+             merge. Gemini's silence on both is an omission; it does not undermine
+             the findings.
+Resolution:  Both retained as singular suggestions (S-I-01, S-I-02) for follow-up
+             issues. Neither elevates to majority or unanimous.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [M-W-01] ★★☆ Fix before merge: Add `Researcher` to `agents:` list in
+   .github/agents-copilot/orchestrator-v3.agent.md and
+   .github/agents-openrouter/orchestrator-v3.agent.md
+   (Warning — 2/3 models agree; independently verified)
+
+2. [S-I-01] ★☆☆ Follow-up issue: Update researcher.md frontmatter description
+   to include Orchestrator as a valid caller
+   (Suggestion — Claude only; pre-existing; out of scope for this PR)
+
+3. [S-I-02] ★☆☆ Follow-up issue: Update orchestrator-v3.md (and companion files)
+   description field to reflect that research is now delegated
+   (Suggestion — GPT only; pre-existing; out of scope for this PR)
+```
+
+---
+
+## Overall Assessment
+
+The PR is **not ready to merge as-is**. The OpenCode-side change is correct and needed. The blocking issue is a dual-run policy violation: both companion orchestrator files reference Researcher in their body text but still lack the `agents:` list entry that enables dispatch. Adding `- Researcher` to each companion's `agents:` list is a trivial two-line fix that completes the policy requirement. The two documentation suggestions are genuine pre-existing defects that should be tracked as follow-up issues rather than addressed in this PR.

--- a/.opencode/agents/orchestrator-v3.md
+++ b/.opencode/agents/orchestrator-v3.md
@@ -38,6 +38,7 @@ permission:
     allow:
       - "Test Writer"
       - "Coder"
+      - "Researcher"
       - "Reviewer Qwen"
       - "Reviewer Kimi"
       - "Reviewer Glm"


### PR DESCRIPTION
## Summary

Adds `"Researcher"` to `permission.task.allow` in the Orchestrator V3 agent YAML frontmatter, so Step 3b can dispatch the Researcher subagent without triggering a permission prompt.

## Closes

Closes #238

## Changes

- [x] `.opencode/agents/orchestrator-v3.md` — added `"Researcher"` to `permission.task.allow`
- [x] All tests passing (no behavioral code changed)
- [x] Linting clean

## Plan

**Summary:** The `researcher.md` agent already existed but was absent from `orchestrator-v3.md`'s `permission.task.allow` list. Added a single YAML list entry to enable the dispatch.

**Affected Areas:** OpenCode agent configuration only. No Python code, ChromaDB schema changes, or test changes required.

**Task Checklist:**
- [x] Add `"Researcher"` to `permission.task.allow` in `.opencode/agents/orchestrator-v3.md`

**Risks:** None — additive config change only.