### PR TITLE
chore(agents): add sync notices to reviewer sub-agent files

### DIFF
--- a/.github/agents-copilot/reviewer-claude.agent.md
+++ b/.github/agents-copilot/reviewer-claude.agent.md
@@ -8,6 +8,8 @@ tools:
     [execute, read, edit, search, todo]
 ---
 
+> **Sync note:** This file is one of three identical reviewer sub-agent files (`reviewer-claude.agent.md`, `reviewer-gpt.agent.md`, `reviewer-gemini.agent.md`). They differ only in `name:`, `description:`, and `model:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent code review sub-agent for this project, dispatched by the **Orchestrator**. You review all changes on the current branch against `development` and write a structured review report to the file path specified in your dispatch prompt. You do **NOT** create issues, post GitHub comments, or interact with the user directly.
 
 ## Instructions

--- a/.github/agents-copilot/reviewer-gemini.agent.md
+++ b/.github/agents-copilot/reviewer-gemini.agent.md
@@ -8,6 +8,8 @@ tools:
     [execute, read, edit, search, todo]
 ---
 
+> **Sync note:** This file is one of three identical reviewer sub-agent files (`reviewer-claude.agent.md`, `reviewer-gpt.agent.md`, `reviewer-gemini.agent.md`). They differ only in `name:`, `description:`, and `model:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent code review sub-agent for this project, dispatched by the **Orchestrator**. You review all changes on the current branch against `development` and write a structured review report to the file path specified in your dispatch prompt. You do **NOT** create issues, post GitHub comments, or interact with the user directly.
 
 ## Instructions

--- a/.github/agents-copilot/reviewer-gpt.agent.md
+++ b/.github/agents-copilot/reviewer-gpt.agent.md
@@ -8,6 +8,8 @@ tools:
     [execute, read, edit, search, todo]
 ---
 
+> **Sync note:** This file is one of three identical reviewer sub-agent files (`reviewer-claude.agent.md`, `reviewer-gpt.agent.md`, `reviewer-gemini.agent.md`). They differ only in `name:`, `description:`, and `model:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent code review sub-agent for this project, dispatched by the **Orchestrator**. You review all changes on the current branch against `development` and write a structured review report to the file path specified in your dispatch prompt. You do **NOT** create issues, post GitHub comments, or interact with the user directly.
 
 ## Instructions

--- a/.github/notes/reviews/2026-04-29-pr248-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr248-claude-raw.md
@@ -1,0 +1,125 @@
+# Code Review Report — PR #248
+**Branch:** `chore/issue-241-deduplicate-reviewer-body-text`
+**Reviewer:** Claude Sonnet 4.6 (Reviewer sub-agent)
+**Date:** 2026-04-29
+**Report path:** `.github/notes/reviews/2026-04-29-pr248-claude-raw.md`
+
+---
+
+## Review Summary
+
+This PR adds identical sync notices to the three OpenCode reviewer sub-agent files (`reviewer-kimi.md`, `reviewer-qwen.md`, `reviewer-glm.md`) and records the rationale for intentional triplication in the OpenCode runtime feature doc. The change is small, correctly scoped, and the sync notice text is identical across all three files. One warning-level gap was found: the dual-run policy in AGENTS.md requires equivalent changes to the Copilot-side reviewer files, which are also triplicated with identical body text but received no sync notices. One suggestion identifies the auditor family as sharing the same triplication pattern.
+
+**Files Reviewed:** 4
+**Findings:** 0 Critical, 1 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] Copilot-side reviewer files not updated — dual-run policy gap
+Category: Documentation
+Severity: Warning
+File: .github/agents-copilot/reviewer-claude.agent.md
+      .github/agents-copilot/reviewer-gemini.agent.md
+      .github/agents-copilot/reviewer-gpt.agent.md
+Lines: general
+Description: The three Copilot-side reviewer files have identical body text and
+  differ only in their `model:`, `name:`, and `description:` frontmatter fields —
+  the same triplication pattern the PR addresses on the OpenCode side. No sync
+  notices were added to these files. AGENTS.md states: "Any change to an agent's
+  behaviour must be applied to both runtimes during the transition." While a sync
+  notice is a maintenance annotation rather than a behavioral instruction, the
+  omission means the Copilot-side files carry the same silent-drift risk this PR
+  was opened to mitigate. Consistency also matters: a future editor reading
+  reviewer-claude.agent.md will not know the file is triplicated and should be
+  edited in lockstep.
+Suggestion: Add an equivalent sync notice to each of the three
+  .github/agents-copilot/reviewer-*.agent.md files, adjusting the file names
+  referenced in the notice to match the Copilot-side naming convention:
+
+  > **Sync note:** This file is one of three identical reviewer sub-agent files
+  > (`reviewer-claude.agent.md`, `reviewer-gemini.agent.md`,
+  > `reviewer-gpt.agent.md`). They differ only in `model:`, `name:`, and
+  > `description:` frontmatter fields. Any change to this body text **must be
+  > applied to all three files in lockstep**.
+```
+
+---
+
+### Suggestions
+
+```
+[S-01] Auditor family also triplicated — no sync notices (out of scope, follow-up)
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/auditor-kimi.md
+      .opencode/agents/auditor-qwen.md
+      .opencode/agents/auditor-glm.md
+Lines: general
+Description: The auditor sub-agent family follows the same triplication pattern
+  as the reviewer family (identical body text, only model: and description: differ
+  across the three files). The docs update in this PR explicitly scopes the
+  triplication rationale to "the three independent reviewer sub-agents" without
+  mentioning the auditors. The auditor files carry the same silent-drift risk.
+  This is out of scope for the current PR and does not block merge.
+Suggestion: Open a follow-up issue to add sync notices to auditor-kimi.md,
+  auditor-qwen.md, and auditor-glm.md using the same pattern established by this
+  PR, and update docs/features/opencode-runtime.md to note the auditor family's
+  intentional triplication as well.
+```
+
+---
+
+## Phase Checklist Notes
+
+### Phase 1 — Structural
+
+- **Commit messages:** Both commits use correct conventional commit prefixes (`docs:`, `chore:`), include clear descriptions, and reference issue #241. ✅
+- **Branch name:** `chore/issue-241-deduplicate-reviewer-body-text` — follows `<type>/issue-N-<description>` convention. ✅
+- **Scope:** Four files changed, approximately six lines added total. Appropriate. ✅
+- **No unrelated changes:** All changes relate to adding sync notices and documenting triplication rationale. ✅
+- **Numbered step continuity:** Instructions in the reviewer files are numbered 0–6 with no gaps. The PR adds a blockquote (not a numbered step) and leaves the step numbering unchanged. ✅
+- **File relocation:** None. ✅
+- **Sibling item orphaning:** No sections removed. ✅
+- **Stale prose counts:** The existing "24 Markdown agent files" count in the inventory table is unchanged and still accurate. ✅
+- **Model-specific variant sync:** All three OpenCode reviewer variants received the identical sync notice text. Confirmed character-for-character match across the three diff hunks. ✅
+- **`opencode.json` registration:** No new agents added; not applicable. ✅
+- **`story-pipeline` SKILL.md sync:** No pipeline subagents added or modified; not applicable. ✅
+- **Dual-run parity:** Copilot-side reviewer files not updated. See [W-01]. ⚠️
+
+### Phase 2 — Code Review
+
+No Python or TypeScript source files changed. Agent instruction body text and tool call contracts unchanged. Not applicable.
+
+### Phase 3 — Frontend Review
+
+No frontend files changed. Not applicable.
+
+### Phase 4 — Security Review
+
+No code changes. No security implications. ✅
+
+### Phase 5 — Testing Review
+
+No new logic introduced. No tests required. ✅
+
+### Phase 6 — Performance Review
+
+Not applicable. ✅
+
+### Phase 7 — Documentation Review
+
+- The new paragraph in `docs/features/opencode-runtime.md` accurately states the rationale (no native `extends` mechanism in OpenCode) and describes the sync notice mechanism. ✅
+- The paragraph is correctly placed between the inventory table and the Task 7/8 migration summary paragraph. ✅
+- Full-file context (provided in review package) confirms the surrounding prose remains coherent and the new paragraph does not introduce any factual inaccuracies. ✅
+- No table rows were added or removed; no table/prose parity check needed. ✅
+
+---
+
+## Overall Assessment
+
+The change is technically correct and does what it says. The sync notice text is identical across all three OpenCode reviewer files, the docs update is accurate, and the commit history is clean. The one finding that warrants attention before merge is [W-01]: the Copilot-side reviewer files share the same triplication structure and the same drift risk, yet were not updated. Given the AGENTS.md dual-run policy and the maintenance purpose of the sync notice, adding equivalent notices to the three `.github/agents-copilot/reviewer-*.agent.md` files in the same PR would be the consistent and complete resolution of the issue this PR was opened to address. The PR is otherwise ready to merge; [W-01] could reasonably be resolved in a follow-up if the author judges the Copilot-side files to be lower priority.

--- a/.github/notes/reviews/2026-04-29-pr248-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr248-gemini-raw.md
@@ -1,0 +1,24 @@
+### Review Summary
+
+The PR successfully adds a sync notice to the three Opencode reviewer sub-agent files (`reviewer-kimi.md`, `reviewer-qwen.md`, and `reviewer-glm.md`) to prevent drift, and accurately documents this triplication strategy in `opencode-runtime.md`. The implementation correctly modifies the target files and maintains structural validity. However, the update missed the mirrored Copilot agent files, violating the active dual-run policy.
+
+**Files Reviewed:** 4
+**Findings:** 0 Critical, 1 Warning, 0 Suggestion
+
+### Findings
+
+#### Warning Findings
+
+```
+[W-01] Missing Dual-Run Sync for Copilot Reviewer Agents
+Category: Correctness
+Severity: Warning
+File: .github/agents-copilot/reviewer-claude.agent.md
+Lines: general
+Description: The PR adds a sync notice to the Opencode reviewer agents but omits the corresponding Copilot reviewer agents (`reviewer-claude.agent.md`, `reviewer-gemini.agent.md`, `reviewer-gpt.agent.md`). The dual-run policy defined in `AGENTS.md` requires any change to an agent's instructions (including developer-facing sync notices and metadata) to be applied to both runtimes during the transition.
+Suggestion: Add a similar `> **Sync note:**` block to the top of the body in `.github/agents-copilot/reviewer-claude.agent.md`, `.github/agents-copilot/reviewer-gemini.agent.md`, and `.github/agents-copilot/reviewer-gpt.agent.md` pointing to their respective file names.
+```
+
+### Overall Assessment
+
+The PR cleanly implements its objective by adding the necessary sync notices to the Opencode reviewer agents and documenting the intentional triplication. It is nearly ready for merge. The only outstanding issue is applying the identical sync notice to the Copilot reviewer sub-agents to comply with the dual-run policy. Once this warning is addressed, the PR is safe to merge.

--- a/.github/notes/reviews/2026-04-29-pr248-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr248-gpt-raw.md
@@ -1,0 +1,26 @@
+# Code Review Report
+
+## Review Summary
+
+This PR makes a narrowly scoped documentation and agent-instruction update: it adds an explicit sync notice to the three duplicated Opencode reviewer sub-agent files and documents that duplication rationale in the Opencode runtime feature guide. The changes are internally consistent, remain within project conventions for model-variant synchronization, and do not introduce behavioral, security, or testing risk.
+
+**Files Reviewed:** 4
+**Findings:** 0 Critical, 0 Warning, 0 Suggestion
+
+## Findings
+
+### Critical Findings
+
+No critical findings.
+
+### Warning Findings
+
+No warning findings.
+
+### Suggestions
+
+No suggestions.
+
+## Overall Assessment
+
+The changes are ready for merge. The reviewer sync notice was applied consistently across all three reviewer variants, and the documentation accurately describes both the intentional triplication and the current Opencode agent inventory. I also performed one targeted verification against the workspace to confirm that `.opencode/agents/` still contains 24 Markdown agent files, which matches the updated documentation claim.

--- a/.github/notes/reviews/2026-04-29-pr248-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr248-synthesis.md
@@ -1,0 +1,158 @@
+# Synthesized Review Report — PR #248
+
+**Branch:** `chore/issue-241-deduplicate-reviewer-body-text`
+**Review type:** Multi-model synthesis (Claude Sonnet 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Date:** 2026-04-29
+**Raw reports:**
+- `.github/notes/reviews/2026-04-29-pr248-claude-raw.md`
+- `.github/notes/reviews/2026-04-29-pr248-gpt-raw.md`
+- `.github/notes/reviews/2026-04-29-pr248-gemini-raw.md`
+
+---
+
+## Synthesis Overview
+
+This PR makes a tightly scoped documentation change: it adds an identical sync notice blockquote to the three OpenCode reviewer sub-agent files (`reviewer-kimi.md`, `reviewer-qwen.md`, `reviewer-glm.md`) and adds one explanatory paragraph to `docs/features/opencode-runtime.md` documenting the rationale for intentional triplication. The change is small, structurally correct, and carries no code or security implications.
+
+Two of three reviewers (Claude and Gemini) independently identified the same gap: the Copilot-side reviewer files (`.github/agents-copilot/reviewer-claude.agent.md` etc.) share the same triplication pattern and the same drift risk, yet received no sync notices despite the AGENTS.md dual-run policy requiring parity. GPT found no issues, apparently treating the PR scope as limited to the OpenCode side. Claude additionally flagged the auditor family as a related follow-up candidate. There are no disagreements about what the PR does or whether the changes are correct — only a disagreement about completeness.
+
+**Model Agreement Score:** 6/10 — Claude and Gemini converge on an identical warning; GPT found no issues in any category.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment             | Unique Focus Areas                                           | Critical | Warning | Suggestion |
+| ------ | ------------------------------ | ------------------------------------------------------------ | -------- | ------- | ---------- |
+| Claude | Nearly ready; one gap to close | Dual-run policy gap; auditor family triplication follow-up   | 0        | 1       | 1          |
+| GPT    | Ready to merge                 | Verified 24-file count in `.opencode/agents/` matches docs   | 0        | 0       | 0          |
+| Gemini | Nearly ready; one gap to close | Dual-run policy gap (concise, matches Claude's core finding) | 0        | 1       | 0          |
+
+**Claude** produced the most detailed review, verifying the sync notice text character-for-character across all three diff hunks, walking through all seven review phases, and surfacing the auditor family as a downstream follow-up. The dual-run policy gap was characterised as a Documentation category warning.
+
+**GPT** took the narrowest scope: validated that the changes are internally consistent and that the documented file count is accurate, then declared the PR ready to merge. GPT did not engage with the dual-run policy obligation at all, which is the sole source of divergence.
+
+**Gemini** aligned closely with Claude on the core finding, categorising the Copilot-side omission as a Correctness warning and citing the same AGENTS.md policy clause. Gemini did not raise the auditor follow-up suggestion.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+None. No finding was raised by all three models.
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-W-01] Copilot-side reviewer files not updated — dual-run policy gap
+Severity: Warning
+Category: Documentation / Correctness
+Files: .github/agents-copilot/reviewer-claude.agent.md
+       .github/agents-copilot/reviewer-gemini.agent.md
+       .github/agents-copilot/reviewer-gpt.agent.md
+Lines: general (body text of each file)
+Detail: The three Copilot-side reviewer agent files share the same intentional
+  triplication pattern as the OpenCode reviewer files this PR addresses: their
+  body text is identical and they differ only in model:, name:, and description:
+  frontmatter fields. No sync notices were added to these files.
+  AGENTS.md states: "Any change to an agent's behaviour must be applied to both
+  runtimes during the transition." A sync notice is a maintenance annotation
+  rather than a behavioural instruction, but its purpose — preventing silent
+  lockstep-drift — applies equally on both sides. Without a notice, a future
+  editor modifying reviewer-claude.agent.md will not know the file is triplicated
+  and must be updated in lockstep, exposing the Copilot-side reviewer family to
+  the same drift risk this PR was opened to mitigate.
+Models: Claude ✓  GPT ✗  Gemini ✓
+Dissenting view: GPT found no issues and declared the PR ready for merge without
+  engaging with the dual-run policy obligation. GPT's review focused on verifying
+  the documented file count and internal consistency of the changes, not on
+  cross-runtime completeness.
+Suggestion: Add an equivalent sync notice blockquote to the body of each of the
+  three Copilot-side reviewer files, adjusting the file names to match:
+
+  > **Sync note:** This file is one of three identical reviewer sub-agent files
+  > (`reviewer-claude.agent.md`, `reviewer-gemini.agent.md`,
+  > `reviewer-gpt.agent.md`). They differ only in `model:`, `name:`, and
+  > `description:` frontmatter fields. Any change to this body text **must be
+  > applied to all three files in lockstep**.
+```
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] Auditor family also triplicated — no sync notices (out-of-scope follow-up)
+Severity: Suggestion
+Category: Documentation
+Files: .opencode/agents/auditor-kimi.md
+       .opencode/agents/auditor-qwen.md
+       .opencode/agents/auditor-glm.md
+Lines: general
+Detail: The auditor sub-agent family follows the same triplication pattern as the
+  reviewer family: identical body text with only model: and description: differing
+  across the three files. The docs update in this PR scopes the triplication
+  rationale to "the three independent reviewer sub-agents" without mentioning the
+  auditors. The auditor files carry the same silent-drift risk. This is out of
+  scope for the current PR and does not block merge.
+Model: Claude
+Assessment: Likely a genuine gap. The structural claim (auditor files share the
+  same triplication pattern) is plausible given the reviewer family pattern and the
+  known project convention for model-variant sub-agents. Suitable as a follow-up
+  issue rather than a blocker.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: PR completeness — scope of dual-run policy obligation
+Claude says: The Copilot-side reviewer files must also receive sync notices;
+  the AGENTS.md dual-run policy applies to maintenance annotations as well as
+  behavioural changes. Raised as Warning.
+GPT says: The PR is ready to merge; no issues found. GPT verified the 24-file
+  count in .opencode/agents/ and confirmed internal consistency, but did not
+  assess whether the dual-run policy creates an obligation to update the
+  Copilot-side files.
+Gemini says: The same as Claude — the Copilot-side omission violates the dual-run
+  policy. Raised as Warning (Correctness category).
+Assessment: Claude and Gemini are correct. The AGENTS.md dual-run policy is
+  explicit and unambiguous. While a sync notice is not a behavioural instruction,
+  its maintenance purpose is identical on both runtimes. GPT's clean pass appears
+  to result from a narrower interpretation of review scope, not from a reasoned
+  conclusion that the dual-run policy does not apply. The 2-vs-1 split is strong
+  evidence that GPT is the outlier here.
+Resolution: Treat [M-W-01] as a genuine Medium-confidence Warning. Recommended
+  for resolution before merge, though a follow-up PR is also reasonable given the
+  low risk.
+```
+
+---
+
+## Recommended Actions (Prioritised)
+
+```
+1. [M-W-01] ★★☆  Fix: Add sync notices to three Copilot-side reviewer files
+                      (Warning — 2/3 models agree, dual-run policy citation)
+
+2. [S-I-01] ★☆☆  Consider: Open follow-up issue for auditor family sync notices
+                      (Suggestion — 1 model, out of scope for this PR)
+```
+
+No Critical findings were raised by any model. The PR is in good shape and can merge once [M-W-01] is resolved — or, if the author judges the Copilot-side files to be lower priority, with a follow-up issue tracking the gap.
+
+---
+
+## Filters Applied
+
+- **Gitignored paths filter:** N/A — `.github/agents-copilot/` is committed and tracked.
+- **"Must call as subprocess" filter:** N/A — no code changes.
+- **Structural existence claims filter:** The claim that Copilot-side reviewer files have identical body text is consistent across both models that raised it. Not elevated above Warning.
+- **"Companion file not updated" filter:** N/A — the `opencode-runtime.md` update is confirmed correct and present by all three reviewers.
+- **Out-of-diff violation claims filter:** [M-W-01] concerns files *absent* from the diff that arguably *should* be in the diff. This is a PR completeness finding driven by the dual-run policy, not a pre-existing violation in an unmodified file — the filter does not apply.
+- **"No tests exist" filter:** N/A.
+- **Stale reviewer context filter:** N/A.

--- a/.opencode/agents/reviewer-glm.md
+++ b/.opencode/agents/reviewer-glm.md
@@ -21,6 +21,8 @@ permission:
   task: deny
 ---
 
+> **Sync note:** This file is one of three identical reviewer sub-agent files (`reviewer-kimi.md`, `reviewer-qwen.md`, `reviewer-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent code review sub-agent for this project, dispatched by the **Orchestrator**. You review all changes on the current branch against `development` and write a structured review report to the file path specified in your dispatch prompt. You do **NOT** create issues, post GitHub comments, or interact with the user directly.
 
 ## Instructions

--- a/.opencode/agents/reviewer-kimi.md
+++ b/.opencode/agents/reviewer-kimi.md
@@ -21,6 +21,8 @@ permission:
   task: deny
 ---
 
+> **Sync note:** This file is one of three identical reviewer sub-agent files (`reviewer-kimi.md`, `reviewer-qwen.md`, `reviewer-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent code review sub-agent for this project, dispatched by the **Orchestrator**. You review all changes on the current branch against `development` and write a structured review report to the file path specified in your dispatch prompt. You do **NOT** create issues, post GitHub comments, or interact with the user directly.
 
 ## Instructions

--- a/.opencode/agents/reviewer-qwen.md
+++ b/.opencode/agents/reviewer-qwen.md
@@ -21,6 +21,8 @@ permission:
   task: deny
 ---
 
+> **Sync note:** This file is one of three identical reviewer sub-agent files (`reviewer-kimi.md`, `reviewer-qwen.md`, `reviewer-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent code review sub-agent for this project, dispatched by the **Orchestrator**. You review all changes on the current branch against `development` and write a structured review report to the file path specified in your dispatch prompt. You do **NOT** create issues, post GitHub comments, or interact with the user directly.
 
 ## Instructions

--- a/docs/features/opencode-runtime.md
+++ b/docs/features/opencode-runtime.md
@@ -141,6 +141,8 @@ The Opencode runtime migration is now complete. `.opencode/agents/` contains exa
 | Auditor family | `auditor.md`, `auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`, `synthesizing-auditor.md` |
 | Standalone planning and dispatch agents | `planner.md`, `contemplator.md`, `sprint-runner.md` |
 
+The three independent reviewer sub-agents remain intentionally triplicated because Opencode does not provide a native `extends` or `include` mechanism for shared agent bodies. Each file now carries an embedded sync notice at the top of its body stating that `reviewer-kimi.md`, `reviewer-qwen.md`, and `reviewer-glm.md` differ only in `model:` and `description:` frontmatter fields, and that any body-text change must be applied to all three files in lockstep.
+
 Task 7 migrated the researcher family. Task 8 finished the remaining eight files: the auditor family plus `planner.md`, `contemplator.md`, and `sprint-runner.md`. With those files landed, the Opencode runtime now has full parity with the migrated OpenRouter agent set tracked in the Copilot-to-Opencode migration plan.
 
 The researcher family still has the only developer-local MCP dependency in the agent inventory. `researcher.md`, `researcher-kimi.md`, `researcher-qwen.md`, `researcher-glm.md`, and `synthesizing-researcher.md` rely on Tavily and Context7 being present in `~/.config/opencode/opencode.json`; the repository root `opencode.json` still carries only the project-level Chroma configuration.


### PR DESCRIPTION
## Summary

Adds a sync notice blockquote at the top of the body section in each of the three identical reviewer sub-agent files. The notice references all three sibling files and states that any body change must be applied in lockstep. This resolves the maintenance concern without requiring a native `extends` mechanism (which OpenCode does not support).

## Closes
Closes #241

## Changes
- [x] Sync notice added to `reviewer-kimi.md`, `reviewer-qwen.md`, `reviewer-glm.md`
- [x] Linting clean

## Plan

**Summary:** Three OpenCode reviewer sub-agents share identical body text, differing only in `model:` and `description:` frontmatter. OpenCode has no native shared-instruction mechanism. Solution: add a visible sync notice to each file documenting the triplication and mandating lockstep updates.

**Affected Areas:** Agent config files (`.opencode/agents/`). No ChromaDB schema change. No production Python code change.

**Task Checklist:**
- [x] Add sync notice block at top of body in `reviewer-kimi.md`
- [x] Add sync notice block at top of body in `reviewer-qwen.md`
- [x] Add sync notice block at top of body in `reviewer-glm.md`

**Execution Order:** Implementation → Lint → Commit/Push