### PR TITLE
sprint-runner: update body to use gh CLI instead of github/* MCP tools

### DIFF
--- a/.github/notes/reviews/2026-04-29-pr250-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr250-claude-raw.md
@@ -1,0 +1,150 @@
+# Code Review Report — PR #250 (Claude)
+
+**Branch:** `feat/issue-245-sprint-runner-gh-cli`
+**Reviewer:** Claude (Reviewer sub-agent)
+**Date:** 2026-04-29
+**Commit:** `9f873cd feat(sprint-runner): replace github/* MCP calls with gh CLI (#245)`
+
+---
+
+## Review Summary
+
+This PR replaces three broken `github/*` MCP tool calls in `.opencode/agents/sprint-runner.md` with equivalent `gh` CLI commands, and adds `"gh*"` to the bash allow-list in the YAML frontmatter. The change addresses a real problem: the Opencode sprint-runner had no `github/*` entry in its `tools:` block, making the old MCP calls non-functional. The migration approach is correct in principle. However, the `--json` field list in Phase 2 Step 1 includes `pull_request`, which is not a valid field for `gh issue list` — this will cause the command to fail at runtime. Additionally, the dual-run counterpart file in `.github/agents-copilot/` was not assessed for a complementary update, and one stale prose note survives from the REST API era.
+
+**Files Reviewed:** 1
+**Findings:** 1 Critical, 1 Warning, 2 Suggestion
+
+---
+
+## Findings
+
+### Critical Findings
+
+```
+[C-01] `pull_request` is not a valid JSON field for `gh issue list`
+Category: Correctness
+Severity: Critical
+File: .opencode/agents/sprint-runner.md
+Lines: 63
+Description: Phase 2 Step 1 requests `--json number,title,labels,assignees,createdAt,pull_request`.
+The `pull_request` field is not part of `gh issue list`'s supported JSON field set. The command
+will fail at runtime with: `X Unknown field: "pull_request"`. The field exists in the GitHub
+REST API response for `/repos/{owner}/{repo}/issues` (which the old MCP call used and which does
+return PRs alongside issues), but `gh issue list` only returns issues and does not expose that
+field. As a consequence Step 4's dependent filtering note ("filter by checking for the absence
+of a `pull_request` key") also becomes unreachable dead logic.
+Suggestion: Remove `pull_request` from the --json field list. Update Step 4's parenthetical
+to reflect that `gh issue list` returns only issues (not PRs) by design, making explicit PR
+filtering unnecessary:
+
+  gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt
+
+Step 4 parenthetical should become:
+  (Note: `gh issue list` returns only issues — PR filtering is not required.)
+```
+
+---
+
+### Warning Findings
+
+```
+[W-01] Dual-run counterpart `.github/agents-copilot/sprint-runner.agent.md` not assessed
+Category: Correctness
+Severity: Warning
+File: .github/agents-copilot/sprint-runner.agent.md
+Lines: general
+Description: AGENTS.md dual-run policy states: "Any change to an agent's behaviour must be
+applied to both runtimes during the transition." The Copilot runtime counterpart
+(`.github/agents-copilot/sprint-runner.agent.md`) was not updated and still contains the old
+`github/list_issues`, `github/list_pull_requests`, and `github/issue_read` MCP calls.
+
+The Copilot runtime has `github/*` in its `tools:` frontmatter and those MCP calls work there —
+so a straight copy of the gh CLI commands is NOT appropriate for that file. However, the PR
+has no comment acknowledging this intentional divergence. The dual-run policy requires that
+behavioural changes are either mirrored or explicitly noted as a deliberate runtime-specific
+divergence.
+
+Suggestion: Add a note to the PR description or a comment in the agent file header explaining
+that the Copilot runtime intentionally retains `github/*` MCP calls because `github/*` tools
+are available in that runtime. Alternatively, if the Copilot runtime is considered legacy-only
+and the file is "frozen", record that decision in the PR description so reviewers and future
+maintainers understand the asymmetry.
+```
+
+---
+
+### Suggestion Findings
+
+```
+[S-01] Stale parenthetical in Phase 2 Step 4
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/sprint-runner.md
+Lines: 73-74
+Description: Step 4 still reads: "Exclude pull requests (the `list_issues` endpoint may include
+PRs — filter by checking for the absence of a `pull_request` key)." This parenthetical was
+accurate for the old GitHub REST API endpoint, which returns both issues and PRs in a combined
+response. The `gh issue list` command does not return PRs at all. The parenthetical is stale
+and may confuse an LLM agent reading the instructions: it will look for a `pull_request` key
+that never appears and may incorrectly conclude all items are issues regardless.
+Suggestion: Replace with a note that reflects the current tool's behaviour, e.g.:
+  "Note: `gh issue list` returns only issues by design; no pull request filtering is required."
+(This finding is superseded by C-01 if the `pull_request` field is removed — both can be
+addressed together.)
+```
+
+```
+[S-02] N+1 issue body fetches in Phase 3 Step 3
+Category: Performance
+Severity: Suggestion
+File: .opencode/agents/sprint-runner.md
+Lines: 93-94
+Description: Phase 3 Step 3 fetches the body of each candidate issue individually via
+`gh issue view N --repo OWNER/REPO --json number,title,body`. For a sprint with N candidate
+issues, this produces N separate API calls after the initial list. If `body` were included
+in the Phase 2 Step 1 fetch (`--json number,title,labels,assignees,createdAt,body`), the
+body data would already be available for all issues and no per-issue API calls would be needed
+during dependency detection. The current approach is not wrong (only filtered candidates are
+queried), but a single fetch in Step 1 is simpler and reduces round-trips.
+Suggestion: Add `body` to the --json field list in Phase 2 Step 1. Update Phase 3 Step 3 to
+read the body from the already-fetched issue data rather than issuing a separate `gh issue view`
+call. This is out-of-scope for this PR if the change was intentional.
+```
+
+---
+
+## Phase Checklist Notes
+
+### Phase 1 — Structural
+
+- Commit message: `feat(sprint-runner): replace github/* MCP calls with gh CLI (#245)` — follows convention, references issue. ✅
+- Branch name: `feat/issue-245-sprint-runner-gh-cli` — follows convention. ✅
+- Scope: 1 file changed, ~10 lines. Appropriate size. ✅
+- No unrelated changes detected. ✅
+- Numbered step continuity: All phases (1–5) have contiguous integer steps. No gaps. ✅
+- File relocation: None. ✅
+- `tools:` array coupling: `"gh*"` bash allow added to match new CLI usage in body text. ✅
+- Section heading drift: No headings changed. ✅
+- Model-specific variant sync: Not applicable (sprint-runner has no model-specific variants). ✅
+- `opencode.json` registration: Not applicable (modifying existing agent, not adding new one). ✅
+
+### Phase 2 — Code / Agent Instructions
+
+- Tool call contracts: `gh issue list`, `gh pr list`, `gh issue view` commands are valid CLI invocations. The `--json` field sets are correct EXCEPT for `pull_request` (see C-01). ✅ (with C-01 caveat)
+- Numbered step continuity: Verified above. ✅
+- Intra-step variable cross-reference: No stored variables introduced. ✅
+
+### Phase 4 — Security
+
+- No credentials or sensitive data introduced. ✅
+- `"gh*"` bash permission is broad but intentional — grants all `gh` subcommands. Acceptable given the agent's dispatch role.
+- No path traversal surface (no file path construction). ✅
+
+### Phase 5 — Testing
+
+- Agent instruction files have no associated tests — standard for this codebase. Not a finding.
+
+### Phase 7 — Documentation
+
+- Dual-run divergence undocumented (see W-01). ⚠️
+- Stale Step 4 parenthetical (see S-01). ⚠️

--- a/.github/notes/reviews/2026-04-29-pr250-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr250-gemini-raw.md
@@ -1,0 +1,48 @@
+### Review Summary
+
+This PR replaces the `github/*` MCP tool endpoints with native `gh` CLI commands in the Sprint Runner agent's issue tracking and dispatch phases. While the CLI mappings effectively cover the required workflows, a critical correctness issue was introduced: the script passes a JSON field argument that the CLI does not recognize, which will cause the agent run to fail.
+
+**Files Reviewed:** 1
+**Findings:** 1 Critical, 1 Warning, 1 Suggestion
+
+### Findings
+
+#### Critical Findings
+
+```
+[C-01] Invalid `gh issue list` JSON field causes execution failure
+Category: Correctness
+Severity: Critical
+File: .opencode/agents/sprint-runner.md
+Lines: 61-63
+Description: In Phase 2 Step 1, the `gh issue list` command passes the `--json` flag with the field `pull_request` (`...createdAt,pull_request`). The `pull_request` field does not exist for the `gh issue list` API. Executing this exact command causes the CLI to crash with an `Unknown JSON field: "pull_request"` error and a non-zero exit code. This breaks the agent's workflow immediately.
+Suggestion: Remove `,pull_request` from the `--json` argument string.
+```
+
+#### Warning Findings
+
+```
+[W-01] Stale PR filter instructions and broken step continuity
+Category: Correctness
+Severity: Warning
+File: .opencode/agents/sprint-runner.md
+Lines: 74-75
+Description: Phrase 2 Step 4 instructs the agent to manually exclude PRs by checking the data, stating "the `list_issues` endpoint may include PRs". This references the replaced MCP endpoint behavior; natively, the `gh issue list` CLI specifically returns only issues, completely excluding PRs. Keeping this step misleads the agent since the `pull_request` field no longer exists. If deleted completely, removing this step without renumbering causes a step discontinuity (`1., 2., 3., 5.`) which violates the structural numbered step continuity rule.
+Suggestion: Delete Step 4 entirely, and renumber the current Step 5 to Step 4 to maintain contiguous integer numbering.
+```
+
+#### Suggestions
+
+```
+[S-01] Add error guards to git branch commands
+Category: Correctness
+Severity: Suggestion
+File: .opencode/agents/sprint-runner.md
+Lines: general (Phase 4 Steps 3 and 6)
+Description: The `git checkout development && git pull origin development` command strings do not include an explicit error guard. Per the shared shell snippet safety instructions, commands whose output is used in subsequent steps should have a failure guard. Adding `|| exit 1` ensures that if git fails (e.g. from network or unresolved stash issues), the agent forcibly halts instead of silently attempting to dispatch on the wrong branch head.
+Suggestion: Update both instances to: `git checkout development && git pull origin development || exit 1`
+```
+
+### Overall Assessment
+
+The PR cleanly handles the migration from MCP tools to locally available `gh` CLI commands but requires immediate correction on the parameter passing layer to make the agent functional. The code is not ready for merge until the `pull_request` JSON field and its stale corresponding reasoning step are pruned. Once fixed, this provides a better zero-dependency path for the runner.

--- a/.github/notes/reviews/2026-04-29-pr250-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr250-gpt-raw.md
@@ -1,0 +1,24 @@
+# Code Review Report
+
+## Review Summary
+
+This PR changes a single agent instruction file to replace GitHub MCP calls with `gh` CLI commands. The scope is small and on-target, but the new Phase 2 issue-list command is not valid for `gh`, so the sprint runner cannot complete its first collection step as written.
+
+**Files Reviewed:** 1  
+**Findings:** 1 Critical, 0 Warning, 0 Suggestion
+
+## Findings
+
+### Critical Findings
+
+[C-01] Invalid `gh issue list` JSON field breaks Sprint Runner issue collation
+Category: Correctness
+Severity: Critical
+File: .opencode/agents/sprint-runner.md
+Lines: 64-76
+Description: The new instruction uses `gh issue list --json number,title,labels,assignees,createdAt,pull_request`, but `gh issue list` does not support a `pull_request` JSON field. A targeted verification against `gh issue list --help` shows the supported fields include `assignees`, `createdAt`, `labels`, `number`, `title`, and others, but not `pull_request`. That means Phase 2 step 1 fails before any issues are collected. The follow-up instruction in step 4 to filter out pull requests by checking for the absence of a `pull_request` key is also stale under `gh issue list`, which already lists issues rather than mixed issue/PR results.
+Suggestion: Replace the command with a valid field list, for example `gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt`, and remove or rewrite the PR-filtering step to match actual `gh` behavior.
+
+## Overall Assessment
+
+Not ready for merge. The intended migration is straightforward, but the primary runtime command in the updated workflow is invalid, so the agent would fail at the first operational step. No broader architectural concerns surfaced in this small diff.

--- a/.github/notes/reviews/2026-04-29-pr250-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr250-synthesis.md
@@ -1,0 +1,198 @@
+## Synthesized Code Review — 2026-04-29 (PR #250)
+
+**Review Type:** Multi-model synthesis (Claude Opus 4.6 + GPT 5.4 + Gemini 3.1 Pro)
+**Branch:** `feat/issue-245-sprint-runner-gh-cli`
+**PR:** #250 (Issue #245 — Replace github/* MCP calls with gh CLI in sprint-runner)
+**Model Agreement Score:** 8/10
+**Overall Assessment:** Not Ready — Fix Before Merge
+
+---
+
+## Synthesis Overview
+
+This PR migrates a single agent instruction file (`.opencode/agents/sprint-runner.md`) from broken `github/*` MCP tool calls to `gh` CLI equivalents, and adds `"gh*"` to the bash allow-list. All three reviewers converged immediately on the same critical defect: the `--json` field list in Phase 2 Step 1 includes `pull_request`, which is not a valid field for `gh issue list` and causes an immediate runtime crash. Two of the three reviewers additionally flagged the stale Phase 2 Step 4 prose as a follow-on correctness issue. The PR is not ready for merge in its current form. Fixing the one unanimous Critical finding (and the companion stale step) is all that is required; the change set is otherwise clean and the migration approach is sound.
+
+**Model Agreement Score:** 8/10 — Strong alignment on the critical defect and substantial agreement on the stale step; models diverged only on severity grading of the stale prose and on whether to surface additional out-of-scope observations.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment           | Unique Focus Areas                              | Critical Count | Warning Count |
+| ------ | ---------------------------- | ----------------------------------------------- | -------------- | ------------- |
+| Claude | Not ready — one blocker      | Dual-run policy gap; N+1 body fetches           | 1              | 1             |
+| GPT    | Not ready — one blocker      | Focused solely on the runtime-breaking field    | 1              | 0             |
+| Gemini | Not ready — one blocker      | Step numbering continuity; git error guards     | 1              | 1             |
+
+**Claude** provided the most comprehensive review, surfacing the dual-run counterpart policy obligation (verified: `.github/agents-copilot/sprint-runner.agent.md` still contains `github/list_issues`) and a performance observation about N+1 body fetches. **GPT** delivered the most concise report, confirming the critical field error with a clean overall assessment and no secondary findings — its C-01 description does acknowledge the stale Step 4 as a downstream consequence. **Gemini** matched Claude's finding count but focused on the structural consequence of the stale step (renumbering discontinuity if Step 4 is deleted) and added a shell safety suggestion about missing `|| exit 1` guards on `git checkout development && git pull` commands — both verified against the actual file.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+```
+[U-C-01] `pull_request` is not a valid JSON field for `gh issue list`
+Severity: Critical
+Category: Correctness
+File: .opencode/agents/sprint-runner.md
+Line: 63
+Detail: Phase 2 Step 1 invokes:
+  gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt,pull_request
+The `pull_request` field does not exist in `gh issue list`'s JSON field set. The gh CLI
+will respond with `X Unknown JSON field: "pull_request"` and a non-zero exit code,
+halting the agent before any issues are collected. This field originates from the old
+GitHub REST API `/repos/{owner}/{repo}/issues` response, which does mix issues and PRs
+and does return a `pull_request` key. The `gh issue list` command is issues-only by
+design and never returns that field.
+Models: Claude ✓  GPT ✓  Gemini ✓
+Suggestion: Remove `pull_request` from the --json field list:
+  gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt
+This should be addressed together with [M-W-01] below (the stale Step 4 that references
+the now-absent field).
+```
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-W-01] Stale Phase 2 Step 4 — PR filter references a field and endpoint that no longer exist
+Severity: Warning
+Category: Correctness
+File: .opencode/agents/sprint-runner.md
+Line: 75
+Detail: Step 4 reads:
+  "Exclude pull requests (the `list_issues` endpoint may include PRs — filter by
+  checking for the absence of a `pull_request` key)."
+Both the endpoint name (`list_issues`) and the field (`pull_request`) belong to the
+replaced MCP call, not to `gh issue list`. The `gh issue list` command is issues-only
+and never surfaces PRs, so the step's premise is false and the check is dead logic.
+Additionally — as Gemini correctly notes — if Step 4 is deleted without renumbering,
+Phase 2 steps become 1, 2, 3, 5, violating the structural numbered-step continuity rule.
+Models: Claude ✓ (S-01, Suggestion)  GPT ✓ (noted within C-01)  Gemini ✓ (W-01, Warning)
+Dissenting view: GPT subsumed this within its C-01 rather than raising it separately.
+Claude rated it Suggestion; Gemini rated it Warning. Given the step-numbering continuity
+consequence and the potential to confuse an LLM agent that will look for a key that never
+appears, the Warning classification is more appropriate.
+Suggestion: Delete Step 4 entirely and renumber the current Step 5 to Step 4. Replace
+with a brief note on the new Step 4 (was Step 5), or add a parenthetical to Step 1 e.g.:
+  (Note: `gh issue list` returns only issues — pull request filtering is not required.)
+```
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] Dual-run counterpart `.github/agents-copilot/sprint-runner.agent.md` not updated — divergence undocumented
+Severity: Warning
+Category: Correctness / Documentation
+File: .github/agents-copilot/sprint-runner.agent.md
+Lines: 42–44
+Detail: AGENTS.md dual-run policy requires that behavioural changes be applied to
+both runtimes or the divergence explicitly documented. The Copilot-runtime counterpart
+still contains `github/list_issues` MCP calls (verified: line 42, 44). However — as
+Claude correctly reasons — the Copilot runtime has `github/*` in its `tools:` frontmatter
+and those MCP calls are functional there, so a straight copy of the `gh` CLI commands
+would be incorrect. The gap is not the missing migration but the missing acknowledgement:
+the PR description contains no comment explaining the intentional asymmetry.
+Model: Claude (W-01)
+Assessment: Genuine finding. The dual-run policy is active per AGENTS.md and
+verified against the actual counterpart file. GPT and Gemini did not review the
+counterpart file. The risk is that a future maintainer treating the Copilot file as
+stale inadvertently removes the working MCP calls. Warrants a one-line explanatory
+comment in the agent file header or PR description rather than a code change.
+```
+
+```
+[S-I-02] N+1 `gh issue view` calls in Phase 3 Step 3 — body not fetched in bulk
+Severity: Suggestion
+Category: Performance
+File: .opencode/agents/sprint-runner.md
+Lines: 93–94
+Detail: Phase 3 Step 3 fetches each candidate issue's body individually via
+`gh issue view N --repo OWNER/REPO --json number,title,body`. If `body` were included
+in the Phase 2 Step 1 fetch, no per-issue API calls would be needed during dependency
+detection. The current approach is functionally correct; this is a round-trip optimisation.
+Model: Claude (S-02)
+Assessment: Valid performance observation, but out-of-scope for a PR whose stated
+purpose is replacing MCP calls with gh equivalents. Defer to a follow-up issue.
+```
+
+```
+[S-I-03] Missing `|| exit 1` guards on `git checkout development && git pull` commands
+Severity: Suggestion
+Category: Correctness
+File: .opencode/agents/sprint-runner.md
+Lines: 125, 147
+Detail: Phase 4 Steps 3 and 6 both run:
+  git checkout development && git pull origin development
+Neither invocation includes `|| exit 1`. If git fails (e.g., network error, unresolved
+merge conflict, detached HEAD), the `&&` chain stops but does not signal failure to
+the agent runtime. Adding `|| exit 1` ensures a hard stop rather than silent continuation
+on the wrong branch head. Both instances were verified in the actual file.
+Model: Gemini (S-01)
+Assessment: Genuine suggestion, consistent with the shell safety conventions used
+elsewhere in the codebase (e.g., Orchestrator V3). Claude did not raise this; GPT did not
+raise this. Applying it is simple and low-risk. Worth including in the corrective pass.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Severity of stale Step 4 prose
+Claude says: Suggestion — stale but non-blocking; superseded by C-01 fix.
+GPT says:    Not raised separately — noted as a downstream consequence of C-01.
+Gemini says: Warning — stale prose plus step-numbering discontinuity created by deletion.
+Assessment: Gemini is correct. The step-numbering consequence is real and independently
+violates a documented structural rule (numbered step continuity). Elevating to Warning
+is the right classification. The [M-W-01] finding reflects this.
+Resolution: Classified as ★★☆ Warning; both Claude's fix suggestion and Gemini's
+renumbering instruction are incorporated into [M-W-01].
+```
+
+```
+[D-02] Scope of review — GPT reported only 1 finding vs Claude (4) and Gemini (3)
+Claude says: Four findings including documentation, performance, and dual-run policy gaps.
+GPT says:    One finding (the critical blocker); everything else is acceptable.
+Gemini says: Three findings including structural and shell-safety concerns.
+Assessment: GPT's minimal-scope approach is not wrong — the critical finding is
+identified correctly, and the other findings are non-blocking. However, the stale Step 4
+note within GPT's C-01 description confirms GPT noticed that issue; it simply chose not
+to file it as a separate finding. No divergence in substance, only in report granularity.
+Resolution: No change to consensus findings. GPT's C-01 is treated as tacitly agreeing
+with the stale-step issue, which supports its classification as ★★☆ Majority.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [U-C-01] ★★★ Fix: Remove `pull_request` from gh issue list --json field list (Critical — all models agree)
+   File: .opencode/agents/sprint-runner.md, line 63
+
+2. [M-W-01] ★★☆ Fix: Delete stale Step 4, renumber Step 5 → 4, add brief note that gh issue list is issues-only (Warning — 2/3 models agree + GPT tacit)
+   File: .opencode/agents/sprint-runner.md, line 75
+
+3. [S-I-01] ★☆☆ Document: Add one-line comment in sprint-runner.agent.md header (or PR description) explaining the Copilot runtime retains github/* MCP calls intentionally (Warning — 1 model, verified)
+   File: .github/agents-copilot/sprint-runner.agent.md
+
+4. [S-I-03] ★☆☆ Consider: Add `|| exit 1` to both git checkout development && git pull instances in Phase 4 (Suggestion — 1 model, verified)
+   File: .opencode/agents/sprint-runner.md, lines 125, 147
+
+5. [S-I-02] ★☆☆ Defer: Include `body` in Phase 2 Step 1 --json fetch to eliminate N+1 gh issue view calls in Phase 3 (Suggestion — 1 model, out-of-scope for this PR)
+   File: .opencode/agents/sprint-runner.md, lines 93–94
+```
+
+---
+
+## Notes
+
+- Actions 1 and 2 are closely coupled and should be addressed in the same commit — removing `pull_request` from the field list and removing the stale Step 4 are two sides of the same correction.
+- Action 3 requires no code change; a one-line comment or PR description update is sufficient to satisfy the dual-run policy documentation requirement.
+- Action 5 is explicitly deferred and should not block this PR.

--- a/.opencode/agents/sprint-runner.md
+++ b/.opencode/agents/sprint-runner.md
@@ -60,8 +60,9 @@ Before starting, read and internalise these shared files:
 
 1. Fetch open issues using the `gh` CLI:
    ```bash
-   gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt,pull_request
+   gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt
    ```
+   > Note: `gh issue list` returns only issues — pull request filtering is not required.
 
 2. For each issue, extract: **number**, **title**, **labels**, **assignees**, and **created date**.
 
@@ -72,9 +73,7 @@ Before starting, read and internalise these shared files:
    - `duplicate`
    - `question`
 
-4. Exclude pull requests (the `list_issues` endpoint may include PRs — filter by checking for the absence of a `pull_request` key).
-
-5. Check for any issues already assigned to an open PR:
+4. Check for any issues already assigned to an open PR:
    - Run `gh pr list --repo OWNER/REPO --state open --base development --json number,body`.
    - Parse PR bodies for `Closes #N` / `Fixes #N` references.
    - Mark those issue numbers as **in-progress** and exclude them from the dispatch list.
@@ -122,7 +121,7 @@ For each approved issue, in order:
 
 3. **Ensure on `development` branch** — run:
    ```bash
-   git checkout development && git pull origin development
+   git checkout development && git pull origin development || exit 1
    ```
 
 4. **Dispatch Orchestrator V3** with a detailed prompt:
@@ -144,7 +143,7 @@ For each approved issue, in order:
 
 6. **Return to `development`** before dispatching the next issue:
    ```bash
-   git checkout development && git pull origin development
+   git checkout development && git pull origin development || exit 1
    ```
 
 7. Proceed to the next issue.

--- a/.opencode/agents/sprint-runner.md
+++ b/.opencode/agents/sprint-runner.md
@@ -18,6 +18,7 @@ permission:
          - "git branch*"
          - "cat*"
          - "echo*"
+         - "gh*"
       deny: []
    task:
       allow:
@@ -57,9 +58,9 @@ Before starting, read and internalise these shared files:
 
 ### Phase 2 — Collate Open Issues
 
-1. Fetch open issues using `github/list_issues`:
-   ```
-   github/list_issues  owner: OWNER, repo: REPO, state: "open"
+1. Fetch open issues using the `gh` CLI:
+   ```bash
+   gh issue list --repo OWNER/REPO --state open --json number,title,labels,assignees,createdAt,pull_request
    ```
 
 2. For each issue, extract: **number**, **title**, **labels**, **assignees**, and **created date**.
@@ -74,7 +75,7 @@ Before starting, read and internalise these shared files:
 4. Exclude pull requests (the `list_issues` endpoint may include PRs — filter by checking for the absence of a `pull_request` key).
 
 5. Check for any issues already assigned to an open PR:
-   - Run `github/list_pull_requests` with `state: "open"` and `base: "development"`.
+   - Run `gh pr list --repo OWNER/REPO --state open --base development --json number,body`.
    - Parse PR bodies for `Closes #N` / `Fixes #N` references.
    - Mark those issue numbers as **in-progress** and exclude them from the dispatch list.
 
@@ -92,7 +93,7 @@ Before starting, read and internalise these shared files:
 2. If any issues were excluded (blocked, in-progress), list them separately with reasons.
 
 3. **Detect potential dependencies** between the candidate issues:
-   - For each issue, read its body using `github/issue_read` (method: `"get"`).
+   - For each issue, read its body using `gh issue view N --repo OWNER/REPO --json number,title,body`.
    - Scan the title and body for references to other issue numbers (`#N`), phrases like "depends on", "requires", "blocked by", "after #N", or "builds on".
    - If issue A references issue B and both are in the candidate list, flag a **potential dependency**.
    - Present flagged pairs to the user with a warning:


### PR DESCRIPTION
## Summary

Replaces all `github/*` MCP tool references in the `.opencode/agents/sprint-runner.md` body with equivalent `gh` CLI commands, restoring Phase 2–3 runtime functionality.

## Closes
Closes #245

## Changes
- [x] Add `gh*` to `permission.bash.allow` in frontmatter
- [x] Phase 2 Step 1: `github/list_issues` → `gh issue list --repo OWNER/REPO --state open --json ...`
- [x] Phase 2 Step 5: `github/list_pull_requests` → `gh pr list --repo OWNER/REPO --state open --base development --json ...`
- [x] Phase 3 Step 3: `github/issue_read` → `gh issue view N --repo OWNER/REPO --json ...`
- [x] Linting clean

## Plan

**Summary:** Replace three `github/*` MCP tool references in `.opencode/agents/sprint-runner.md` with equivalent `gh` CLI commands, and add `gh*` to `permission.bash.allow`. This restores Phase 2–3 runtime functionality for the sprint-runner agent.

**Affected Areas:** Agent instruction file only (`.opencode/agents/sprint-runner.md`). No Python source, no tests, no ChromaDB schema change.

**Task Checklist:**
1. ✅ Add `gh*` to `permission.bash.allow` in frontmatter
2. ✅ Phase 2 Step 1: replace `github/list_issues` block
3. ✅ Phase 2 Step 5: replace `github/list_pull_requests` call
4. ✅ Phase 3 Step 3: replace `github/issue_read` call
