### PR TITLE
chore(agents): add sync notices to auditor sub-agent files

### DIFF
--- a/.github/agents-copilot/auditor-claude.agent.md
+++ b/.github/agents-copilot/auditor-claude.agent.md
@@ -8,6 +8,8 @@ tools:
     [execute, read, github/issue_read, github/list_issues, github/list_pull_requests, github/pull_request_read, github/search_issues, github/search_pull_requests, 'io.github.tavily-ai/tavily-mcp/*', search, web, 'io.github.upstash/context7/*', todo]
 ---
 
+> **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-claude.agent.md`, `auditor-gpt.agent.md`, `auditor-gemini.agent.md`). They differ only in `name:`, `description:`, and `model:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent audit sub-agent for this project, dispatched by the **Synthesizing Auditor**. You perform the full audit process and return a structured report. You do **NOT** write files, create issues, or interact with the user directly. Your sole output is a comprehensive audit report returned to the Synthesizing Auditor for cross-model synthesis.
 
 ## Instructions

--- a/.github/agents-copilot/auditor-gemini.agent.md
+++ b/.github/agents-copilot/auditor-gemini.agent.md
@@ -8,6 +8,8 @@ tools:
     [execute, read, github/issue_read, github/list_issues, github/list_pull_requests, github/pull_request_read, github/search_issues, github/search_pull_requests, 'io.github.tavily-ai/tavily-mcp/*', search, web, 'io.github.upstash/context7/*', todo]
 ---
 
+> **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-claude.agent.md`, `auditor-gpt.agent.md`, `auditor-gemini.agent.md`). They differ only in `name:`, `description:`, and `model:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent audit sub-agent for this project, dispatched by the **Synthesizing Auditor**. You perform the full audit process and return a structured report. You do **NOT** write files, create issues, or interact with the user directly. Your sole output is a comprehensive audit report returned to the Synthesizing Auditor for cross-model synthesis.
 
 ## Instructions

--- a/.github/agents-copilot/auditor-gpt.agent.md
+++ b/.github/agents-copilot/auditor-gpt.agent.md
@@ -8,6 +8,8 @@ tools:
     [execute, read, github/issue_read, github/list_issues, github/list_pull_requests, github/pull_request_read, github/search_issues, github/search_pull_requests, 'io.github.tavily-ai/tavily-mcp/*', search, web, 'io.github.upstash/context7/*', todo]
 ---
 
+> **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-claude.agent.md`, `auditor-gpt.agent.md`, `auditor-gemini.agent.md`). They differ only in `name:`, `description:`, and `model:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent audit sub-agent for this project, dispatched by the **Synthesizing Auditor**. You perform the full audit process and return a structured report. You do **NOT** write files, create issues, or interact with the user directly. Your sole output is a comprehensive audit report returned to the Synthesizing Auditor for cross-model synthesis.
 
 ## Instructions

--- a/.github/notes/reviews/2026-04-29-pr251-claude-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr251-claude-raw.md
@@ -1,0 +1,83 @@
+# Code Review Report — PR #251 (chore/issue-249-auditor-sync-notices)
+
+**Reviewer:** Claude (Reviewer sub-agent)
+**Date:** 2026-04-29
+**Branch:** `chore/issue-249-auditor-sync-notices`
+**Base:** `development`
+**Commit:** `67ab3fa`
+
+---
+
+## Review Summary
+
+This PR adds sync notice blockquotes to all six auditor sub-agent files across both active runtimes (GitHub Copilot and Opencode), mirroring the pattern already present in the reviewer sub-agent files. The change is purely documentary — no agent behaviour, tool contracts, or dispatch logic is modified. All six files receive the correct notice text, and the sibling file lists and "differ only in" field enumerations are accurate for each runtime group. One pre-existing description/model version mismatch in `auditor-claude.agent.md` is noted as a suggestion; it is not introduced by this PR.
+
+**Files Reviewed:** 6
+**Findings:** 0 Critical, 0 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Critical Findings
+
+None.
+
+### Warning Findings
+
+None.
+
+### Suggestions
+
+```
+[S-01] Pre-existing model version mismatch in auditor-claude description
+Category: Documentation
+Severity: Suggestion
+File: .github/agents-copilot/auditor-claude.agent.md
+Lines: 3
+Description: The `description` frontmatter field reads "running on Claude Opus 4.6" but
+the `model:` field specifies `Claude Sonnet 4.6 (copilot)`. These are distinct Claude
+variants; the description is misleading and will surface incorrect model information to
+any system that renders the description field. This defect predates this PR and was not
+introduced here.
+Suggestion: Update the description to read "running on Claude Sonnet 4.6" to match the
+model field, or align both fields to the intended model variant.
+```
+
+---
+
+## Phase Notes
+
+**Phase 1 — Structural:**
+- Commit message follows convention (`chore(scope): description (#issue)`). ✓
+- Branch name follows convention (`chore/issue-N-short-description`). ✓
+- Scope is minimal: 2 lines added per file × 6 files. ✓
+- All changes directly serve the stated purpose. ✓
+- Numbered step lists (0–4) in all six files are contiguous with no gaps. ✓
+- No files relocated; no stale path references to check. ✓
+- Copilot sync note lists all three correct file names (`auditor-claude.agent.md`, `auditor-gpt.agent.md`, `auditor-gemini.agent.md`) and correctly identifies `name:`, `description:`, and `model:` as the differing fields. ✓
+- Opencode sync note lists all three correct file names (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`) and correctly identifies `model:` and `description:` as the differing fields (Opencode frontmatter has no `name:` field; omission is correct). ✓
+- No `opencode.json` registration check required — no new agent files added. ✓
+- No `story-pipeline` SKILL.md sync required — auditor agents are not story pipeline subagents. ✓
+
+**Phase 2 — Code:** No Python or TypeScript source changes. N/A.
+
+**Phase 3 — Frontend:** No frontend changes. N/A.
+
+**Phase 4 — Security:** No code, credentials, or input-handling changes. N/A.
+
+**Phase 5 — Testing:** Documentation-only change; no executable logic introduced. No tests required.
+
+**Phase 6 — Performance:** N/A.
+
+**Phase 7 — Documentation:**
+- Sync notice wording is consistent within each runtime group. ✓
+- Sync notices accurately model the file relationship (identical body, differing frontmatter only). ✓
+- Pattern matches the established convention already present in reviewer sub-agent files. ✓
+- No companion reference tables or prose counts required updating. ✓
+
+---
+
+## Overall Assessment
+
+The PR is correct, complete, and ready to merge. The sync notices are accurately formed, consistently applied across both runtimes, and faithfully mirror the pattern used in the reviewer sub-agent files. There are no correctness defects, security concerns, or missing test coverage. The single suggestion (S-01) is a pre-existing description/model field inconsistency in `auditor-claude.agent.md` that was not introduced by this PR and does not block merge.

--- a/.github/notes/reviews/2026-04-29-pr251-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr251-gemini-raw.md
@@ -1,0 +1,33 @@
+# Code Review Report (Gemini)
+
+**Branch:** chore/issue-249-auditor-sync-notices
+**Commit:** 67ab3fa
+
+## Phase 1: Scope & Intent Check
+**Intent:** Add synchronization notices to the three Copilot auditor sub-agent files and the three Opencode auditor sub-agent files.
+**Assessment:** The diff perfectly matches the stated intent. Exactly six files were modified across the two runtime directories to include the appropriate sync notices.
+
+## Phase 2: Correctness & Logic
+**Assessment:** PASS
+- The sync notes correctly identify their respective triplet sibling files (`auditor-claude.agent.md`, `auditor-gpt.agent.md`, `auditor-gemini.agent.md` for Copilot, and `auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md` for Opencode).
+- The notes accurately describe the specific frontmatter fields that differ among the duplicated files in their respective runtime environments.
+
+## Phase 3: Security & Performance
+**Assessment:** PASS
+- No security or performance implications. These are Markdown instruction updates for agents.
+
+## Phase 4: Test Coverage
+**Assessment:** N/A
+- No tests apply to these prompt markdown additions.
+
+## Phase 5: Project Conventions
+**Assessment:** PASS
+- **Dual-run Policy Compliance:** The change properly applies to both Copilot and Opencode equivalents, strictly adhering to the mandated dual-run policy.
+- The use of the `> **Sync note:**` format conforms exactly to existing project norms for duplicated sub-agent components.
+
+## Phase 6: Out-of-Scope Opportunities / Suggestions
+- None.
+
+## Phase 7: Final Verdict
+**Result:** APPROVE
+**Summary:** Clean, accurate chore that improves maintainability of the identical sub-agent prompts. Ready to merge.

--- a/.github/notes/reviews/2026-04-29-pr251-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-29-pr251-gpt-raw.md
@@ -1,0 +1,32 @@
+# Code Review Report
+
+## Review Summary
+
+This PR adds a sync notice to the Copilot and Opencode auditor sub-agent variants so future body-text edits are applied in lockstep across each three-model family. The change is small and otherwise clean, but it leaves the parallel OpenRouter auditor variants unchanged even though repository documentation still treats `.github/agents-openrouter/` as a preserved dual-run source surface for the migrated Opencode agents.
+
+**Files Reviewed:** 11
+**Findings:** 0 Critical, 1 Warning, 0 Suggestion
+
+## Findings
+
+### Critical Findings
+
+None.
+
+### Warning Findings
+
+[W-01] Auditor sync notice added to only two of three maintained auditor variant families
+Category: Documentation
+Severity: Warning
+File: general
+Lines: general
+Description: The new sync notice was added to `.github/agents-copilot/auditor-{claude,gpt,gemini}.agent.md` and `.opencode/agents/auditor-{kimi,qwen,glm}.md`, but the companion OpenRouter auditor variants in `.github/agents-openrouter/auditor-{kimi,qwen,glm}.agent.md` still lack the same body-text warning. Repository docs still describe `.github/agents-openrouter/` as the preserved migration source and dual-run companion surface for `.opencode/agents/`. Leaving that family unchanged means the PR's new lockstep-maintenance rule is itself out of sync across maintained auditor prompt variants, which increases future prompt drift risk and conflicts with the documented dual-run policy.
+Suggestion: Add the same sync notice to `.github/agents-openrouter/auditor-kimi.agent.md`, `.github/agents-openrouter/auditor-qwen.agent.md`, and `.github/agents-openrouter/auditor-glm.agent.md`, or explicitly document why that family is excluded from the lockstep requirement.
+
+### Suggestions
+
+None.
+
+## Overall Assessment
+
+This branch is close, but not fully ready to merge under the repository's dual-run agent maintenance rules. The functional change is harmless, yet the PR stops one family short of the full companion-file update needed to make the new sync instruction authoritative everywhere the auditor variants are still preserved and referenced.

--- a/.github/notes/reviews/2026-04-29-pr251-synthesis.md
+++ b/.github/notes/reviews/2026-04-29-pr251-synthesis.md
@@ -1,0 +1,146 @@
+# Synthesized Code Review Report — PR #251
+
+**Branch:** `chore/issue-249-auditor-sync-notices`
+**Base:** `development`
+**Commit:** `67ab3fa`
+**Date:** 2026-04-29
+**Reviewers:** Claude (Reviewer sub-agent), GPT (Reviewer sub-agent), Gemini (Reviewer sub-agent)
+
+---
+
+## Synthesis Overview
+
+PR #251 adds sync notice blockquotes to all six auditor sub-agent files across both active runtimes (`.github/agents-copilot/` and `.opencode/agents/`), mirroring the existing pattern already present in the reviewer sub-agent files. Two of three reviewers found the PR clean and approved it without reservation; the third (GPT) raised a Warning asserting that the `.github/agents-openrouter/` auditor family also required the sync notice under the dual-run policy. Verification against the authoritative runtime documentation in `AGENTS.md` shows GPT's finding is a false positive — `.github/agents-openrouter/` is the preserved migration source artifact, not an active runtime, and the PR correctly covers both active runtimes. The only genuine finding is a pre-existing description/model version mismatch in `auditor-claude.agent.md`, surfaced by Claude as a Suggestion.
+
+**Model Agreement Score:** 7/10 — Claude and Gemini reached identical APPROVE verdicts; GPT's single dissenting Warning is resolved as a false positive after codebase verification.
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- |
+| Claude | APPROVE — ready to merge | Pre-existing description/model mismatch in `auditor-claude.agent.md`; detailed phase-by-phase structural verification | 0 | 0 |
+| GPT    | NOT READY — missing OpenRouter family sync notice | Reviewed 11 files (including `.github/agents-openrouter/` family); flagged absence of sync notice from that directory | 0 | 1 |
+| Gemini | APPROVE — clean chore | Confirmed dual-run policy compliance for both active runtimes; passed all phases | 0 | 0 |
+
+**Claude** performed the most thorough structural review, verifying file list accuracy, "differ only in" field enumerations, and phase-by-phase checklists for all six modified files. It uniquely noticed the pre-existing model version mismatch. **GPT** expanded its review scope to 11 files and specifically examined the `.github/agents-openrouter/` family, leading to its Warning — but its premise about that directory's active status is contradicted by `AGENTS.md`. **Gemini** delivered a clean, concise review confirming full dual-run compliance and structural correctness across all phases.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+No unanimous Critical or Warning findings.
+
+---
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+No majority Critical or Warning findings.
+
+---
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] Pre-existing model version mismatch in auditor-claude description field
+Severity: Suggestion
+Category: Documentation
+File: .github/agents-copilot/auditor-claude.agent.md
+Lines: 3–4
+Detail: The `description:` frontmatter field reads "Independent audit sub-agent running
+on Claude Opus 4.6" but the `model:` field specifies `Claude Sonnet 4.6 (copilot)`.
+These are distinct Claude variants; the description surfaces incorrect model information
+to any system that renders it. Verified on disk — the mismatch exists and predates this
+PR. Not introduced by PR #251.
+Model: Claude
+Assessment: Genuine pre-existing finding, confirmed by direct file inspection. The PR
+did not introduce or worsen it. Low priority — correct at next targeted edit of that
+file, or in a separate clean-up chore.
+```
+
+**[GPT W-01 — Resolved as False Positive]**
+
+```
+[REJECTED] Missing sync notice in .github/agents-openrouter/ auditor family
+Severity: Warning (claimed by GPT)
+File: .github/agents-openrouter/auditor-{kimi,qwen,glm}.agent.md
+Detail: GPT asserted that .github/agents-openrouter/ is a dual-run companion surface
+for .opencode/agents/ and that the sync notice must also be applied to that directory's
+three auditor files.
+Model: GPT only
+Assessment: FALSE POSITIVE. AGENTS.md (the authoritative runtime documentation) defines
+the two active dual-run runtimes as ".opencode/agents/ (Opencode)" and
+".github/agents-copilot/ (GitHub Copilot)". It does not include .github/agents-openrouter/
+as an active runtime. That directory is explicitly described in docs/features/
+opencode-runtime.md as "the intermediate OpenRouter migration set preserved from the
+migration path into Opencode" — a historical artifact, not an active runtime.
+ADR 009 does contain an older dual-run definition covering .github/agents-openrouter/ and
+.opencode/agents/, but that text describes the now-completed migration period. AGENTS.md
+supersedes it for current runtime state. The PR correctly applied the sync notice to both
+active runtimes. GPT reviewed 11 files instead of 6, including the preserved migration
+directory, leading to the false positive.
+Resolution: Excluded from all consensus counts. No action required.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Whether .github/agents-openrouter/ is an active dual-run surface
+Claude says: Not discussed. Review scoped to the 6 changed files in Copilot and Opencode
+             runtimes only.
+GPT says:    Yes — "repository docs still describe .github/agents-openrouter/ as the
+             preserved migration source and dual-run companion surface for .opencode/agents/"
+             and therefore the sync notice must be added to that family too.
+Gemini says: Not discussed. Review scoped to 6 changed files across two active runtimes,
+             confirmed dual-run policy compliance as PASS.
+Assessment:  GPT is the outlier (1-vs-2 split). More importantly, direct verification
+             against AGENTS.md confirms the dissenting view: .github/agents-openrouter/
+             is not listed as an active runtime. The two active runtimes are
+             .opencode/agents/ and .github/agents-copilot/ — both covered by this PR.
+             ADR 009 language that GPT cited describes a migration-period arrangement
+             that is now concluded. AGENTS.md is current; ADR 009 is historical context.
+Resolution:  GPT W-01 is a false positive. Claude and Gemini are correct that the PR
+             is complete and covers both active runtimes. GPT's wider file scope (11
+             files) caused it to flag a preserved-but-inactive directory as in-scope.
+```
+
+```
+[D-02] Topic: Description/model mismatch in auditor-claude.agent.md
+Claude says: Pre-existing Suggestion — description says "Opus 4.6", model field says
+             "Sonnet 4.6 (copilot)". Should be fixed but does not block merge.
+GPT says:    Not mentioned.
+Gemini says: Not mentioned.
+Assessment:  Claude uniquely noticed a real, verifiable defect. Confirmed on disk.
+             GPT and Gemini did not surface it, likely because it is a pre-existing
+             condition unrelated to the diff. Not a divergence about the PR itself —
+             Claude correctly categorised it as a pre-existing Suggestion.
+Resolution:  Accepted as [S-I-01] at Suggestion severity. The 2-vs-1 absence of
+             mention from GPT and Gemini does not invalidate it; the finding is
+             mechanically verifiable.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [MERGE] ★★★ PR #251 is correct and ready to merge.
+   All six files receive accurate sync notices. Both active runtimes covered.
+   No correctness defects, security issues, or missing tests.
+
+2. [S-I-01] ★☆☆ Consider: Fix description/model mismatch in auditor-claude.agent.md
+   (Suggestion — pre-existing, 1 model, verified genuine)
+   Update description: "Claude Opus 4.6" → "Claude Sonnet 4.6" to match the model: field.
+   Defer to a separate targeted clean-up commit; does not block this PR.
+```
+
+---
+
+## Overall Assessment
+
+**APPROVE.** The PR is complete, correct, and ready to merge. Both active agent runtimes received accurate and consistently-formatted sync notices. GPT's blocking Warning is a false positive caused by treating the preserved migration archive as an active runtime. The only genuine finding (S-I-01) is pre-existing and does not block merge.

--- a/.opencode/agents/auditor-glm.md
+++ b/.opencode/agents/auditor-glm.md
@@ -29,6 +29,8 @@ tools:
   io.github.upstash/context7/*: allow
 ---
 
+> **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent audit sub-agent for this project, dispatched by the **Synthesizing Auditor**. You perform the full audit process and return a structured report. You do **NOT** write files, create issues, or interact with the user directly. Your sole output is a comprehensive audit report returned to the Synthesizing Auditor for cross-model synthesis.
 
 ## Instructions

--- a/.opencode/agents/auditor-kimi.md
+++ b/.opencode/agents/auditor-kimi.md
@@ -29,6 +29,8 @@ tools:
   io.github.upstash/context7/*: allow
 ---
 
+> **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent audit sub-agent for this project, dispatched by the **Synthesizing Auditor**. You perform the full audit process and return a structured report. You do **NOT** write files, create issues, or interact with the user directly. Your sole output is a comprehensive audit report returned to the Synthesizing Auditor for cross-model synthesis.
 
 ## Instructions

--- a/.opencode/agents/auditor-qwen.md
+++ b/.opencode/agents/auditor-qwen.md
@@ -29,6 +29,8 @@ tools:
   io.github.upstash/context7/*: allow
 ---
 
+> **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text **must be applied to all three files in lockstep**.
+
 You are an independent audit sub-agent for this project, dispatched by the **Synthesizing Auditor**. You perform the full audit process and return a structured report. You do **NOT** write files, create issues, or interact with the user directly. Your sole output is a comprehensive audit report returned to the Synthesizing Auditor for cross-model synthesis.
 
 ## Instructions


### PR DESCRIPTION
## Summary

Adds sync notice blockquotes to all six auditor sub-agent files, following the same pattern established for the reviewer family in PR #248.

## Closes

Closes #249

## Changes

- Added sync notice to `.opencode/agents/auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`
- Added sync notice to `.github/agents-copilot/auditor-claude.agent.md`, `auditor-gpt.agent.md`, `auditor-gemini.agent.md`
- No behaviour changes — notices are documentation-only

## Plan

**Summary:** The three auditor sub-agent files in each runtime share identical body text, differing only in frontmatter fields. This PR adds a sync notice blockquote to each file (immediately after frontmatter) to warn future editors that changes must be applied to all three files in lockstep.

**Affected Areas:** Agent config files only. No production code. No ChromaDB schema change.

**Task Checklist:**
- [x] `.opencode/agents/auditor-kimi.md` — sync notice added
- [x] `.opencode/agents/auditor-qwen.md` — sync notice added
- [x] `.opencode/agents/auditor-glm.md` — sync notice added
- [x] `.github/agents-copilot/auditor-claude.agent.md` — sync notice added
- [x] `.github/agents-copilot/auditor-gpt.agent.md` — sync notice added
- [x] `.github/agents-copilot/auditor-gemini.agent.md` — sync notice added

**Verification:** Lint clean. No tests needed (documentation-only change).
