### PR TITLE
fix(agents): align tools: block ordering in auditor sub-agent variants to match parent

### DIFF
--- a/.github/notes/reflections/archive/issue-256-auditor-tools-ordering-fix-validated-2026-04-30.md
+++ b/.github/notes/reflections/archive/issue-256-auditor-tools-ordering-fix-validated-2026-04-30.md
@@ -1,0 +1,32 @@
+---
+date: "2026-04-30"
+issue: 256
+pr: 258
+category: agent
+targets:
+  - ".opencode/agents/auditor-kimi.md"
+  - ".opencode/agents/auditor-qwen.md"
+  - ".opencode/agents/auditor-glm.md"
+severity: minor
+status: active
+---
+
+## Auditor variant tools ordering fix — clean cycle validates reflection pipeline
+
+### Finding
+
+Issue #256 (PR #258) corrected a `tools:` block ordering inconsistency in the three auditor variant files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). The parent `auditor.md` lists `chroma/*` → `context7/*` → `tavily/*`; the variants had `context7/*` and `tavily/*` swapped relative to that order. The fix was cosmetic-only — no behavioral change, no runtime impact. Unanimous reviewer approval, zero findings requiring fixes.
+
+### Observation
+
+This cycle serves as a direct validation of the reflection pipeline: the ordering inconsistency was first identified by the synthesized reviewer during PR #253, immediately recorded as `issue-254-tools-ordering-coder-guidance.md`, and a coder guidance rule was added to `coder.md` Rule 10 before issue #256 was even opened. The fix in #258 then closed the pre-existing gap cleanly. The end-to-end path — reviewer detects → reflection records → coder guidance added → follow-up issue fixes root cause — completed without friction.
+
+The absence of any review findings also confirms that variant files in good structural shape produce low-noise review cycles. The sync note expansion from issue-254 (covering frontmatter as well as body text) provides ongoing protection against future divergence of this class.
+
+### Suggested Improvement
+
+No new improvements needed. The tools ordering guidance in `coder.md` and the expanded sync note in the auditor variant files collectively close the structural gap that produced this issue. No further action required.
+
+### Action Taken
+
+No action taken. Recording as a clean-cycle validation note for pattern confirmation.

--- a/.github/notes/reflections/issue-256-auditor-tools-ordering-fix-validated.md
+++ b/.github/notes/reflections/issue-256-auditor-tools-ordering-fix-validated.md
@@ -1,0 +1,32 @@
+---
+date: "2026-04-30"
+issue: 256
+pr: 258
+category: agent
+targets:
+  - ".opencode/agents/auditor-kimi.md"
+  - ".opencode/agents/auditor-qwen.md"
+  - ".opencode/agents/auditor-glm.md"
+severity: minor
+status: archived
+---
+
+> **Archived.** See canonical copy: `archive/issue-256-auditor-tools-ordering-fix-validated-2026-04-30.md`
+
+### Finding
+
+Issue #256 (PR #258) corrected a `tools:` block ordering inconsistency in the three auditor variant files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). The parent `auditor.md` lists `chroma/*` → `context7/*` → `tavily/*`; the variants had `context7/*` and `tavily/*` swapped relative to that order. The fix was cosmetic-only — no behavioral change, no runtime impact. Unanimous reviewer approval, zero findings requiring fixes.
+
+### Observation
+
+This cycle serves as a direct validation of the reflection pipeline: the ordering inconsistency was first identified by the synthesized reviewer during PR #253, immediately recorded as `issue-254-tools-ordering-coder-guidance.md`, and a coder guidance rule was added to `coder.md` Rule 10 before issue #256 was even opened. The fix in #258 then closed the pre-existing gap cleanly. The end-to-end path — reviewer detects → reflection records → coder guidance added → follow-up issue fixes root cause — completed without friction.
+
+The absence of any review findings also confirms that variant files in good structural shape produce low-noise review cycles. The sync note expansion from issue-254 (covering frontmatter as well as body text) provides ongoing protection against future divergence of this class.
+
+### Suggested Improvement
+
+No new improvements needed. The tools ordering guidance in `coder.md` and the expanded sync note in the auditor variant files collectively close the structural gap that produced this issue. No further action required.
+
+### Action Taken
+
+No action taken. Recording as a clean-cycle validation note for pattern confirmation.

--- a/.github/notes/reviews/2026-04-30-pr258-claude-raw.md
+++ b/.github/notes/reviews/2026-04-30-pr258-claude-raw.md
@@ -1,0 +1,98 @@
+# Code Review Report — PR #258 (Claude Raw)
+
+**Branch:** `fix/issue-256-auditor-tools-ordering`
+**Reviewer:** Claude Sonnet 4.6
+**Date:** 2026-04-30
+**Commit:** `9e82202`
+
+---
+
+## Review Summary
+
+Single-purpose cosmetic fix: reorders the `tools:` block in all three auditor sub-agent variants (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`) so that `context7` precedes `tavily-mcp`, matching the ordering in the parent `auditor.md`. No tool additions, removals, or body text changes. All three lockstep files updated in the same commit.
+
+**Files Reviewed:** 4 (3 changed + parent `auditor.md` for reference)
+**Findings:** 0 Critical, 0 Warning, 1 Suggestion
+
+---
+
+## Findings
+
+### Critical Findings
+
+None.
+
+### Warning Findings
+
+None.
+
+### Suggestions
+
+```
+[S-01] YAML map ordering has no semantic effect — commit message could note this
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/auditor-glm.md, auditor-kimi.md, auditor-qwen.md
+Lines: general
+Description: YAML mapping keys are unordered per spec; most parsers (PyYAML, js-yaml) load them
+into dicts where insertion order is irrelevant to runtime behaviour. The commit message "align
+tools: block ordering" is accurate, but the PR description does not note that the change is
+purely cosmetic. Future reviewers scanning the commit log may wonder whether a specific tool
+load order was required for correctness — a brief parenthetical ("cosmetic; YAML map ordering
+has no runtime effect") would prevent that confusion.
+Suggestion: Append "(cosmetic consistency; no functional effect)" to the commit body, or add a
+one-line note to the PR description. No file changes required.
+```
+
+---
+
+## Phase 1 — Structural Review
+
+- **Commit message:** Conforms — `fix(type): message (#issue)` format, references issue #256. ✓
+- **Branch name:** `fix/issue-256-auditor-tools-ordering` — follows `fix/issue-N-...` convention. ✓
+- **Scope:** 6 lines changed across 3 files. Well within bounds. ✓
+- **No unrelated changes:** Diff contains only the reorder. ✓
+- **Numbered step lists:** Body text is identical across all three files and the parent — not modified. No gaps introduced. ✓
+- **Lockstep sync:** The sync note in each file requires all three variants to be updated in lockstep. All three were updated in the same commit. ✓
+- **Model-specific variant sync (Phase 1 checklist):** Parent `auditor.md` `tools:` ordering after this PR:
+  ```yaml
+  tools:
+    "chroma/*": true
+    "io.github.upstash/context7/*": true
+    "io.github.tavily-ai/tavily-mcp/*": true
+  ```
+  All three variants now match. ✓
+- **`opencode.json` registration:** No new agents added — existing agents reordered only. No registration check needed. ✓
+- **Companion file concept sweep:** No tool names changed (only ordering). No grep sweep required. ✓
+- **`tools:` array coupling — removal direction:** No tools removed from the `tools:` block. ✓
+- **`tools:` array coupling — addition direction:** No tools added. ✓
+
+## Phase 2 — Code Review
+
+No Python, TypeScript, or logic code changed. All changed lines are YAML frontmatter. N/A.
+
+## Phase 3 — Frontend Review
+
+No frontend changes. N/A.
+
+## Phase 4 — Security Review
+
+YAML `tools:` block ordering change has no security implications. Tool grant set is identical before and after. ✓
+
+## Phase 5 — Testing Review
+
+No logic changed; no tests required or expected for a cosmetic YAML ordering fix. ✓
+
+## Phase 6 — Performance Review
+
+N/A.
+
+## Phase 7 — Documentation Review
+
+Body text is unchanged in all three files. The sync note remains accurate. ✓
+
+---
+
+## Overall Assessment
+
+Ready to merge. The change is minimal, correct, and complete — all three lockstep variant files were updated in a single commit to match the parent `auditor.md` tool ordering. There are no functional, security, or correctness concerns. The sole suggestion (S-01) is optional documentation hygiene and does not block merge.

--- a/.github/notes/reviews/2026-04-30-pr258-gemini-raw.md
+++ b/.github/notes/reviews/2026-04-30-pr258-gemini-raw.md
@@ -1,0 +1,13 @@
+### Review Summary
+
+This PR correctly aligns the `tools:` block ordering across the three Opencode auditor sub-agent variants (`auditor-glm.md`, `auditor-kimi.md`, `auditor-qwen.md`) so that `io.github.tavily-ai/tavily-mcp/*` appears after `io.github.upstash/context7/*`. 
+
+The changes successfully satisfy the strict synchronization constraint specified in the files' frontmatter sync notes. The modifications have been applied identically and in lockstep across all three variant files, ensuring maintenance consistency without altering any runtime behaviour (as YAML mappings are unordered).
+
+Branch naming (`fix/issue-256-auditor-tools-ordering`) and commit messaging follow project conventions.
+
+**Decision:** Approve
+
+### Findings
+
+No issues found.

--- a/.github/notes/reviews/2026-04-30-pr258-gpt-raw.md
+++ b/.github/notes/reviews/2026-04-30-pr258-gpt-raw.md
@@ -1,0 +1,26 @@
+# Code Review Report
+
+## Review Summary
+
+This PR changes only the `tools:` block ordering in the three model-specific auditor variants so that they match the parent auditor agent. The change is small, targeted, and aligns with an existing repository convention that variant agent files preserve parent `tools:` ordering to avoid parity drift and follow-up review noise.
+
+**Files Reviewed:** 3
+**Findings:** 0 Critical, 0 Warning, 0 Suggestion
+
+## Findings
+
+### Critical Findings
+
+None.
+
+### Warning Findings
+
+None.
+
+### Suggestions
+
+None.
+
+## Overall Assessment
+
+This change is ready for merge. I found no correctness, security, testing, or convention issues in scope: the branch name and commit message follow project conventions, the edit is applied consistently across all three auditor variants, and the resulting `tools:` ordering now matches the parent [auditor definition](.opencode/agents/auditor.md). Residual risk is low because the PR does not alter behavior, permissions, or instruction body text.

--- a/.github/notes/reviews/2026-04-30-pr258-synthesis.md
+++ b/.github/notes/reviews/2026-04-30-pr258-synthesis.md
@@ -1,0 +1,138 @@
+# Synthesized Review Report — PR #258
+
+**Branch:** `fix/issue-256-auditor-tools-ordering`
+**Date:** 2026-04-30
+**Commit:** `9e82202`
+**Synthesis by:** GitHub Copilot (Synthesizing Reviewer)
+**Raw reports:** `2026-04-30-pr258-claude-raw.md`, `2026-04-30-pr258-gpt-raw.md`, `2026-04-30-pr258-gemini-raw.md`
+
+---
+
+## Synthesis Overview
+
+This PR reorders the `tools:` block in the three auditor sub-agent variant files (`auditor-glm.md`, `auditor-kimi.md`, `auditor-qwen.md`) so that `context7` precedes `tavily-mcp`, aligning with the parent `auditor.md` definition. All three reviewers independently concluded the change is correct, complete, and safe to merge. Agreement across models was exceptionally high — the only divergence is whether to suggest a minor documentation note on the cosmetic nature of the change. There are no Critical or Warning findings in any report.
+
+**Model Agreement Score:** 9/10
+
+---
+
+## Individual Report Summaries
+
+| Model  | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ------ | ------------------ | ------------------ | -------------- | ------------- |
+| Claude | Approve — ready to merge | Lockstep sync verification; YAML ordering semantics; full phase-by-phase checklist | 0 | 0 |
+| GPT    | Approve — ready to merge | Parity drift prevention; variant-to-parent matching | 0 | 0 |
+| Gemini | Approve — ready to merge | Synchronisation constraint satisfaction; runtime behaviour confirmation | 0 | 0 |
+
+**Claude** conducted the most thorough structural walkthrough, running through all seven review phases explicitly and verifying the lockstep sync requirement. It surfaced one optional documentation suggestion about noting the cosmetic nature of the change in the commit body or PR description.
+
+**GPT** gave a clean pass with no findings or suggestions. It confirmed the branch name, commit message, and per-file consistency without reservations.
+
+**Gemini** also gave a clean pass. It emphasised that YAML mappings are unordered and explicitly called out that runtime behaviour is unchanged, then issued an unconditional Approve.
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+```
+[U-A-01] Change is correct, complete, and safe to merge
+Severity: Informational (positive consensus)
+Category: Correctness
+Files: .opencode/agents/auditor-glm.md, auditor-kimi.md, auditor-qwen.md
+Detail: All three models independently verified that the tools: block in each variant file
+        now matches the parent auditor.md ordering (chroma → context7 → tavily-mcp). The
+        edit was applied consistently across all three files in a single commit, satisfying
+        the lockstep synchronisation requirement stated in each file's frontmatter sync note.
+        No tool grants were added, removed, or modified — only the key ordering changed.
+Models: Claude ✓  GPT ✓  Gemini ✓
+```
+
+```
+[U-A-02] No security, functional, or runtime concerns
+Severity: Informational (positive consensus)
+Category: Security / Correctness
+Files: all changed files
+Detail: YAML mapping keys are unordered per the YAML 1.2 spec. The tools: block is parsed
+        into a dictionary where insertion order has no effect on which tools are granted or
+        how they are invoked. The tool grant set is identical before and after the change.
+        All three models independently confirmed there are no security implications.
+Models: Claude ✓  GPT ✓  Gemini ✓
+```
+
+```
+[U-A-03] Branch name and commit message follow project conventions
+Severity: Informational (positive consensus)
+Category: Style
+Detail: Branch fix/issue-256-auditor-tools-ordering follows the fix/issue-N-... convention.
+        Commit message follows fix(type): message (#issue) format and references issue #256.
+Models: Claude ✓  GPT ✓  Gemini ✓
+```
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+None.
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-I-01] Commit body or PR description could note the change is purely cosmetic
+Severity: Suggestion
+Category: Documentation
+File: Commit message / PR description (not a source file)
+Detail: Claude noted that because YAML map ordering has no runtime effect, future reviewers
+        scanning the commit log may wonder whether a specific tool load order was required
+        for correctness. A brief parenthetical — e.g., "(cosmetic consistency; no functional
+        effect)" — in the commit body or PR description would eliminate that ambiguity.
+Model: Claude only
+Assessment: This is a genuine, low-stakes documentation suggestion. GPT and Gemini did
+            acknowledge the cosmetic nature of the change (GPT: "does not alter behavior,
+            permissions, or instruction body text"; Gemini: "without altering any runtime
+            behaviour") but neither flagged the absence of an explicit note as worth
+            mentioning. The suggestion is valid but entirely optional — it does not affect
+            the correctness or safety of the change and does not block merge.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Whether to suggest a documentation note on the cosmetic nature of the change
+
+Claude says: A brief note in the commit body or PR description clarifying that the change
+             is purely cosmetic ("no runtime effect") would help future reviewers.
+
+GPT says:    No suggestion needed; the PR is already clear. Clean pass with zero findings.
+
+Gemini says: No suggestion needed; the cosmetic nature is self-evident from the change.
+             Clean pass with unconditional Approve.
+
+Assessment:  2-vs-1 split (GPT + Gemini vs. Claude). Claude's suggestion is reasonable —
+             the YAML ordering point is non-obvious to reviewers unfamiliar with the spec —
+             but GPT and Gemini correctly judge it as sub-threshold for even a suggestion
+             in a change this small and well-named. The PR branch name and commit message
+             already communicate intent clearly enough.
+
+Resolution:  Treat as optional. Not elevated to majority finding. Included as [S-I-01] at
+             Suggestion severity for completeness.
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+```
+1. [U-A-01 / U-A-02 / U-A-03] ★★★ Merge — all three models approve unconditionally.
+   No blocking findings exist.
+
+2. [S-I-01] ★☆☆ Optional: Append "(cosmetic consistency; no functional effect)" to the
+   commit body or PR description. Does not block merge. Apply at discretion.
+```
+
+---
+
+## Final Verdict
+
+**APPROVED — ready to merge.** Unanimous consensus across all three models. Zero Critical findings, zero Warning findings. The single Suggestion is optional documentation hygiene from one model only and does not affect correctness or safety.

--- a/.opencode/agents/auditor-glm.md
+++ b/.opencode/agents/auditor-glm.md
@@ -26,8 +26,8 @@ permission:
   task: deny
 tools:
   "chroma/*": true
-  "io.github.tavily-ai/tavily-mcp/*": true
   "io.github.upstash/context7/*": true
+  "io.github.tavily-ai/tavily-mcp/*": true
 ---
 
 > **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text or other frontmatter **must be applied to all three files in lockstep**.

--- a/.opencode/agents/auditor-kimi.md
+++ b/.opencode/agents/auditor-kimi.md
@@ -26,8 +26,8 @@ permission:
   task: deny
 tools:
   "chroma/*": true
-  "io.github.tavily-ai/tavily-mcp/*": true
   "io.github.upstash/context7/*": true
+  "io.github.tavily-ai/tavily-mcp/*": true
 ---
 
 > **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text or other frontmatter **must be applied to all three files in lockstep**.

--- a/.opencode/agents/auditor-qwen.md
+++ b/.opencode/agents/auditor-qwen.md
@@ -26,8 +26,8 @@ permission:
   task: deny
 tools:
   "chroma/*": true
-  "io.github.tavily-ai/tavily-mcp/*": true
   "io.github.upstash/context7/*": true
+  "io.github.tavily-ai/tavily-mcp/*": true
 ---
 
 > **Sync note:** This file is one of three identical auditor sub-agent files (`auditor-kimi.md`, `auditor-qwen.md`, `auditor-glm.md`). They differ only in `model:` and `description:` frontmatter fields. Any change to this body text or other frontmatter **must be applied to all three files in lockstep**.


### PR DESCRIPTION
## Summary

Reorders the `tools:` block in the three auditor sub-agent variant files to match the parent `auditor.md` ordering.

**Before:** `chroma/*` → `tavily/*` → `context7/*`
**After:** `chroma/*` → `context7/*` → `tavily/*`

YAML maps are semantically unordered so runtime behaviour is unchanged, but the alignment makes future lockstep sync reviews easier to validate.

## Closes
Closes #256

## Changes
- [x] `auditor-kimi.md` — tools: block reordered to match parent
- [x] `auditor-qwen.md` — tools: block reordered to match parent
- [x] `auditor-glm.md` — tools: block reordered to match parent

## Checklist
- [x] Implementation complete
- [x] No behavioral changes (YAML map ordering only)
- [x] Linting not applicable (Markdown/YAML agent files)