### PR TITLE
fix(contemplator): add gh* bash permission and replace github/search_issues reference

### DIFF
--- a/.github/notes/reviews/2026-04-30-pr270-glm-raw.md
+++ b/.github/notes/reviews/2026-04-30-pr270-glm-raw.md
@@ -1,0 +1,99 @@
+# Code Review Report — PR #270 (GLM)
+
+**Branch:** `fix/issue-261-contemplator-gh-permissions`
+**Commit:** `b5d998c fix(contemplator): add gh* bash permission and replace github/search_issues (#261)`
+**Reviewer:** GLM 5.1 (openrouter/z-ai/glm-5.1)
+
+---
+
+### Review Summary
+
+This PR is a focused, single-file fix that adds `"gh*": "allow"` to the Opencode Contemplator agent's bash permissions and replaces the non-functional `github/search_issues` MCP tool reference with equivalent `gh issue list` and `gh pr list` CLI commands. The change directly resolves issue #261 and prior audit finding [U-W-03]. The commit follows convention, the scope is tight, and the replacement commands are syntactically correct. No critical issues were found. One warning-level inconsistency with a sibling agent's `--repo` flag usage and two minor suggestions are noted.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 1 Warning, 2 Suggestion
+
+---
+
+### Phase 1 — Structural Review
+
+- [x] **Commit messages** — `fix(contemplator): add gh* bash permission and replace github/search_issues (#261)` follows `fix(scope): description (#issue)` convention.
+- [x] **Branch name** — `fix/issue-261-contemplator-gh-permissions` follows `fix/issue-N-...` convention.
+- [x] **Scope** — 1 file, 3 lines added, 2 lines removed. Appropriately minimal.
+- [x] **No unrelated changes** — all changes directly support the stated purpose.
+- [x] **Numbered step lists** — Phase 2 steps remain contiguous (1, 2, 3, 4). No gaps introduced.
+- [x] **File relocation** — none.
+- [x] **Sibling item orphaning** — none.
+- [x] **Stale prose counts** — none affected.
+- [x] **Companion file concept sweep** — grep for `github/search_issues` across `.github/` and `.opencode/` confirms: remaining references are in Copilot-runtime variant files (`.github/agents-copilot/contemplator.agent.md`), skill files (`.github/skills/github-issues/SKILL.md`), shared process files (`_shared/audit-process.md`, `_shared/repo-context.md`), and review/notes archives. Those contexts still use the `github/*` MCP tools natively (Copilot runtime) or document the tool interface for reference purposes. No Opencode agent file was missed.
+- [x] **`tools:` array coupling** — contemplator's `tools:` block has no `github/*` entry and now correctly uses `gh` CLI instead. No tools array change needed.
+- [x] **Model-specific variant sync** — contemplator.md has no model-specific variants under `.opencode/agents/`.
+- [x] **Section heading drift** — "Repository Identity" heading still accurately describes its content after the wording change from `github/*` tool calls to `gh` commands.
+- [x] **YAML frontmatter section removal** — none.
+- [x] **Agent `model:` field** — `openrouter/moonshotai/kimi-k2.6` is a single scalar string. Correct.
+- [x] **opencode.json registration** — no new agent file added; only an edit to an existing file.
+- [x] **story-pipeline SKILL.md sync** — contemplator is not a pipeline subagent.
+- [x] **Dispatch contract completeness** — contemplator is not a dispatched subagent.
+- [x] **Summary table vs body text parity** — no tables in the file.
+- [x] **Shell snippet safety** — the `gh` commands are read-only list/view operations. No `rm`, file writes, or path construction. No `|| exit 1` guards needed for informational queries.
+
+### Phases 2–7 — Code, Security, Testing, Performance, Documentation
+
+- **Code correctness:** The `"gh*": "allow"` glob correctly matches `gh issue list`, `gh pr list`, and any future `gh` subcommands the agent may need. The JSON field names (`number`, `title`, `state`, `closedAt`) are all valid `gh issue list` output fields. The `closedAt` field is correctly requested for closed issues, enabling the agent to apply date-based reasoning on the returned data.
+- **Security:** No concerns. The `gh*` permission allows both read and write `gh` subcommands, but the agent's instructions restrict it to read-only queries (`list`, `view`). The agent's `edit: deny` restriction prevents file writes. The `gh*` glob could theoretically match non-GitHub CLI tools (e.g., `ghc` for Haskell), but such tools are unlikely on the execution environment and the agent would not be instructed to use them.
+- **Testing:** No Python code changes; agent instruction file only. No test coverage applicable.
+- **Performance:** `gh issue list` and `gh pr list` default to 30 results. For an active repository, 30 closed issues may not span 30 days of activity. Noted as suggestion S-01.
+- **Documentation:** The semantic change from "issues closed in the last 30 days" (old text) to "recently closed issues" (new text) is a minor weakening of specificity. However, since the `closedAt` field is included in the JSON output, the agent can filter by date during post-processing, making the behavior functionally equivalent.
+
+---
+
+### Findings
+
+#### Critical Findings
+
+None.
+
+#### Warning Findings
+
+```
+[W-01] gh commands omit --repo OWNER/REPO despite reading repo.md for OWNER and REPO
+Category: Correctness
+Severity: Warning
+File: .opencode/agents/contemplator.md
+Lines: 49, 82
+Description: The "Repository Identity" section instructs the agent to "read `.github/notes/repo.md` to confirm `OWNER` and `REPO`", but the `gh` CLI commands in Phase 2 do not use these values — they omit the `--repo OWNER/REPO` flag that the sprint-runner agent consistently uses in its equivalent commands (e.g., `gh issue list --repo OWNER/REPO --state open`). This creates two issues: (1) an instruction-following agent may be confused about why it read values it never uses; (2) if the agent is run from a directory that is not the git repository root, `gh` will fail to detect the repo. While the typical execution context is the repo root (where auto-detection works), the inconsistency with sprint-runner's pattern suggests this was an oversight rather than a deliberate design choice.
+Suggestion: Add `--repo OWNER/REPO` to all three `gh` commands in Phase 2, matching the sprint-runner pattern:
+  - `gh issue list --repo OWNER/REPO --state closed --json number,title,state,closedAt`
+  - `gh issue list --repo OWNER/REPO --state open --json number,title,state`
+  - `gh pr list --repo OWNER/REPO --state open --json number,title,state`
+```
+
+#### Suggestions
+
+```
+[S-01] gh issue list --state closed default limit may truncate coverage
+Category: Performance
+Severity: Suggestion
+File: .opencode/agents/contemplator.md
+Lines: 82
+Description: `gh issue list` defaults to 30 results. On an active repository, 30 closed issues may not cover the last 30 days of activity, reducing the Phase 2 signal quality. The old `github/search_issues` approach had comparable implicit limits, but the `gh` CLI exposes the limit via `--limit`, making it easy to improve.
+Suggestion: Consider adding `--limit 100` to the closed-issues command:
+  `gh issue list --repo OWNER/REPO --state closed --limit 100 --json number,title,state,closedAt`
+The open-issue and open-PR commands are less likely to need a higher limit and can remain at the default 30.
+```
+
+```
+[S-02] planner.md has the same github/* tool reference without gh* permission (out-of-scope)
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/planner.md
+Lines: 55
+Description: The planner.md agent (not changed in this PR) still contains the prose "Before making any `github/*` tool call" and lists "GitHub API — for issue/PR context" as a capability, but its `permission.bash` block lacks `"gh*": "allow"` — the same root cause that prompted issue #261 for the contemplator. Additionally, `_shared/repo-context.md` and `_shared/audit-process.md` still reference `github/*` tool calls, which are correct for the Copilot runtime but misleading for Opencode agents that include those shared files. This is out-of-scope for this PR but should be tracked.
+Suggestion: File a follow-up issue to audit all `.opencode/agents/*.md` files for the same pattern (body text referencing `github/*` tools without `gh*` bash permission) and update `_shared/repo-context.md` and `_shared/audit-process.md` to accommodate both runtimes.
+```
+
+---
+
+### Overall Assessment
+
+Ready for merge. The change is correct and minimal — it unblocks the Contemplator's Phase 2 GitHub research workflow under the Opencode runtime by adding the necessary bash permission and replacing the unavailable `github/search_issues` MCP tool with equivalent `gh` CLI commands. The one Warning finding (missing `--repo OWNER/REPO` flag) is a consistency gap with the sprint-runner pattern that should be addressed but does not break the typical execution path. The two Suggestions are low-priority improvements that can be tracked separately. No security concerns, no breaking changes, no convention violations.

--- a/.github/notes/reviews/2026-04-30-pr270-kimi-raw.md
+++ b/.github/notes/reviews/2026-04-30-pr270-kimi-raw.md
@@ -1,0 +1,69 @@
+# Code Review Report — fix/issue-261-contemplator-gh-permissions
+
+**Reviewer:** Kimi (moonshotai/kimi-k2.6)
+**Branch:** fix/issue-261-contemplator-gh-permissions
+**Base:** development
+**Date:** 2026-04-30
+
+---
+
+## Review Summary
+
+This PR is a minimal, targeted fix for issue #261. It adds `"gh*": "allow"` to the Opencode Contemplator agent's `permission.bash` block and replaces the Copilot-style `github/search_issues` tool call (unavailable under Opencode) with equivalent `gh issue list` and `gh pr list` CLI commands. Only one file is changed, the scope is tightly bounded, and the commit message follows convention.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 1 Warning, 3 Suggestions
+
+---
+
+## Findings
+
+### Warning Findings
+
+```
+[W-01] Phase 2 "last 30 days" intent not implemented by new `gh` commands
+Category: Correctness
+Severity: Warning
+File: .opencode/agents/contemplator.md
+Lines: 79-82
+Description: The introductory prose at line 79 still instructs the agent to "find issues closed in the last 30 days and any currently open issues or PRs." However, the replaced `gh issue list --state closed --json ...` command (line 80) has no date filter or search parameter. `gh issue list` returns the most recently closed issues up to its default limit (30), regardless of when they were closed. This creates a mismatch between stated intent and actual command behaviour — the agent may see issues from much earlier than 30 days ago, or miss recently closed issues if the default limit is exceeded, without any explicit signal that the filter is absent.
+Suggestion: Either add a `--search` filter (e.g. `--search "closed:>$(date -d '30 days ago' +%Y-%m-%d)"` if supported by the local `gh` version) or update the prose to remove the "last 30 days" claim and instead say "recently closed issues." Alternatively, add a note instructing the agent to inspect `closedAt` in the JSON output and mentally filter to the last 30 days.
+```
+
+### Suggestions
+
+```
+[S-01] Default `gh` list limit of 30 may be too low for pattern detection
+Category: Correctness
+Severity: Suggestion
+File: .opencode/agents/contemplator.md
+Lines: 80-82
+Description: `gh issue list` and `gh pr list` both default to 30 results. For an active repository, 30 closed issues may not be enough to detect meaningful patterns over the last 30 days. The old `github/search_issues` approach also had pagination, but the agent instruction did not mention limits. Adding an explicit `--limit 100` would provide more signal without significantly increasing latency.
+Suggestion: Append `--limit 100` to each `gh issue list` and `gh pr list` command.
+```
+
+```
+[S-02] Capability description still refers to "GitHub API" while agent uses `gh` CLI
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/contemplator.md
+Lines: 24-25
+Description: The capabilities bullet list says "GitHub API — for issue/PR activity." However, the `tools:` array contains no `github/*` entries, and the Phase 2 instructions now use `gh` CLI commands rather than GitHub MCP tool calls. This creates a minor mismatch between described capability and actual mechanism.
+Suggestion: Update the bullet to "GitHub CLI (`gh`) — for issue/PR activity" to accurately reflect the runtime mechanism.
+```
+
+```
+[S-03] Dual-run companion files use different but valid runtime-specific commands
+Category: Style
+Severity: Suggestion
+File: .github/agents-openrouter/contemplator.agent.md, .github/agents-copilot/contemplator.agent.md
+Lines: 62 (both files)
+Description: The OpenRouter and Copilot contemplator variants (not in the diff) still instruct `github/search_issues`, which is valid because those runtimes have `github/*` tools enabled. The Opencode variant correctly uses `gh` CLI because it lacks `github/*` tools. While this runtime-specific divergence is technically correct, it means the three contemplator files now use permanently different command patterns for the same conceptual step. Future maintainers updating Phase 2 logic would need to apply changes in three places with different syntax.
+Suggestion: This is noted as a minor maintainability concern only — no action required in this PR. If desired, a future cleanup issue could consider standardizing all contemplator variants on `gh` CLI commands (available everywhere), but that is out of scope for this fix.
+```
+
+---
+
+## Overall Assessment
+
+The PR is **ready for merge** with no blocking issues. It correctly resolves the runtime failure identified in issue #261 by granting the Contemplator agent permission to invoke the `gh` CLI and replacing an unavailable Copilot tool call with working Opencode-equivalent commands. The change is minimal, focused, and does not introduce security concerns. The sole Warning relates to a prose/command intent mismatch around date filtering; this is mild and does not prevent the agent from functioning. All three Suggestions are cosmetic or enhancement-grade.

--- a/.github/notes/reviews/2026-04-30-pr270-qwen-raw.md
+++ b/.github/notes/reviews/2026-04-30-pr270-qwen-raw.md
@@ -1,0 +1,44 @@
+# Code Review Report — PR #270 (qwen)
+
+**Branch:** `fix/issue-261-contemplator-gh-permissions`
+**Commit:** `b5d998c fix(contemplator): add gh* bash permission and replace github/search_issues (#261)`
+**Reviewer:** qwen/qwen3.6-plus
+**Date:** 2026-04-30
+
+## Review Summary
+
+This PR is a minimal, targeted fix for issue #261. It adds `"gh*": "allow"` to the Opencode Contemplator agent's `permission.bash` block and replaces the Copilot-style `github/search_issues` tool call (unavailable under Opencode) with equivalent `gh issue list` and `gh pr list` CLI commands. Only one file is changed, the scope is tightly bounded, and the commit message follows convention. No critical issues found. Two suggestions noted — one regarding result pagination limits, one regarding long-term maintenance of divergent runtime instructions.
+
+**Files Reviewed:** 1
+**Findings:** 0 Critical, 0 Warning, 2 Suggestions
+
+## Findings
+
+### Suggestions
+
+```
+[S-01] gh issue list default result limit may be insufficient for pattern detection
+Category: Correctness
+Severity: Suggestion
+File: .opencode/agents/contemplator.md
+Lines: 82 (Phase 2, step 2)
+Description: `gh issue list` and `gh pr list` both default to 30 results. For an active repository, 30 closed issues may not capture enough signal over the last 30 days to detect meaningful patterns. The old `github/search_issues` approach also had implicit limits, but making the limit explicit would improve reliability.
+Suggestion: Consider adding `--limit 100` to the `gh issue list --state closed` and `gh pr list` commands to provide more signal without significantly increasing latency:
+  gh issue list --state closed --limit 100 --json number,title,state,closedAt
+  gh issue list --state open --limit 100 --json number,title,state
+  gh pr list --state open --limit 100 --json number,title,state
+```
+
+```
+[S-02] Runtime-specific divergence in Phase 2 GitHub research instructions
+Category: Documentation
+Severity: Suggestion
+File: .opencode/agents/contemplator.md
+Lines: 82 (Phase 2, step 2)
+Description: The Opencode contemplator now uses `gh` CLI commands for Phase 2 GitHub research, while the OpenRouter variant (`.github/agents-openrouter/contemplator.agent.md`) and Copilot variant (`.github/agents-copilot/contemplator.agent.md`) still use `github/search_issues`. This divergence is technically correct — those runtimes have `github/*` tools available while Opencode does not — but it means future maintainers updating Phase 2 logic must apply changes in three places with different syntax. Out-of-scope for this PR since the runtimes have genuinely different tool availability, but worth tracking as a maintenance concern.
+Suggestion: Consider adding a comment near the Phase 2 step noting the runtime-specific divergence, or track as a deferred item for eventual harmonisation when a unified approach becomes feasible.
+```
+
+## Overall Assessment
+
+**Ready for merge.** The change is correct, minimal, and directly addresses the issue identified in prior audits. The `gh*` bash permission unblocks the Contemplator's Phase 2 GitHub research workflow under Opencode. The `gh` CLI commands are syntactically correct and produce equivalent output to the previous `github/search_issues` approach. No security concerns, no breaking changes, no convention violations.

--- a/.github/notes/reviews/2026-04-30-pr270-synthesis.md
+++ b/.github/notes/reviews/2026-04-30-pr270-synthesis.md
@@ -1,0 +1,175 @@
+# Synthesized Code Review Report — PR #270
+
+**Branch:** `fix/issue-261-contemplator-gh-permissions`
+**Base:** `development`
+**Commit:** `b5d998c fix(contemplator): add gh* bash permission and replace github/search_issues (#261)`
+**Review Type:** Multi-model synthesis (Qwen + Kimi + GLM)
+**Date:** 2026-04-30
+
+---
+
+## Synthesis Overview
+
+This PR is a minimal, single-file fix that unblocks the Opencode Contemplator agent by adding `"gh*": "allow"` to its `permission.bash` block and replacing the unavailable Copilot-style `github/search_issues` tool call with equivalent `gh issue list` / `gh pr list` CLI commands. All three models agree the change is correct, tightly scoped, and ready for merge. There are no Critical findings. Two Suggestions reached unanimous or majority consensus, and one Warning was raised by a single model regarding a consistency gap with the `--repo` flag pattern used elsewhere.
+
+**Model Agreement Score:** 8/10 — near-universal agreement on overall assessment and the `--limit` suggestion. Divergence is limited to one false-positive Warning (Kimi, stale-text misread) and one valid but singular Warning (GLM, `--repo` consistency).
+
+---
+
+## Individual Report Summaries
+
+| Model | Overall Assessment | Unique Focus Areas | Critical Count | Warning Count |
+| ----- | ------------------ | ------------------ | -------------- | ------------- |
+| Kimi  | Ready for merge. Identified prose/command mismatch around "last 30 days" (false positive — text already updated in PR). Raised `--limit` suggestion and runtime divergence concern. | Prose intent mismatch (stale text); capability description mismatch | 0 | 1 |
+| Qwen  | Ready for merge. Focused on `--limit` suggestion and runtime divergence. Did not flag any warning-level issues. | None unique — aligned with Kimi on core suggestions | 0 | 0 |
+| GLM   | Ready for merge. Performed full structural checklist. Flagged missing `--repo` flag as Warning. Noted planner.md and shared-file out-of-scope pattern. | Missing `--repo` flag; planner.md gotcha | 0 | 1 |
+
+---
+
+## Consensus Findings
+
+### ★★★ Unanimous Findings (All Three Models Agree)
+
+```
+[U-S-01] Add explicit --limit to gh list commands for better signal coverage
+Severity: Suggestion
+Category: Correctness
+File: .opencode/agents/contemplator.md
+Lines: 82
+Detail: All three models agree that `gh issue list` and `gh pr list` default to 30 results. For an active repository, 30 closed issues may not provide enough signal to detect meaningful patterns over the contemplation window. The old `github/search_issues` approach also had implicit limits, but the `gh` CLI exposes `--limit`, making the constraint explicit and adjustable.
+Models: Qwen ✓ Kimi ✓ GLM ✓
+Suggestion: Append `--limit 100` to each of the three `gh` commands in Phase 2, step 2:
+  gh issue list --state closed --limit 100 --json number,title,state,closedAt
+  gh issue list --state open --limit 100 --json number,title,state
+  gh pr list --state open --limit 100 --json number,title,state
+```
+
+### ★★☆ Majority Findings (Two of Three Models Agree)
+
+```
+[M-S-01] Runtime-specific Phase 2 divergence across contemplator variants creates maintenance burden
+Severity: Suggestion
+Category: Style
+File: .opencode/agents/contemplator.md / .github/agents-openrouter/contemplator.agent.md / .github/agents-copilot/contemplator.agent.md
+Lines: general (cross-file)
+Detail: Kimi and Qwen both note that the Opencode contemplator now uses `gh` CLI commands for Phase 2 GitHub research, while the OpenRouter and Copilot variants still instruct `github/search_issues`. This divergence is technically correct because those runtimes have `github/*` tools available while Opencode does not, but it means future maintainers updating Phase 2 logic must apply changes in three places with different syntax.
+Models: Qwen ✓ Kimi ✓ GLM ✗
+Dissenting view: GLM does not raise this finding; instead, GLM flags the same underlying dual-runtime issue in a different agent (`planner.md`) and shared files. GLM's structural checklist confirmed the companion files are correct for their respective runtimes.
+Suggestion: This is noted as a minor maintainability concern only — no action required in this PR. If desired, a future cleanup issue could consider standardizing all contemplator variants on `gh` CLI commands (available everywhere) or adding a comment near Phase 2 noting the runtime-specific divergence.
+```
+
+### ★☆☆ Singular Findings (Only One Model Reported)
+
+```
+[S-W-01] Missing --repo OWNER/REPO flag in Phase 2 gh commands despite reading repo.md
+Severity: Warning
+Category: Correctness
+File: .opencode/agents/contemplator.md
+Lines: 49, 82
+Detail: GLM flags that the "Repository Identity" section instructs the agent to read `.github/notes/repo.md` for `OWNER` and `REPO`, but the three `gh` CLI commands in Phase 2 omit the `--repo OWNER/REPO` flag that the sprint-runner agent consistently uses (e.g., `gh issue list --repo OWNER/REPO --state open`). This creates a consistency gap: an instruction-following agent may be confused about why it read values it never uses, and if the agent runs from a directory other than the repo root, `gh` will fail to auto-detect the repository. The typical Opencode execution context is the repo root (where auto-detection works), so the impact is low-probability.
+Model: GLM
+Assessment: The finding is valid — the inconsistency with sprint-runner is real and the unused OWNER/REPO variables are a genuine instruction drift. However, `gh` auto-detects the repository from the working directory's git remote, and the agent is virtually always invoked from the repo root. Rating as Warning is appropriate given the potential for confusion, but it is not blocking.
+Suggestion: Add `--repo OWNER/REPO` to all three `gh` commands in Phase 2, matching the sprint-runner pattern:
+  gh issue list --repo OWNER/REPO --state closed --json number,title,state,closedAt
+  gh issue list --repo OWNER/REPO --state open --json number,title,state
+  gh pr list --repo OWNER/REPO --state open --json number,title,state
+```
+
+```
+[S-S-01] Capability description still refers to "GitHub API" while agent uses gh CLI
+Severity: Suggestion
+Category: Documentation
+File: .opencode/agents/contemplator.md
+Lines: 45
+Detail: Kimi notes that the capabilities bullet list says "GitHub API — for issue/PR activity." However, the `tools:` array contains no `github/*` entries, and the Phase 2 instructions now use `gh` CLI commands rather than GitHub MCP tool calls. This creates a minor mismatch between described capability and actual mechanism.
+Model: Kimi
+Assessment: Genuine minor documentation drift. The `gh` CLI is a wrapper around the GitHub API, so the intent is not wrong, but the description should reflect the actual runtime mechanism.
+Suggestion: Update the bullet to "GitHub CLI (`gh`) — for issue/PR activity" to accurately reflect the runtime mechanism.
+```
+
+```
+[S-S-02] planner.md and shared files still reference github/* tools without gh* permission
+Severity: Suggestion
+Category: Documentation
+File: .opencode/agents/planner.md / .github/agents/_shared/repo-context.md / .github/agents/_shared/audit-process.md
+Lines: general (out-of-scope files)
+Detail: GLM observes that `planner.md` still contains prose "Before making any `github/*` tool call" and lists "GitHub API — for issue/PR context" as a capability, but its `permission.bash` block lacks `"gh*": "allow"` — the same root cause that prompted issue #261 for the contemplator. Additionally, `_shared/repo-context.md` and `_shared/audit-process.md` still reference `github/*` tool calls, which are correct for the Copilot runtime but misleading for Opencode agents that include those shared files.
+Model: GLM
+Assessment: Valid observation, but the files are **not in this PR's diff**. The finding is out-of-scope for PR #270. It should be tracked in a follow-up issue rather than blocking this merge.
+Suggestion: File a follow-up issue to audit all `.opencode/agents/*.md` files for the same pattern (body text referencing `github/*` tools without `gh*` bash permission) and update shared files to accommodate both runtimes.
+Resolution: Downgraded to out-of-scope — file not changed in this PR. Excluded from consensus counts.
+```
+
+---
+
+## Divergence Analysis
+
+```
+[D-01] Topic: Does the Phase 2 prose still claim "last 30 days"?
+Kimi says: The introductory prose at line 79 still instructs the agent to "find issues closed in the last 30 days and any currently open issues or PRs," creating a Warning-level mismatch because the replaced `gh issue list` command has no date filter.
+Qwen says: Nothing about "last 30 days" — considers the commands correct and equivalent.
+GLM says: Acknowledges the semantic change from "issues closed in the last 30 days" (old text) to "recently closed issues" (new text), and considers the behavior functionally equivalent because `closedAt` is included in the JSON output enabling agent-side date filtering.
+Assessment: Kimi misread the diff and flagged the old text. The PR already changed the prose from "issues closed in the last 30 days" to "recently closed issues," deliberately removing the specific time-bound claim to avoid a command-level mismatch. The `gh` command returns the most recent 30 closed issues in reverse chronological order, which satisfies the "recently closed" intent. This is not a Warning.
+Resolution: Kimi [W-01] is a false positive caused by stale-text misread. Downgraded to "already addressed — text updated in this PR." Excluded from consensus counts.
+```
+
+```
+[D-02] Topic: Should gh commands include --repo OWNER/REPO?
+Kimi says: No mention of missing `--repo` flag. Considers commands syntactically correct.
+Qwen says: No mention; considers commands syntactically correct and equivalent.
+GLM says: Warning — the commands omit `--repo OWNER/REPO` despite the agent reading repo.md for those values, creating inconsistency with sprint-runner's pattern and potential failure if CWD is not the repo root.
+Assessment: GLM's finding is valid. Sprint-runner consistently uses `--repo OWNER/REPO` in equivalent commands. The contemplator instructs the agent to read OWNER and REPO but never uses them. However, `gh` auto-detects the repo from the current directory's git remote, and the typical Opencode execution context is the repo root. The impact is low-probability but the inconsistency is real.
+Resolution: Retain as Singular Warning [S-W-01].
+```
+
+```
+[D-03] Topic: Severity of default limit truncation
+Kimi says: Suggestion
+Qwen says: Suggestion
+GLM says: Suggestion
+Assessment: No divergence. All three models independently agree this is a Suggestion, not a Warning or Critical.
+Resolution: Unanimous consensus [U-S-01].
+```
+
+---
+
+## Recommended Actions (Prioritized)
+
+1. **[U-S-01] ★★★ Consider:** Add `--limit 100` to all three `gh` list commands in Phase 2, step 2 (Suggestion — all models agree).
+2. **[M-S-01] ★★☆ Consider:** Document the runtime-specific Phase 2 divergence across contemplator variants as a known maintenance concern (Suggestion — 2/3 models agree).
+3. **[S-W-01] ★☆☆ Fix:** Add `--repo OWNER/REPO` to all three `gh` commands in Phase 2, matching the sprint-runner pattern (Warning — 1 model only).
+4. **[S-S-01] ★☆☆ Consider:** Update the capabilities bullet from "GitHub API" to "GitHub CLI (`gh`)" (Suggestion — 1 model only).
+5. **[S-S-02] ★☆☆ Track:** File a follow-up issue to audit `planner.md` and shared process files for the same `github/*` vs `gh*` mismatch (out-of-scope — 1 model only).
+
+---
+
+## Writing Review Notes
+
+## Synthesized Code Review — 2026-04-30
+
+**Review Type:** Multi-model synthesis (Qwen + Kimi + GLM)
+**Branch:** fix/issue-261-contemplator-gh-permissions
+**Model Agreement Score:** 8/10
+**Overall Assessment:** Clean — all three models recommend merge. One singular Warning and several Suggestions remain, none blocking.
+
+### Finding Counts by Consensus
+
+| Consensus         | Critical | Warning | Suggestion |
+| ----------------- | -------- | ------- | ---------- |
+| ★★★ Unanimous     | 0        | 0       | 1          |
+| ★★☆ Majority      | 0        | 0       | 1          |
+| ★☆☆ Singular      | 0        | 1       | 2          |
+
+### Key Findings
+
+- [U-S-01] Add `--limit 100` to `gh issue list` and `gh pr list` commands for better signal coverage (★★★)
+- [M-S-01] Runtime-specific Phase 2 divergence across contemplator variants is a maintenance concern (★★☆)
+- [S-W-01] Missing `--repo OWNER/REPO` in contemplator Phase 2 commands despite reading repo.md (★☆☆)
+- [S-S-01] Capability description still says "GitHub API" while runtime mechanism is `gh` CLI (★☆☆)
+- [S-S-02] planner.md and shared files still reference `github/*` tools without `gh*` permission — out-of-scope (★☆☆)
+
+### Divergences
+
+- [D-01] **"Last 30 days" prose mismatch** — Kimi raised a Warning based on the old pre-PR text; the PR already changed the phrase to "recently closed issues." Downgraded to false positive.
+- [D-02] **`--repo` flag consistency** — GLM flagged a valid inconsistency with sprint-runner; Kimi and Qwen did not mention it. Retained as singular Warning.
+- [D-03] **`--limit` severity** — All three models independently agree the default limit issue is a Suggestion. No divergence.

--- a/.opencode/agents/contemplator.md
+++ b/.opencode/agents/contemplator.md
@@ -42,7 +42,7 @@ You have direct access to:
 
 - File system (read/search) — for codebase scanning and notes
 - Shell commands — for git log, dependency checks, route lists
-- GitHub API — for issue/PR activity
+- GitHub CLI (`gh`) — for issue/PR activity
 - Web/Context7 — for external documentation research
 - File editing — read-only; cannot create or modify files
 - `todo` — track contemplation progress
@@ -79,7 +79,7 @@ See `.github/instructions/chromadb.instructions.md` for standard query patterns 
 Build a picture of what has changed recently:
 
 1. **Git log**: run `git log --oneline -20` to see the last 20 commits. Note the scope and cadence of recent work.
-2. **Recent GitHub issues**: run `gh issue list --state closed --json number,title,state,closedAt` to find recently closed issues, `gh issue list --state open --json number,title,state` for open issues, and `gh pr list --state open --json number,title,state` for open PRs. Note patterns — are certain areas repeatedly touched?
+2. **Recent GitHub issues**: run `gh issue list --repo OWNER/REPO --state closed --limit 100 --json number,title,state,closedAt` to find recently closed issues, `gh issue list --repo OWNER/REPO --state open --limit 100 --json number,title,state` for open issues, and `gh pr list --repo OWNER/REPO --state open --limit 100 --json number,title,state` for open PRs. Note patterns — are certain areas repeatedly touched?
 3. **Uncommitted changes**: run `git status` — are there unstaged or untracked files that suggest work in progress?
 4. **Dependency freshness**: check for outdated dependencies using `pip list --outdated`. Flag anything significantly behind or with known vulnerabilities.
 

--- a/.opencode/agents/contemplator.md
+++ b/.opencode/agents/contemplator.md
@@ -20,6 +20,7 @@ permission:
     "pip*": "allow"
     "python*": "allow"
     "echo*": "allow"
+    "gh*": "allow"
   task:
     "*": "deny"
     "synthesizing-researcher": "allow"
@@ -48,7 +49,7 @@ You have direct access to:
 
 ## Repository Identity
 
-Before making any `github/*` tool call, read `.github/notes/repo.md` and use `OWNER` and `REPO` from that file. If the file is missing, run `git remote get-url origin` to parse and record them there first.
+Before running `gh` commands, read `.github/notes/repo.md` to confirm `OWNER` and `REPO`. If the file is missing, run `git remote get-url origin` to parse and record them there first.
 
 ## Contemplation Process
 
@@ -78,7 +79,7 @@ See `.github/instructions/chromadb.instructions.md` for standard query patterns 
 Build a picture of what has changed recently:
 
 1. **Git log**: run `git log --oneline -20` to see the last 20 commits. Note the scope and cadence of recent work.
-2. **Recent GitHub issues**: use `github/search_issues` to find issues closed in the last 30 days and any currently open issues or PRs. Note patterns — are certain areas repeatedly touched?
+2. **Recent GitHub issues**: run `gh issue list --state closed --json number,title,state,closedAt` to find recently closed issues, `gh issue list --state open --json number,title,state` for open issues, and `gh pr list --state open --json number,title,state` for open PRs. Note patterns — are certain areas repeatedly touched?
 3. **Uncommitted changes**: run `git status` — are there unstaged or untracked files that suggest work in progress?
 4. **Dependency freshness**: check for outdated dependencies using `pip list --outdated`. Flag anything significantly behind or with known vulnerabilities.
 


### PR DESCRIPTION
## Summary

Fixes the Contemplator agent's Phase 2 GitHub research workflow so it functions under the Opencode runtime.

## Changes

- Added `"gh*": "allow"` to `permission.bash` in `contemplator.md` frontmatter.
- Replaced the Copilot-only `github/search_issues` tool reference with equivalent `gh` CLI commands (`gh issue list`, `gh pr list`).
- Updated the Repository Identity section to reference `gh` commands instead of `github/*` tool calls.
- Verified no other Copilot-prefixed tool names remain in the body.

## Closes

Closes #261
Closes audit finding `[U-W-03]` from 2026-04-30 synthesized audit.

## Acceptance criteria

- [x] `contemplator.md` `permission.bash` includes `"gh*": "allow"`.
- [x] `contemplator.md` body replaces `github/search_issues` with equivalent `gh` CLI commands.
- [x] No other Copilot-prefixed tool names remain in the contemplator body.