### PR TITLE
fix(consistency-checker): pass real chapter outline to prompt

### DIFF
--- a/.github/notes/reflections/issue-293-stale-feature-doc-outline-variable.md
+++ b/.github/notes/reflections/issue-293-stale-feature-doc-outline-variable.md
@@ -1,0 +1,41 @@
+---
+date: "2026-05-02"
+issue: 293
+pr: 305
+category: instruction
+targets:
+  - "docs/features/direct-generation-prompts.md"
+severity: minor
+status: active
+---
+
+## ConsistencyCheckerAgent `outline` variable description stale after PR #305
+
+### Finding
+
+After PR #305 plumbed real outline data into `ConsistencyCheckerAgent`, the feature doc
+`docs/features/direct-generation-prompts.md` still described the `outline` computed variable as:
+
+> `outline` — currently empty string (reserved for future use)
+
+That comment predated the fix. The variable is no longer empty — it is now populated by
+`_extract_outline_text(outline_result, chapter_number)`, which prefers `chapter_details[N-1]`,
+falls back to `chapter_outlines[N-1]`, and returns `""` only when neither is present.
+
+### Observation
+
+"Reserved for future use" annotations in feature docs become stale the moment the feature ships.
+When the Documenter is not dispatched (or a narrowly-scoped fix is merged without a doc pass),
+these markers persist indefinitely. Reviewers may then cite them as architecture references and
+incorrectly conclude the field is unused.
+
+### Suggested Improvement
+
+Update the `outline` bullet under ConsistencyCheckerAgent in `docs/features/direct-generation-prompts.md`
+to describe actual behaviour: populated by `_extract_outline_text()` from `OutlineResult`, with
+`chapter_details` preferred over `chapter_outlines`, empty string when neither is available.
+
+### Action Taken
+
+Applied: updated the `outline` variable description in `docs/features/direct-generation-prompts.md`
+to reflect the real behaviour introduced in PR #305.

--- a/docs/features/direct-generation-prompts.md
+++ b/docs/features/direct-generation-prompts.md
@@ -122,7 +122,7 @@ Each of the five direct-generation prompts is loaded by a specific Python-native
 - **Computed variables:**
   - `chapter_content` — the raw chapter text
   - `story_name`, `chapter_number` — story identifier and chapter index
-  - `outline` — currently empty string (reserved for future use)
+  - `outline` — populated by `_extract_outline_text(outline_result, chapter_number)`: prefers `chapter_details[N-1]` (JSON-serialised), falls back to `chapter_outlines[N-1]`, returns `""` when neither is present
 - **User message:** `{"role": "user", "content": "Return the JSON consistency report."}`
 - **Output parsing:** `_extract_consistency_result()` first attempts the new direct-generation JSON format (`{"issues": [...], "has_critical_findings": bool}`), then falls back to the legacy format (`wiki_lint_findings`, `semantic_findings`, `cross_chapter_findings`). It also strips JSON markdown fences automatically.
 - **Returns:** A dict with `issues` (list) and `passed` (bool).

--- a/src/presentation/agents/consistency_checker.py
+++ b/src/presentation/agents/consistency_checker.py
@@ -6,6 +6,7 @@ import json
 from typing import Any, AsyncIterator, cast
 
 from application.interfaces.model_provider import ModelProvider
+from application.pipeline.handoffs import OutlineResult
 from domain.value_objects.model_config import ModelConfig
 from infrastructure.prompts.prompt_loader import PromptLoader
 from presentation.pipeline_primitives import (
@@ -116,6 +117,34 @@ def _extract_consistency_result(text: str) -> dict[str, Any]:
     return {"issues": issues, "passed": passed}
 
 
+def _extract_outline_text(
+    outline_result: OutlineResult | None,
+    chapter_number: int,
+) -> str:
+    if outline_result is None:
+        return ""
+
+    chapter_index = chapter_number - 1
+
+    try:
+        chapter_details = outline_result.chapter_details[chapter_index]
+    except IndexError:
+        chapter_details = None
+
+    if chapter_details:
+        return json.dumps(chapter_details, ensure_ascii=False, indent=2)
+
+    try:
+        chapter_outline = outline_result.chapter_outlines[chapter_index]
+    except IndexError:
+        chapter_outline = None
+
+    if chapter_outline:
+        return json.dumps(chapter_outline, ensure_ascii=False, indent=2)
+
+    return ""
+
+
 class ConsistencyCheckerAgent:
     def __init__(
         self,
@@ -135,6 +164,7 @@ class ConsistencyCheckerAgent:
         story_name: str,
         chapter_number: int,
         chapter_content: str,
+        outline_result: OutlineResult | None = None,
     ) -> dict[str, Any]:
         """Check chapter for consistency issues.
 
@@ -149,13 +179,14 @@ class ConsistencyCheckerAgent:
         )
 
         loader = self._loader
+        outline = _extract_outline_text(outline_result, chapter_number)
         system_prompt = loader.load_prompt(
             "chapter_review/consistency_check_direct",
             variables={
                 "chapter_content": chapter_content,
                 "story_name": story_name,
                 "chapter_number": str(chapter_number),
-                "outline": "",
+                "outline": outline,
             },
         )
 

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -562,7 +562,10 @@ async def _continue_pipeline(
                     return state
 
                 consistency_result = await consistency_agent.run(
-                    state.story_name, chapter_number, draft.content
+                    state.story_name,
+                    chapter_number,
+                    draft.content,
+                    outline_result=outline_result,
                 )
                 if not consistency_result["passed"]:
                     await bus.emit(

--- a/tests/unit/test_consistency_checker.py
+++ b/tests/unit/test_consistency_checker.py
@@ -13,6 +13,7 @@ from presentation.agents.consistency_checker import (
     ConsistencyCheckerAgent,
     _extract_consistency_result,
 )
+from application.pipeline.handoffs import OutlineResult
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
 
 
@@ -269,3 +270,161 @@ async def test_run_does_not_truncate_chapter_content() -> None:
 
     assert captured["chapter_content"] == long_chapter
     assert len(captured["chapter_content"]) == 20_000
+
+
+@pytest.mark.asyncio
+async def test_consistency_checker_outline_plumbed() -> None:
+    captured: dict[str, str] = {}
+    outline_result = OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[{"chapter": 1, "summary": "The hero departs"}],
+        summary="summary",
+        genre="fantasy",
+        themes=["courage"],
+    )
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if variables is not None:
+            captured["outline"] = variables["outline"]
+        return "system prompt"
+
+    response = '{"has_critical_findings": false, "issues": []}'
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = ConsistencyCheckerAgent(
+        provider=_ProviderStub([response]),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        side_effect=capture_prompt,
+    ):
+        await agent.run(
+            "test-story",
+            1,
+            "chapter content",
+            outline_result=outline_result,
+        )
+
+    bus.close()
+
+    assert captured["outline"] != ""
+
+
+@pytest.mark.asyncio
+async def test_consistency_checker_outline_prefers_chapter_details() -> None:
+    captured: dict[str, str] = {}
+    outline_result = OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[{"summary": "fallback"}],
+        summary="summary",
+        genre="fantasy",
+        themes=["courage"],
+        chapter_details=[{"detail": "hero fights dragon"}],
+    )
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if variables is not None:
+            captured["outline"] = variables["outline"]
+        return "system prompt"
+
+    response = '{"has_critical_findings": false, "issues": []}'
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = ConsistencyCheckerAgent(
+        provider=_ProviderStub([response]),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        side_effect=capture_prompt,
+    ):
+        await agent.run(
+            "test-story",
+            1,
+            "chapter content",
+            outline_result=outline_result,
+        )
+
+    bus.close()
+
+    assert "hero fights dragon" in captured["outline"]
+
+
+@pytest.mark.asyncio
+async def test_consistency_checker_outline_fallback_when_no_details() -> None:
+    captured: dict[str, str] = {}
+    outline_result = OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[{"summary": "fallback text"}],
+        summary="summary",
+        genre="fantasy",
+        themes=["courage"],
+        chapter_details=[],
+    )
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if variables is not None:
+            captured["outline"] = variables["outline"]
+        return "system prompt"
+
+    response = '{"has_critical_findings": false, "issues": []}'
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = ConsistencyCheckerAgent(
+        provider=_ProviderStub([response]),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        side_effect=capture_prompt,
+    ):
+        await agent.run(
+            "test-story",
+            1,
+            "chapter content",
+            outline_result=outline_result,
+        )
+
+    bus.close()
+
+    assert "fallback text" in captured["outline"]
+
+
+@pytest.mark.asyncio
+async def test_consistency_checker_outline_empty_when_no_outline_result() -> None:
+    captured: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if variables is not None:
+            captured["outline"] = variables["outline"]
+        return "system prompt"
+
+    response = '{"has_critical_findings": false, "issues": []}'
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = ConsistencyCheckerAgent(
+        provider=_ProviderStub([response]),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        side_effect=capture_prompt,
+    ):
+        await agent.run("test-story", 1, "chapter content")
+
+    bus.close()
+
+    assert captured["outline"] == ""


### PR DESCRIPTION
## Summary

`ConsistencyCheckerAgent` was passing `outline=""` to the `chapter_review/consistency_check_direct` prompt, preventing it from catching contradictions between chapter prose and the planned events, character focus, or setting.

This fix reads the chapter-specific outline data from `OutlineResult` and injects it as the `{outline}` template variable.

## Closes
Closes #293

## Changes
- `_extract_outline_text(outline_result, chapter_number)` helper added — prefers `chapter_details[chapter_number - 1]`, falls back to `chapter_outlines[chapter_number - 1]`, returns `""` when absent
- `ConsistencyCheckerAgent.run()` accepts `outline_result: OutlineResult | None = None` and calls the helper before prompt load
- Orchestrator call site updated to pass `outline_result=outline_result`
- 4 new regression tests in `tests/unit/test_consistency_checker.py` (`test_consistency_checker_outline_plumbed`, `_prefers_chapter_details`, `_fallback_when_no_details`, `_empty_when_no_outline_result`)

## Plan

### Task checklist
- [x] Add `_extract_outline_text` helper with fallback logic
- [x] Update `ConsistencyCheckerAgent.run()` signature and body
- [x] Update call site in orchestrator
- [x] Add 4 regression tests
- [x] All 42 relevant unit tests passing
- [x] Linting clean (`ruff check` / `ruff format`)

### Verification
42 tests passed (0 failed, 0 skipped) across `test_consistency_checker.py` and `test_orchestrator.py`. Linting clean.
