### PR TITLE
feat(final-editor): add prose_scrub + voice_consistency_pass diagnostic stage before edit

### DIFF
--- a/.github/notes/reflections/archive/issue-294-wiki-bootstrap-key-files-stale-2026-05-02.md
+++ b/.github/notes/reflections/archive/issue-294-wiki-bootstrap-key-files-stale-2026-05-02.md
@@ -1,0 +1,46 @@
+---
+date: "2026-05-02"
+issue: 294
+pr: 306
+category: instruction
+targets:
+  - "docs/features/wiki-maintainer.md"
+severity: minor
+---
+
+## `wiki-maintainer.md` Key Files table omits `bootstrap_wiki_from_story()` entry point
+
+### Finding
+
+After PR #306 added `bootstrap_wiki_from_story()` as a public programmatic API in
+`src/tools/wiki_extract.py` (exported in `__all__`), the Key Files table in
+`docs/features/wiki-maintainer.md` still described that file as:
+
+> Extraction pipeline and programmatic `update_wiki_from_chapter()` API used after each chapter
+
+The description makes no mention of the new bootstrap entry point, giving readers the
+impression that the file only handles post-chapter incremental updates. Additionally,
+`tests/unit/test_wiki_bootstrap.py` (5 tests covering the new bootstrap function) is
+absent from the Key Files table, whereas the companion `tests/unit/test_wiki_maintainer.py`
+is listed.
+
+### Observation
+
+When a file gains a second public entry point, the Key Files table description becomes
+misleading rather than merely incomplete — it actively directs readers toward only one
+mode of use. The pattern "stale-description-after-adding-API" has recurred previously
+(issue #293: `outline` computed variable described as reserved after it was populated).
+Feature docs should be updated as part of the same PR that adds the API.
+
+### Suggested Improvement
+
+1. Update the `src/tools/wiki_extract.py` row in the Key Files table to mention both
+   programmatic entry points.
+2. Add a `tests/unit/test_wiki_bootstrap.py` row to the Key Files table.
+
+### Action Taken
+
+Applied:
+- Updated `src/tools/wiki_extract.py` description in Key Files table to mention both
+  `bootstrap_wiki_from_story()` and `update_wiki_from_chapter()`.
+- Added `tests/unit/test_wiki_bootstrap.py` row to Key Files table.

--- a/.github/notes/reflections/issue-295-final-editor-pass-types-stale.md
+++ b/.github/notes/reflections/issue-295-final-editor-pass-types-stale.md
@@ -1,0 +1,72 @@
+---
+date: "2026-05-02"
+issue: 295
+pr: 307
+category: skill
+targets:
+  - "prompts/skills/final-edit/SKILL.md"
+  - "prompts/agents/story-orchestrator.md"
+  - "prompts/agents/final-editor.md"
+severity: minor
+---
+
+## `final-editor` prose-scrub diagnostics absent from SKILL.md Pass Types table and Phase 9 spec
+
+### Finding
+
+After PR #307 wired `enable_scrubbing` into `FinalEditorAgent` as a two-stage diagnostic
+flow, two documents still omit the change:
+
+1. `prompts/skills/final-edit/SKILL.md` — the Pass Types table lists "Prose Scrub" with
+   only `prose-scrubber` as the agent. `final-editor` now runs prose-scrub diagnostics
+   as Stage 1a when `settings.enable_scrubbing` is `true`, but the table makes no mention
+   of this.
+
+2. `prompts/agents/story-orchestrator.md` — Phase 9 dispatch notes do not mention
+   `enable_scrubbing` or the Stage 1a/1b pre-pass. An agent following the orchestrator
+   prompt would dispatch `final-editor` without knowing that passing
+   `config.generation.enable_scrubbing: true` activates the diagnostic flow.
+
+A third document (`prompts/agents/final-editor.md`) is the OpenCode workflow spec. Its
+Workflow section has no `enable_scrubbing` conditional steps (Stage 1a prose scrub,
+Stage 1b voice pass). This is a larger structural change and is classified as major.
+
+### Observation
+
+The pattern from issue #294 (`stale-description-after-adding-API`) recurs: when a
+pipeline stage gains new optional behaviour gated by a config flag, the skill table and
+the orchestrator dispatch note often remain at the pre-feature baseline. Readers consulting
+only the SKILL.md or the orchestrator prompt would believe prose-scrub diagnostics are
+exclusively a Phase 7.5 concern (prose-scrubber subagent, not yet wired), unaware that
+`enable_scrubbing: true` already activates them in Phase 9.
+
+### Suggested Improvement
+
+**Minor (targets 1 and 2 — apply immediately):**
+
+1. `prompts/skills/final-edit/SKILL.md` — update the Prose Scrub row in the Pass Types
+   table to include `final-editor` as the Stage 1a agent when `enable_scrubbing: true`.
+2. `prompts/agents/story-orchestrator.md` — Phase 9 dispatch block: add a bullet noting
+   that `final-editor` runs prose-scrub and voice-consistency diagnostics (Stage 1a/1b)
+   before each chapter edit when `config.generation.enable_scrubbing` is `true`.
+
+**Major (target 3 — propose for approval):**
+
+3. `prompts/agents/final-editor.md` — add `enable_scrubbing` conditional steps 3a/3b to
+   the Workflow section so an OpenCode `final-editor` dispatch performs the Stage 1
+   diagnostic passes (load `prompts/final_edit/prose_scrub.md`, call model, collect
+   `prose_findings`; load `prompts/final_edit/voice_consistency_pass.md`, call model,
+   collect `voice_findings`) and injects them into the Stage 2 `edit_chapter_direct` call.
+   This is a structural addition to the workflow and could affect downstream OpenCode runs.
+
+### Action Taken
+
+Applied (minor):
+- Updated `prompts/skills/final-edit/SKILL.md` Prose Scrub row to list both
+  `prose-scrubber` and `final-editor` (Stage 1a, when `enable_scrubbing: true`).
+- Updated `prompts/agents/story-orchestrator.md` Phase 9 dispatch block to mention
+  the `enable_scrubbing` Stage 1a/1b diagnostic pre-pass.
+
+Proposed (major):
+- `prompts/agents/final-editor.md` Workflow — add `enable_scrubbing` Stage 1a/1b steps.
+  Awaiting approval before applying.

--- a/docs/features/prose-quality-passes.md
+++ b/docs/features/prose-quality-passes.md
@@ -4,24 +4,25 @@
 
 ## Overview
 
-Issue #121 and PR #128 introduced two prose-quality surfaces: `prose-scrubber` and `final-editor`. The current Python-native orchestrator slice only wires `final-editor`. Issue #185 / PR #198 replaces the old Phase 9 stub with a real `FinalEditorAgent` execution path in `src/presentation/orchestrator.py`.
+Issue #121 and PR #128 introduced two prose-quality surfaces: `prose-scrubber` and `final-editor`. Issue #185 / PR #198 replaced the old Phase 9 stub with a real `FinalEditorAgent` execution path in `src/presentation/orchestrator.py`, and issue #295 / PR #307 wired `enable_scrubbing` into that agent as a diagnostic pre-pass.
 
 `final-editor` now runs after the chapter loop and before assembly. It sends one approved chapter at a time through a streamed LLM edit pass, preserves the original chapter if the model returns empty output, updates `state.approved_chapters`, and writes `stories/<name>/output/story_edited.md` before `story.md` is assembled.
 
-`prose-scrubber` prompt assets still exist, but that phase is not currently invoked by `src/presentation/orchestrator.py`. Both passes remain optional at the configuration layer, and neither replaces the chapter approval gate.
+When `generation.enable_scrubbing` is `true`, `FinalEditorAgent` runs two Stage 1 diagnostics before the chapter polish pass: `prompts/final_edit/prose_scrub.md` produces `prose_findings`, and `prompts/final_edit/voice_consistency_pass.md` produces `voice_findings`. Stage 2 then injects both findings into `prompts/final_edit/edit_chapter_direct.md`. When `enable_scrubbing` is `false`, Stage 1 is skipped and Stage 2 receives empty strings, preserving the earlier final-edit behavior. Neither path replaces the chapter approval gate.
 
 ## Pipeline Placement
 
 | Pass | Agent | Pipeline Position | Trigger | Scope |
 |------|-------|-------------------|---------|-------|
-| Prose Scrub | `prose-scrubber` | Not wired in current orchestrator slice | `generation.enable_scrubbing: true` | Sentence and paragraph |
-| Final Edit | `final-editor` | Phase 9, after chapter-loop and before assembly | `generation.enable_final_edit` not explicitly `false` | One accepted chapter at a time |
+| Prose Scrub Diagnostics | `final-editor` | Phase 9 Stage 1a, before chapter polish | `generation.enable_final_edit` not explicitly `false` and `generation.enable_scrubbing: true` | Sentence and paragraph findings |
+| Voice Consistency Diagnostics | `final-editor` | Phase 9 Stage 1b, before chapter polish | `generation.enable_final_edit` not explicitly `false` and `generation.enable_scrubbing: true` | Voice and prior-chapter consistency findings |
+| Final Edit | `final-editor` | Phase 9 Stage 2, after diagnostics and before assembly | `generation.enable_final_edit` not explicitly `false` | One accepted chapter at a time |
 
 The passes are complementary:
 
 - `quality-reviewer` is still a separate concept from prose polishing.
-- `prose-scrubber` remains a documented prompt surface, not an active orchestrator phase.
-- `final-editor` is the only prose-quality pass currently executed by the Python-native orchestrator.
+- `prose-scrub` and `voice-consistency` prompts now run as internal `final-editor` diagnostics, not as standalone orchestrator phases.
+- `final-editor` remains the only prose-quality phase directly invoked by the Python-native orchestrator.
 
 ## User Guide
 
@@ -33,19 +34,21 @@ generation:
   enable_final_edit: true
 ```
 
-Current behavior in `src/presentation/orchestrator.py`:
+Current behavior in `src/presentation/orchestrator.py` and `src/presentation/agents/final_editor.py`:
 
 - `enable_final_edit` skips Phase 9 only when the value is explicitly `false`
 - if the key is missing from the raw `generation` config mapping, the orchestrator treats final-edit as enabled
-- `enable_scrubbing` is not currently consulted by the active orchestrator code path
+- `enable_scrubbing: true` runs Stage 1a/1b diagnostic prompts before the chapter polish pass
+- `enable_scrubbing: false` skips those diagnostics and passes empty findings into the chapter polish prompt
+- `enable_scrubbing` has no effect if `enable_final_edit` skips Phase 9 entirely
 
 ## Developer Guide
 
 ### `prose-scrubber`
 
-`prose-scrubber` is not wired into `src/presentation/orchestrator.py` today. Keep its prompt assets and related docs as design/reference material until a future pipeline slice reconnects the phase.
+`prose-scrubber` is not a standalone orchestrator phase, but its prompt is now wired into `src/presentation/agents/final_editor.py` as Stage 1a of the final-edit flow.
 
-Because the active orchestrator never calls this pass, do not document `chapter_{N}_scrubbed` as a current runtime artifact of the Python-native path.
+The active runtime does not write a separate `chapter_{N}_scrubbed` artifact. The findings stay in-memory and flow into the Stage 2 chapter-polish prompt.
 
 ### `final-editor`
 
@@ -53,7 +56,10 @@ Because the active orchestrator never calls this pass, do not document `chapter_
 
 Operational details:
 
+- When `settings.enable_scrubbing` is `true`, loads `prompts/final_edit/prose_scrub.md` and gathers `prose_findings`
+- When `settings.enable_scrubbing` is `true`, loads `prompts/final_edit/voice_consistency_pass.md` and gathers `voice_findings`
 - Loads `prompts/final_edit/edit_chapter_direct.md` via `PromptLoader.load_prompt()`
+- Injects `{prose_findings}` and `{voice_findings}` into `edit_chapter_direct.md`
 - Uses the `chapter_writer` model role for the streaming edit pass
 - Emits one `WikiContextEvent` per chapter with phase `final-edit`
 - Sends one user message containing the chapter title and full chapter content
@@ -68,6 +74,7 @@ Operational details:
 
 | Agent | Tool | Purpose |
 |-------|------|---------|
+| `final-editor` | `PromptLoader` | Load `prompts/final_edit/prose_scrub.md` and `prompts/final_edit/voice_consistency_pass.md` when scrubbing is enabled |
 | `final-editor` | `PromptLoader` | Load `prompts/final_edit/edit_chapter_direct.md` |
 | `final-editor` | `ModelProvider.stream_text(...)` | Run one streamed edit pass per approved chapter |
 | `final-editor` | `TokenStreamBus` | Surface editing output tokens live |
@@ -78,13 +85,16 @@ Operational details:
 The current implementation relies on agent prompt instructions rather than a separate runtime skill loader. The active guardrails are:
 
 - Final-edit is optional and skips cleanly when disabled
+- Scrubbing diagnostics are optional and skip cleanly when disabled, passing empty findings into Stage 2
 - Empty model output must not erase accepted chapter content
 - The phase edits accepted chapter drafts only; it does not reopen approval gates
 - The current orchestrator writes one phase-level savepoint, not per-chapter final-edit checkpoints
 
 ### Key Files
 
-- `prompts/final_edit/edit_chapter_direct.md` — Phase 9 direct-generation prompt for manuscript polish
+- `prompts/final_edit/prose_scrub.md` — Stage 1a prose diagnostics prompt
+- `prompts/final_edit/voice_consistency_pass.md` — Stage 1b voice diagnostics prompt
+- `prompts/final_edit/edit_chapter_direct.md` — Stage 2 direct-generation prompt for manuscript polish with injected diagnostic findings
 - `prompts/agents/final-editor.md` — OpenCode/Copilot workflow specification (not used by the Python-native runtime)
 - `src/presentation/agents/final_editor.py` — streaming agent implementation and empty-output fallback
 - `src/presentation/orchestrator.py` — Phase 9 wiring, config flag check, `story_edited.md` write, and `final_edit_complete` savepoint
@@ -101,7 +111,7 @@ The current Python-native path mutates `state.approved_chapters`, writes one edi
 
 ### Testing
 
-`tests/unit/test_orchestrator.py` covers the active final-edit orchestration paths with `test_final_edit_phase_invokes_agent()` and `test_final_edit_phase_skipped_when_disabled()`.
+`tests/unit/test_final_editor_agent.py`, `tests/unit/test_final_editor.py`, and `tests/unit/test_orchestrator.py` cover the active final-edit flow, including scrub gating, prompt-variable handoff, and Phase 9 orchestration.
 
 - `prompts/final_edit/edit_chapter_direct.md`
 - `src/presentation/agents/final_editor.py`
@@ -111,7 +121,7 @@ The current Python-native path mutates `state.approved_chapters`, writes one edi
 
 | Setting | Location | Default | Effect |
 |---------|----------|---------|--------|
-| `enable_scrubbing` | `generation` | `true` | Reserved for a future prose-scrubber reintegration; unused by the active orchestrator |
+| `enable_scrubbing` | `generation` | `true` | When final-edit runs, execute prose-scrub and voice-consistency diagnostics before chapter polish |
 | `enable_final_edit` | `generation` | `true` when the raw config key is absent in `orchestrator.py` | Enables or skips Phase 9 `final-editor` |
 
 ## Related
@@ -121,3 +131,5 @@ The current Python-native path mutates `state.approved_chapters`, writes one edi
 - [ADR 001: Hybrid Agent-Tool Architecture](../planning/adr/001-hybrid-agent-tool-architecture.md) — Depth-1 orchestration pattern
 - Issue #185 — Implement final-edit phase and add narrative-arc phase
 - PR #198 — Narrative-arc and final-edit implementation
+- Issue #295 — Final-editor scrub and voice diagnostics
+- PR #307 — Wire `enable_scrubbing` into `FinalEditorAgent`

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -757,7 +757,7 @@ All configuration lives in `config.yml` in the repository root. No secrets are r
 | `chapter_max_revisions` | 3 | Max chapter revision passes |
 | `enable_chapter_revisions` | true | Enable chapter revision loop |
 | `enable_final_edit` | false | Run final polish pass |
-| `enable_scrubbing` | true | Remove redundant phrases |
+| `enable_scrubbing` | true | When final edit runs, gather prose-scrub and voice-consistency diagnostics before chapter polish |
 | `strategy` | "outline-chapter" | Writing strategy |
 | `use_chunked_outline_generation` | true | Generate outline in chunks |
 | `outline_chunk_size` | 10 | Chapters per outline chunk |
@@ -871,6 +871,7 @@ generation:
 | `chapter_max_revisions` | 3 | Per-chapter quality loop |
 | `enable_outline_critique` | true | Iterative outline refinement |
 | `enable_final_edit` | true | Post-generation polish pass |
+| `enable_scrubbing` | true | Feed prose and voice diagnostics into final edit |
 | `debug` | false | Cleaner output |
 
 ### 8.3 Short Story Preset
@@ -887,7 +888,7 @@ generation:
   enable_chapter_revisions: false
   enable_outline_critique: false
   enable_final_edit: false
-  enable_scrubbing: true
+  enable_scrubbing: false
   use_chunked_outline_generation: false
   stream: true
   debug: true
@@ -897,7 +898,7 @@ generation:
 |---------|-------|-----|
 | `wanted_chapters` | 10 | Novella length |
 | `chapter_max_revisions` | 0 | No per-chapter revision loop |
-| `enable_scrubbing` | true | Still clean up redundant prose |
+| `enable_scrubbing` | false | Skip final-edit diagnostics because final edit is disabled |
 
 ### 8.4 Settings Change Summary Table
 
@@ -911,7 +912,7 @@ generation:
 | `enable_chapter_revisions` | false | true | false |
 | `enable_outline_critique` | false | true | false |
 | `enable_final_edit` | false | true | false |
-| `enable_scrubbing` | false | true | true |
+| `enable_scrubbing` | false | true | false |
 | `use_chunked_outline_generation` | false | true | false |
 
 ---
@@ -1697,7 +1698,7 @@ The pipeline resumes from the last completed phase savepoint. If chapter 7 was h
 
 **Fix:**
 1. Increase model temperature (add `?temperature=0.8` to the model URI in `config.yml`)
-2. Enable `enable_scrubbing: true` to remove redundant phrases
+2. Enable both `enable_final_edit: true` and `enable_scrubbing: true` to feed prose and voice diagnostics into the final chapter polish pass
 3. Enable `enable_chapter_revisions: true` and provide feedback like `revise Vary sentence openings; avoid starting three consecutive paragraphs with "She"`
 
 ### Scene generation pipeline issues

--- a/prompts/agents/story-orchestrator.md
+++ b/prompts/agents/story-orchestrator.md
@@ -340,6 +340,7 @@ If `enable_scrubbing: false`: skip this phase.
 
 If `enable_final_edit: true` in config:
 - Dispatch `final-editor` with: `story_name`, `chapter_numbers` (all assembled), `config`
+- When `config.generation.enable_scrubbing` is `true`, `final-editor` runs Stage 1a prose-scrub diagnostics and Stage 1b voice-consistency diagnostics before each chapter edit; findings are injected into the Stage 2 polish pass
 - `final-editor` returns: `chapters_processed`, `total_issues_found`, `total_revisions_made`
 - Log result
 

--- a/prompts/final_edit/edit_chapter_direct.md
+++ b/prompts/final_edit/edit_chapter_direct.md
@@ -16,6 +16,9 @@ You are a senior prose editor performing a final polish pass on a single chapter
 {chapter_text}
 </CHAPTER_TEXT>
 
+## Diagnostic Findings
+{prose_findings}{voice_findings}
+
 ## SCOPE OF WORK
 You may make the following types of changes:
 - **Wording refinement:** Improve word choice for clarity, rhythm, and precision.

--- a/prompts/skills/final-edit/SKILL.md
+++ b/prompts/skills/final-edit/SKILL.md
@@ -17,7 +17,7 @@ This skill defines the final prose-polish layer that runs after chapter drafting
 | Voice Consistency | Chapter | Post-assembly, per chapter | final-editor |
 | Pacing | Chapter | Post-assembly, per chapter | final-editor |
 | Cross-Chapter Coherence | Manuscript | Post-assembly | final-editor |
-| Prose Scrub | Sentence/Paragraph | Per-chapter post-generation | prose-scrubber |
+| Prose Scrub | Sentence/Paragraph | Phase 9 Stage 1a diagnostic when `enable_scrubbing: true` | `final-editor` (Stage 1a); `prose-scrubber` (Phase 7.5 standalone, not yet wired) |
 
 ## Output Format
 

--- a/src/presentation/agents/final_editor.py
+++ b/src/presentation/agents/final_editor.py
@@ -80,6 +80,54 @@ class FinalEditorAgent:
                 draft.chapter_number, ""
             )
 
+            if settings.enable_scrubbing:
+                prose_prompt = loader.load_prompt(
+                    "final_edit/prose_scrub",
+                    variables={
+                        "chapter_text": draft.content,
+                        "chapter_number": str(draft.chapter_number),
+                    },
+                )
+                messages = [
+                    {"role": "system", "content": prose_prompt},
+                    {"role": "user", "content": "Return the findings JSON."},
+                ]
+                prose_findings = ""
+                stream = cast(
+                    AsyncIterator[str],
+                    self.provider.stream_text(
+                        messages, model_config, seed=settings.seed
+                    ),
+                )
+                async for token in stream:
+                    prose_findings += token
+                prose_findings = prose_findings.strip()
+
+                voice_prompt = loader.load_prompt(
+                    "final_edit/voice_consistency_pass",
+                    variables={
+                        "chapter_text": draft.content,
+                        "prior_chapters_summary": prior_chapters_summary,
+                    },
+                )
+                messages = [
+                    {"role": "system", "content": voice_prompt},
+                    {"role": "user", "content": "Return the findings JSON."},
+                ]
+                voice_findings = ""
+                stream = cast(
+                    AsyncIterator[str],
+                    self.provider.stream_text(
+                        messages, model_config, seed=settings.seed
+                    ),
+                )
+                async for token in stream:
+                    voice_findings += token
+                voice_findings = voice_findings.strip()
+            else:
+                prose_findings = ""
+                voice_findings = ""
+
             system_prompt = loader.load_prompt(
                 "final_edit/edit_chapter_direct",
                 variables={
@@ -87,6 +135,8 @@ class FinalEditorAgent:
                     "chapter_number": str(draft.chapter_number),
                     "chapter_title": draft.title,
                     "prior_chapters_summary": prior_chapters_summary,
+                    "prose_findings": prose_findings,
+                    "voice_findings": voice_findings,
                 },
             )
 

--- a/tests/unit/test_final_editor.py
+++ b/tests/unit/test_final_editor.py
@@ -45,10 +45,10 @@ def _draft(n: int, content: str = "") -> ChapterDraft:
 @pytest.mark.asyncio
 async def test_prior_chapters_summary_excludes_future_chapters() -> None:
     """Chapter N must only see chapters 1..N-1 in prior_chapters_summary."""
-    captured: list[dict] = []
+    captured: list[tuple[str, dict]] = []
 
     def capture_prompt(name: str, variables: dict | None = None) -> str:
-        captured.append(dict(variables or {}))
+        captured.append((name, dict(variables or {})))
         return "system"
 
     bus = TokenStreamBus()
@@ -68,13 +68,18 @@ async def test_prior_chapters_summary_excludes_future_chapters() -> None:
         await agent.run("s", drafts, GenerationSettings.from_dict({}))
 
     bus.close()
+    edit_prompt_variables = [
+        variables
+        for name, variables in captured
+        if name == "final_edit/edit_chapter_direct"
+    ]
 
     # Chapter 1: no prior summaries.
-    assert captured[0]["prior_chapters_summary"] == ""
+    assert edit_prompt_variables[0]["prior_chapters_summary"] == ""
     # Chapter 2: only chapter 1.
-    assert "Chapter 1:" in captured[1]["prior_chapters_summary"]
-    assert "Chapter 3:" not in captured[1]["prior_chapters_summary"]
+    assert "Chapter 1:" in edit_prompt_variables[1]["prior_chapters_summary"]
+    assert "Chapter 3:" not in edit_prompt_variables[1]["prior_chapters_summary"]
     # Chapter 3: chapters 1 and 2 only.
-    assert "Chapter 1:" in captured[2]["prior_chapters_summary"]
-    assert "Chapter 2:" in captured[2]["prior_chapters_summary"]
-    assert "Chapter 3:" not in captured[2]["prior_chapters_summary"]
+    assert "Chapter 1:" in edit_prompt_variables[2]["prior_chapters_summary"]
+    assert "Chapter 2:" in edit_prompt_variables[2]["prior_chapters_summary"]
+    assert "Chapter 3:" not in edit_prompt_variables[2]["prior_chapters_summary"]

--- a/tests/unit/test_final_editor_agent.py
+++ b/tests/unit/test_final_editor_agent.py
@@ -1,0 +1,158 @@
+"""Unit tests for FinalEditorAgent scrubbing flow."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import ChapterDraft
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.final_editor import FinalEditorAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+async def _stream_tokens(tokens: list[str]):
+    for token in tokens:
+        yield token
+
+
+class _ProviderStub:
+    def __init__(self, response: str) -> None:
+        self.response = response
+
+    def stream_text(self, messages, model_config, seed=None):
+        return _stream_tokens([self.response])
+
+
+class _SequentialProviderStub:
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = responses
+        self._index = 0
+
+    def stream_text(self, messages, model_config, seed=None):
+        response = self._responses[self._index]
+        self._index += 1
+        return _stream_tokens([response])
+
+
+def _draft(n: int, content: str = "") -> ChapterDraft:
+    return ChapterDraft(
+        story_name="s",
+        chapter_number=n,
+        title=f"Chapter {n}",
+        content=content or f"Chapter {n} body content",
+        word_count=4,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scrubbing_enabled_invokes_prose_scrub_and_voice_pass() -> None:
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = FinalEditorAgent(
+        provider=_ProviderStub("polished"),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        return_value="system",
+    ) as mock_load_prompt:
+        await agent.run(
+            "s",
+            [_draft(1)],
+            GenerationSettings.from_dict({"enable_scrubbing": True}),
+        )
+
+    bus.close()
+
+    prompt_names = [call.args[0] for call in mock_load_prompt.call_args_list]
+    assert prompt_names.count("final_edit/prose_scrub") == 1
+    assert prompt_names.count("final_edit/voice_consistency_pass") == 1
+    assert prompt_names.count("final_edit/edit_chapter_direct") == 1
+
+
+@pytest.mark.asyncio
+async def test_scrubbing_enabled_passes_findings_to_edit_chapter_direct() -> None:
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = FinalEditorAgent(
+        provider=_SequentialProviderStub(
+            [
+                '{"issues":["prose finding"]}',
+                '{"issues":["voice finding"]}',
+                "polished",
+            ]
+        ),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+    captured_edit_variables: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if name == "final_edit/edit_chapter_direct":
+            captured_edit_variables.update(variables or {})
+        return "system"
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        side_effect=capture_prompt,
+    ):
+        await agent.run(
+            "s",
+            [_draft(1)],
+            GenerationSettings.from_dict({"enable_scrubbing": True}),
+        )
+
+    bus.close()
+
+    assert captured_edit_variables["prose_findings"]
+    assert captured_edit_variables["voice_findings"]
+
+
+@pytest.mark.asyncio
+async def test_scrubbing_disabled_skips_stage1_calls_only_edit_chapter_direct() -> None:
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = FinalEditorAgent(
+        provider=_ProviderStub("polished"),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+    captured_edit_variables: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if name == "final_edit/edit_chapter_direct":
+            captured_edit_variables.update(variables or {})
+        return "system"
+
+    with patch(
+        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+        side_effect=capture_prompt,
+    ) as mock_load_prompt:
+        await agent.run(
+            "s",
+            [_draft(1)],
+            GenerationSettings.from_dict({"enable_scrubbing": False}),
+        )
+
+    bus.close()
+
+    prompt_names = [call.args[0] for call in mock_load_prompt.call_args_list]
+    assert prompt_names.count("final_edit/edit_chapter_direct") == 1
+    assert "final_edit/prose_scrub" not in prompt_names
+    assert "final_edit/voice_consistency_pass" not in prompt_names
+    assert captured_edit_variables["prose_findings"] == ""
+    assert captured_edit_variables["voice_findings"] == ""


### PR DESCRIPTION
## Summary

Extends `FinalEditorAgent` to a two-stage flow gated by `settings.enable_scrubbing`. When enabled, Stage 1 runs `prose_scrub` and `voice_consistency_pass` per chapter to gather structured diagnostic findings. Stage 2 passes those findings as template variables into `edit_chapter_direct`, giving the final editor structured context to act on. When disabled, empty strings flow through, preserving existing behaviour exactly.

## Closes
Closes #295

## Changes
- [x] `FinalEditorAgent.run()` extended with two-stage flow gated by `enable_scrubbing`
- [x] `prompts/final_edit/edit_chapter_direct.md` updated with optional `{prose_findings}` and `{voice_findings}` placeholders (backward compatible)
- [x] `tests/unit/test_final_editor_agent.py` created with 3 tests covering both flag values
- [x] `tests/unit/test_final_editor.py` updated to filter on `edit_chapter_direct` calls (compatible with new multi-prompt flow)
- [x] All tests passing (verified)
- [x] Linting clean

## Plan

**Stage 1 (when `enable_scrubbing=True`):**
1. `final_edit/prose_scrub` → `prose_findings` (pacing, redundancy, clarity)
2. `final_edit/voice_consistency_pass` → `voice_findings` (POV drift, character-voice)

**Stage 2 (always):**
3. `final_edit/edit_chapter_direct` with `prose_findings` and `voice_findings` injected

**Stage 1 (when `enable_scrubbing=False`):**
- Skipped entirely; empty strings passed to Stage 2

**Verification:**
- `test_scrubbing_enabled_invokes_prose_scrub_and_voice_pass` — passes
- `test_scrubbing_enabled_passes_findings_to_edit_chapter_direct` — passes
- `test_scrubbing_disabled_skips_stage1_calls_only_edit_chapter_direct` — passes
- 48 tests across final-editor, orchestrator, story-foundation, pipeline-handoffs — all pass