### PR TITLE
feat(markdown-pointer): Add persist_markdown/read_markdown_ref helpers and storage convention

### DIFF
--- a/.github/notes/gotchas.md
+++ b/.github/notes/gotchas.md
@@ -1650,7 +1650,7 @@ ChromaDB ID: `gotcha-advisory-phase-completion-semantics-046`
 **Source:** issue #316, PR #328
 **Severity:** info
 
-`_atomic_write(path, content)` in `src/presentation/orchestrator.py` calls
+`_atomic_write(path, content)` in `src/tools/_io.py` calls
 `path.parent.mkdir(parents=True, exist_ok=True)` as its **first step** before writing. Callers
 (including `_write_savepoint`) must **not** add a separate `path.parent.mkdir()` call before
 invoking `_atomic_write` — it is redundant and falsely implies that directory creation is the

--- a/.github/notes/reflections/archive/issue-316-preexisting-failure-baseline-in-workflow-2026-05-03.md
+++ b/.github/notes/reflections/archive/issue-316-preexisting-failure-baseline-in-workflow-2026-05-03.md
@@ -1,4 +1,3 @@
-<!-- STALE — archived to archive/issue-316-preexisting-failure-baseline-in-workflow-2026-05-03.md — delete this file -->
 ---
 date: "2026-05-03"
 issue: 316
@@ -53,3 +52,4 @@ before the first commit prevents confusion and saves review cycles.
 ### Action Taken
 
 Proposed for approval — structural addition to a shared workflow instruction file used by all agents.
+Archived during issue #317 collation (2026-05-03). Major proposal remains pending approval.

--- a/.github/notes/reflections/issue-316-atomic-write-mkdir-contract.md
+++ b/.github/notes/reflections/issue-316-atomic-write-mkdir-contract.md
@@ -1,3 +1,4 @@
+<!-- STALE — archived to archive/issue-316-atomic-write-mkdir-contract-2026-05-03.md — delete this file -->
 ---
 date: "2026-05-03"
 issue: 316

--- a/.github/notes/reflections/issue-317-persist-markdown-redundant-mkdir.md
+++ b/.github/notes/reflections/issue-317-persist-markdown-redundant-mkdir.md
@@ -1,0 +1,58 @@
+---
+date: "2026-05-03"
+issue: 317
+pr: 329
+category: instruction
+targets:
+  - ".github/notes/gotchas.md"
+  - "src/tools/_persist.py"
+severity: minor
+status: active
+---
+
+## `persist_markdown` calls `mkdir` redundantly — violates gotcha #047; gotcha #047 had wrong file reference
+
+### Finding
+
+PR #329 (issue #317) introduced `persist_markdown` in `src/tools/_persist.py`. The implementation
+calls `target_path.parent.mkdir(parents=True, exist_ok=True)` immediately before calling
+`_atomic_write(target_path, body)`. Since `_atomic_write` (defined in `src/tools/_io.py`) already
+calls `path.parent.mkdir(parents=True, exist_ok=True)` as its first step, the explicit `mkdir`
+in `persist_markdown` is redundant — a direct violation of gotcha #047.
+
+Additionally, the text of gotcha #047 itself contained an incorrect file reference. It stated that
+`_atomic_write` lives in `src/presentation/orchestrator.py`, but the canonical definition is in
+`src/tools/_io.py`. `orchestrator.py` imports `_atomic_write` from `tools._io` — it is a caller,
+not the definition site.
+
+### Observation
+
+The gotcha #047 file-location error is a plausible source of confusion: a developer reading the
+gotcha and searching `orchestrator.py` for `_atomic_write` would find only import/call sites, not
+the function body, and might conclude the gotcha is wrong rather than that the file reference is
+wrong. This undermines trust in the gotcha and could cause the convention to be silently abandoned.
+
+The redundant `mkdir` in `persist_markdown` is harmless (both calls use `exist_ok=True`) but:
+- Creates the false impression that callers are responsible for ensuring the directory exists before
+  calling `_atomic_write`
+- Establishes a bad pattern for future persist helpers written alongside `persist_markdown`
+- Contradicts the convention established and documented in PR #328 just one PR earlier
+
+### Suggested Improvement
+
+1. **Applied immediately**: Correct the file reference in gotcha #047 from
+   `src/presentation/orchestrator.py` to `src/tools/_io.py`.
+
+2. **Code fix needed** (follow-up PR): Remove the redundant `mkdir` call from `persist_markdown`
+   in `src/tools/_persist.py`:
+   ```python
+   # Remove this line:
+   target_path.parent.mkdir(parents=True, exist_ok=True)
+   ```
+   `_atomic_write` owns directory creation. Callers must not duplicate it.
+
+### Action Taken
+
+Applied: corrected `src/presentation/orchestrator.py` → `src/tools/_io.py` in gotcha #047 text.
+Code fix (remove redundant mkdir from `persist_markdown`) deferred to a follow-up PR — production
+code changes are outside the Reflection agent's edit scope.

--- a/.github/notes/reflections/issue-317-read-markdown-ref-security-tests.md
+++ b/.github/notes/reflections/issue-317-read-markdown-ref-security-tests.md
@@ -1,0 +1,57 @@
+---
+date: "2026-05-03"
+issue: 317
+pr: 329
+category: agent
+targets:
+  - "tests/unit/test_persist.py"
+severity: minor
+status: active
+---
+
+## `read_markdown_ref` security validation paths not covered by tests
+
+### Finding
+
+PR #329 (issue #317) added 7 unit tests in `tests/unit/test_persist.py` covering
+`persist_markdown` and `read_markdown_ref`. The security validation in `persist_markdown` is
+well-tested: `test_rejects_path_traversal` and `test_rejects_absolute_path` both confirm that
+`_validate_relative_path` raises `ValueError` for `..` and `/`-prefixed inputs.
+
+However, `read_markdown_ref` also calls `_validate_relative_path(relative_path)` on the `$ref`
+value extracted from a pointer dict — and this call path has no corresponding test. There are no
+tests verifying that `read_markdown_ref(tmp_path, {"$ref": "../evil.md"})` or
+`read_markdown_ref(tmp_path, {"$ref": "/etc/passwd"})` raise `ValueError`.
+
+### Observation
+
+A crafted pointer dict reaching `read_markdown_ref` with a traversal or absolute path is a
+realistic attack vector when pointer dicts are read from user-controlled or untrusted storage. The
+validation code is present and correct, but untested. Without a test, a future refactor could
+silently remove the `_validate_relative_path` call from `read_markdown_ref` without any test
+failure, creating a path-traversal vulnerability.
+
+The general pattern: whenever a security guard exists in a function, ALL entry points to that guard
+must be tested independently — even when the guard is implemented via a shared helper. Tests of
+function A do not cover function B even when both call the same shared validator.
+
+### Suggested Improvement
+
+Add two tests to `TestReadMarkdownRef` in `tests/unit/test_persist.py`:
+
+```python
+def test_rejects_traversal_in_pointer(self, tmp_path) -> None:
+    with pytest.raises(ValueError):
+        read_markdown_ref(tmp_path, {"$ref": "../evil.md"})
+
+def test_rejects_absolute_path_in_pointer(self, tmp_path) -> None:
+    with pytest.raises(ValueError):
+        read_markdown_ref(tmp_path, {"$ref": "/etc/passwd"})
+```
+
+These can be added in a follow-up commit on this branch or in a later hardening PR.
+
+### Action Taken
+
+Proposed: two additional test cases for `TestReadMarkdownRef` to verify security validation
+through the `read_markdown_ref` entry point. Follow-up PR or branch commit needed.

--- a/.github/notes/reflections/issue-317-tools-doc-missing-persist-helpers.md
+++ b/.github/notes/reflections/issue-317-tools-doc-missing-persist-helpers.md
@@ -1,0 +1,45 @@
+---
+date: "2026-05-03"
+issue: 317
+pr: 329
+category: instruction
+targets:
+  - "docs/tools.md"
+severity: minor
+status: active
+---
+
+## `docs/tools.md` not updated to list `src/tools/_persist.py`
+
+### Finding
+
+PR #329 (issue #317) added `src/tools/_persist.py` as a new shared internal helper module
+exposing `persist_markdown` and `read_markdown_ref`. The `docs/tools.md` "Shared Internal
+Helpers" section — which lists `_io.py`, `_llm.py`, `_wiki.py`, and `migrate_state_slim.py` —
+was not updated to include `_persist.py`.
+
+### Observation
+
+`docs/tools.md` is the canonical reference for the tool layer. Agents, contributors, and reviewers
+consult it to understand what modules exist and what they provide. A missing entry means:
+
+- Future Coders implementing persist helpers won't discover the module via documentation and may
+  duplicate its functionality or import it incorrectly
+- Reviewers checking whether new code should use `_persist.py` have no reference to find it
+- The storage convention in `docs/planning/separate-markdown-from-json/convention.md` references
+  the API but `docs/tools.md` is the expected authoritative inventory
+
+### Suggested Improvement
+
+Add a row to the "Shared Internal Helpers" table in `docs/tools.md`:
+
+```markdown
+| `src/tools/_persist.py` | Markdown pointer helpers: `persist_markdown` writes markdown to disk and returns a `{"$ref": ...}` pointer; `read_markdown_ref` resolves pointers or passthrough legacy strings |
+```
+
+This should be added after the `_io.py` row (alphabetical order within the shared helpers section).
+
+### Action Taken
+
+Proposed: doc update to `docs/tools.md` Shared Internal Helpers table. This change is in
+`docs/` — outside the Reflection agent's direct edit scope. Requires a follow-up doc commit.

--- a/docs/planning/separate-markdown-from-json/convention.md
+++ b/docs/planning/separate-markdown-from-json/convention.md
@@ -1,0 +1,88 @@
+# Markdown Pointer Storage Convention
+
+> Defines the pointer-based markdown storage convention introduced by ADR 011.
+
+## Overview
+
+JSON fields that contain markdown content are stored as pointer objects instead of inline strings. The JSON value becomes `{ "$ref": "..." }`, and the markdown body lives in a sibling `.md` file on disk. This keeps JSON for structured metadata, keeps markdown editable as markdown, and gives the pipeline stable file paths for follow-on indexing and migration work.
+
+## What Counts As Markdown Content
+
+A field counts as markdown content if any of these rules match:
+
+1. It contains `\n\n`.
+2. It contains a markdown heading matching `^#{1,6} `.
+3. It contains a fenced code block marker `` ``` ``.
+4. It exceeds 500 characters of free text.
+
+When a field matches any rule, persist the body to a `.md` file and store a pointer in JSON instead of the raw string.
+
+## Pointer Shape
+
+Pointer objects use one shape only:
+
+```json
+{ "$ref": "relative/path/to/file.md" }
+```
+
+Paths are always relative to the story root. The `$ref` key is the single recognised marker. This follows familiar JSON Schema and OpenAPI vocabulary.
+
+## Rule B: No JSON Inside Markdown Fenced Blocks
+
+Structured payloads stay structured. If a value is JSON, persist it as JSON in a JSON file or JSON sub-document. Do not store structured data as a `` ```json `` string inside another JSON value.
+
+This rule prevents double-encoded and triple-encoded payloads that are hard to diff, validate, and round-trip safely.
+
+## Storage Path Conventions
+
+Suggested path patterns:
+
+- Character sheets: `characters/<slug>/sheet.md`, `characters/<slug>/chunks/<key>.md`
+- Setting sheets: `settings/<slug>/sheet.md`, `settings/<slug>/chunks/<key>.md`
+- Chapter recaps: `chapters/chapter_<N>/recap.md`
+- Story prompt: `prompt.md`
+- Outline chapter summaries: `outline/chapter_<N>_summary.md`
+
+These paths are conventions, not arbitrary examples. Writers should keep file locations stable so downstream readers, migrations, and ChromaDB source-sync can rely on predictable on-disk paths.
+
+## Helper API
+
+The persistence helpers live in `src/tools/_persist.py`.
+
+- `persist_markdown(story_root, relative_path, body)` writes the markdown file atomically and returns the pointer dict.
+- `read_markdown_ref(story_root, ref)` resolves either a pointer dict or a legacy inline string and returns the markdown body.
+
+Reference signatures:
+
+```python
+persist_markdown(story_root, relative_path, body) -> {"$ref": relative_path}
+read_markdown_ref(story_root, ref) -> str
+```
+
+## Backward Compatibility
+
+`read_markdown_ref` accepts both legacy plain strings and new pointer dicts. Read sites can switch to the helper immediately without breaking stories that still store inline markdown during the migration window.
+
+## Concrete Example
+
+Before:
+
+```json
+{
+  "sheet": "# Yara Osei\n\n## Background\n\nYara was born..."
+}
+```
+
+After:
+
+```json
+{
+  "sheet": {"$ref": "characters/yara-osei/sheet.md"}
+}
+```
+
+The markdown body then lives in `characters/yara-osei/sheet.md` relative to the story root.
+
+## JSON Schema
+
+`src/application/schemas/markdown_ref.json` validates the pointer shape. The schema requires a single `$ref` string and rejects additional properties.

--- a/src/application/schemas/markdown_ref.json
+++ b/src/application/schemas/markdown_ref.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["$ref"],
+  "properties": {
+    "$ref": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/tools/_persist.py
+++ b/src/tools/_persist.py
@@ -1,0 +1,44 @@
+"""Markdown persistence helpers for the pointer-based storage convention."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src = str(Path(__file__).resolve().parents[1])
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from tools._io import _atomic_write  # noqa: E402
+
+
+def _validate_relative_path(relative_path: str) -> Path:
+    path = Path(relative_path)
+    if path.is_absolute():
+        raise ValueError("relative_path must not be absolute")
+    if ".." in path.parts:
+        raise ValueError("relative_path must not contain '..'")
+    return path
+
+
+def persist_markdown(story_root: Path, relative_path: str, body: str) -> dict[str, str]:
+    _validate_relative_path(relative_path)
+    target_path = story_root / relative_path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(target_path, body)
+    return {"$ref": relative_path}
+
+
+def read_markdown_ref(story_root: Path, ref: dict[str, str] | str) -> str:
+    if isinstance(ref, str):
+        return ref
+    if not isinstance(ref, dict):
+        raise TypeError("ref must be a dict with '$ref' or a string")
+
+    relative_path = ref.get("$ref")
+    if not isinstance(relative_path, str):
+        raise ValueError("ref dict must contain a string '$ref'")
+
+    _validate_relative_path(relative_path)
+    return (story_root / relative_path).read_text(encoding="utf-8")

--- a/tests/unit/test_persist.py
+++ b/tests/unit/test_persist.py
@@ -1,0 +1,42 @@
+"""Verification tests for markdown pointer persistence helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tools._persist import persist_markdown, read_markdown_ref
+
+
+class TestPersistMarkdown:
+    def test_writes_file_and_returns_pointer(self, tmp_path) -> None:
+        result = persist_markdown(tmp_path, "foo/bar.md", "# Hello")
+
+        assert result == {"$ref": "foo/bar.md"}
+        assert (tmp_path / "foo/bar.md").read_text(encoding="utf-8") == "# Hello"
+
+    def test_creates_parent_directories(self, tmp_path) -> None:
+        persist_markdown(tmp_path, "a/b/c.md", "body")
+
+        assert (tmp_path / "a/b/c.md").exists()
+
+    def test_rejects_path_traversal(self, tmp_path) -> None:
+        with pytest.raises(ValueError):
+            persist_markdown(tmp_path, "../escape.md", "body")
+
+    def test_rejects_absolute_path(self, tmp_path) -> None:
+        with pytest.raises(ValueError):
+            persist_markdown(tmp_path, "/etc/passwd", "body")
+
+
+class TestReadMarkdownRef:
+    def test_round_trip(self, tmp_path) -> None:
+        pointer = persist_markdown(tmp_path, "foo/bar.md", "# Hello")
+
+        assert read_markdown_ref(tmp_path, pointer) == "# Hello"
+
+    def test_legacy_string_passthrough(self, tmp_path) -> None:
+        assert read_markdown_ref(tmp_path, "some legacy string") == "some legacy string"
+
+    def test_raises_on_invalid_type(self, tmp_path) -> None:
+        with pytest.raises(TypeError):
+            read_markdown_ref(tmp_path, 42)


### PR DESCRIPTION
## Summary

Adds the foundational persistence helpers and storage convention document for separating large markdown bodies out of JSON state files (ADR 011). This is the prerequisite for all subsequent pointer-format write conversions and for ChromaDB source-sync (ADR 012), which relies on stable on-disk `.md` paths.

## Closes

Closes #317

## Changes

- [x] `src/tools/_persist.py` — `persist_markdown` and `read_markdown_ref` helpers with full type hints, path-traversal protection, atomic writes, backward-compat legacy-string pass-through
- [x] `src/application/schemas/markdown_ref.json` — JSON Schema (draft-07) validating the `{"$ref": "..."}` pointer shape
- [x] `tests/unit/test_persist.py` — 7 tests: round-trip, legacy passthrough, path traversal rejection, absolute path rejection, parent dir creation
- [x] All tests passing (7/7 verified)
- [x] Linting and mypy clean

## Plan

### Task 1: Add `persist_markdown` / `read_markdown_ref` helpers
- [x] `src/tools/_persist.py` exposing both helpers
- [x] Path traversal rejected
- [x] Round-trip test passing
- [x] Legacy-string fallback test passing

### Task 2: Document the storage convention + JSON Schema
- [ ] `docs/planning/separate-markdown-from-json/convention.md`
- [x] `src/application/schemas/markdown_ref.json`