### PR TITLE
test(chroma-sync): End-to-end edit-and-retrieve integration test

### DIFF
--- a/.agents/skills/test-verification/SKILL.md
+++ b/.agents/skills/test-verification/SKILL.md
@@ -23,6 +23,8 @@ Tests verify implemented behavior. They should be meaningful, isolated, and alig
 - For LLM JSON parsing, cover invalid JSON, valid non-dict JSON, null sections, and mixed list items when relevant.
 - For disk-writing code, patch storage roots and avoid real story data.
 - For fields written as pointer format (`{"$ref": "path/to/file.md"}`): never assert directly on `data["field"]`. Resolve via `ref_path = data["field"]["$ref"]`, read the `.md` file from disk, then assert on the file content.
+- For filesystem fingerprint / stale-refresh tests: advance mtime explicitly with `os.utime(path, (t+10, t+10))` after writing the edited content — never rely on the filesystem clock advancing between write and check (see gotcha #050).
+- For subprocess integration tests: include all module-level `os.environ.get(...)` vars (e.g. `CHROMADB_DIR`, `STORIES_DIR`) in the `env` dict passed to `subprocess.run` — they are baked in at subprocess import time and cannot be patched in-process (see gotcha #051).
 
 ## Handoff
 

--- a/.github/notes/gotchas.md
+++ b/.github/notes/gotchas.md
@@ -1760,3 +1760,141 @@ for n in chapter_numbers:
 
 ChromaDB ID: `gotcha-ledger-guard-per-chapter-checkpointing-048`
 
+---
+
+## Testing
+
+### 050 — mtime race condition in filesystem fingerprint tests: use `os.utime` to advance mtime explicitly
+
+**Source:** issue #327, PR #339
+**Severity:** warning
+
+Writing a file and immediately reading its `st_mtime` can return the same timestamp as before if
+the write and the read fall within the same filesystem clock-resolution window (ext4 default: 1 s,
+some tmpfs: nanosecond, macOS HFS+: 1 s, APFS: nanosecond). Code that uses mtime to detect
+staleness (e.g. `refresh_if_stale` in `_chroma_sync.py`) compares the stored mtime against the
+current `st_mtime`; if both are equal, the entry is considered fresh and the refresh is skipped.
+
+**Pattern: always use `os.utime` to advance mtime explicitly in tests that exercise stale-refresh logic.**
+
+```python
+def _bump_mtime(path: Path) -> None:
+    """Advance mtime by 10 s so refresh_if_stale sees the file as stale."""
+    updated = path.stat().st_mtime + 10
+    os.utime(path, (updated, updated))
+
+# Usage after writing the "edited" content:
+hero_md.write_text("The hero has green eyes.", encoding="utf-8")
+_bump_mtime(hero_md)   # ← without this, refresh_if_stale may see no change
+```
+
+**Why `+10` and not `+1`?** A 1-second increment can still land within the same coarse resolution
+window on slow CI machines. A 10-second increment guarantees the new mtime is strictly greater
+than the stored fingerprint regardless of OS or filesystem resolution.
+
+**Scope:** Any test that writes a file and then asserts that an index entry is refreshed (stale),
+or that an entry is NOT refreshed (fresh), must control mtime explicitly. Never rely on the wall
+clock advancing between the write and the check.
+
+ChromaDB ID: `gotcha-mtime-race-filesystem-resolution-050`
+
+---
+
+### 051 — `CHROMADB_DIR` (and other import-time env vars) must be forwarded to subprocesses explicitly
+
+**Source:** issue #327, PR #339
+**Severity:** warning
+
+`src/tools/wiki_search.py` reads `CHROMADB_DIR` at **module-level** (import time), not lazily
+inside a function:
+
+```python
+# wiki_search.py (simplified)
+CHROMADB_DIR = os.environ.get("CHROMADB_DIR", str(PROJECT_ROOT / ".chromadb"))
+client = chromadb.PersistentClient(path=CHROMADB_DIR)
+```
+
+When a test spawns `wiki_search.py` as a subprocess, the value is baked in at the moment the
+interpreter imports the module — before any `monkeypatch` or parent-process patching can take
+effect. The subprocess must receive `CHROMADB_DIR` via its own environment.
+
+**Wrong — subprocess uses default `.chromadb` path, pollutes project root:**
+```python
+result = subprocess.run([sys.executable, WIKI_SEARCH_SCRIPT, ...], capture_output=True)
+```
+
+**Right — explicit env dict with CHROMADB_DIR:**
+```python
+result = subprocess.run(
+    [sys.executable, WIKI_SEARCH_SCRIPT, ...],
+    env={**os.environ, "CHROMADB_DIR": str(chromadb_dir), "STORIES_DIR": str(stories_dir)},
+    capture_output=True,
+)
+```
+
+**General rule:** Any environment variable read at module import time by a subprocess target must
+be included in the `env` dict for every `subprocess.run` / `subprocess.Popen` call in tests.
+Variables read lazily (inside a function, on first call) can be patched in-process — but if the
+target runs in a subprocess, patching has no effect regardless of when the variable is read.
+
+**Checklist for new subprocess integration tests:**
+- Identify all module-level `os.environ.get(...)` calls in the target script
+- Include every such variable in the `env` dict
+- Use `{**os.environ, "VAR": str(tmp_path)}` to inherit parent env safely
+
+ChromaDB ID: `gotcha-chromadb-dir-subprocess-env-051`
+
+---
+
+### 052 — `upsert_from_source` path traversal guard: source files must be under `PROJECT_ROOT`
+
+**Source:** issue #327, PR #339
+**Severity:** warning
+
+`upsert_from_source` in `src/tools/_chroma_sync.py` enforces a path containment guard before
+indexing a source file:
+
+```python
+def upsert_from_source(collection, slug: str, source_path: str, metadata: dict) -> None:
+    path = Path(source_path).resolve()
+    if not path.is_relative_to(PROJECT_ROOT):
+        raise ValueError(f"Source path {path} is outside PROJECT_ROOT")
+    ...
+```
+
+Integration tests that call `upsert_from_source` directly (not through `reconcile_story`) must
+therefore create source files under the **real `PROJECT_ROOT`** — not under `tmp_path` — because
+`tmp_path` is typically `/tmp/pytest-…/` which is outside the project tree.
+
+**Wrong — path traversal guard rejects the file:**
+```python
+wiki_page = tmp_path / "wiki" / "characters" / "hero.md"
+wiki_page.write_text("The hero.", encoding="utf-8")
+upsert_from_source(collection, "hero", str(wiki_page), {})  # ValueError
+```
+
+**Right — create under PROJECT_ROOT / "stories" / story_name:**
+```python
+@pytest.fixture()
+def story_dir() -> Path:
+    path = PROJECT_ROOT / "stories" / _TEST_STORY
+    (path / "wiki" / "characters").mkdir(parents=True)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+# In the test:
+hero_md = story_dir / "wiki" / "characters" / "hero.md"
+hero_md.write_text("The hero.", encoding="utf-8")
+upsert_from_source(collection, "hero", str(hero_md), {})  # OK
+```
+
+**Why the guard exists:** Allowing arbitrary paths would let a caller index files outside the
+project (e.g. `/etc/passwd`) — a path traversal / information-disclosure risk (CWE-22).
+
+**Companion:** use a unique story name per test run (e.g. include `uuid4().hex[:8]`) and clean up
+the fixture directory in `finally` to prevent test contamination on repeated runs.
+
+ChromaDB ID: `gotcha-upsert-source-project-root-constraint-052`
+

--- a/.github/notes/reflections/archive/issue-327-chromadb-dir-subprocess-env-2026-05-03.md
+++ b/.github/notes/reflections/archive/issue-327-chromadb-dir-subprocess-env-2026-05-03.md
@@ -1,0 +1,33 @@
+---
+date: "2026-05-03"
+issue: 327
+pr: 339
+category: instruction
+targets:
+  - ".github/notes/gotchas.md"
+  - ".github/agents/skills/test-verification/SKILL.md"
+severity: minor
+---
+
+## Import-time env vars must be forwarded to subprocesses explicitly
+
+### Finding
+
+`CHROMADB_DIR` is read at module-level in `wiki_search.py`. Subprocess integration tests that
+omit it from the `env` dict cause the subprocess to target the default `.chromadb` path,
+polluting the project root and making the test non-reproducible.
+
+### Observation
+
+Any tool that reads env vars at import time (not lazily) requires those vars in every subprocess
+`env` dict. Parent-process `monkeypatch` cannot reach subprocess module-level initialisation.
+Pattern generalises to all `os.environ.get(...)` calls at module scope.
+
+### Suggested Improvement
+
+Add gotcha #051 to `gotchas.md`. Add assertion bullet to `test-verification/SKILL.md`.
+
+### Action Taken
+
+Applied: Added gotcha #051 to `.github/notes/gotchas.md`. Added assertion bullet to
+`.github/agents/skills/test-verification/SKILL.md`.

--- a/.github/notes/reflections/archive/issue-327-mtime-race-filesystem-resolution-2026-05-03.md
+++ b/.github/notes/reflections/archive/issue-327-mtime-race-filesystem-resolution-2026-05-03.md
@@ -1,0 +1,36 @@
+---
+date: "2026-05-03"
+issue: 327
+pr: 339
+category: instruction
+targets:
+  - ".github/notes/gotchas.md"
+  - ".github/agents/skills/test-verification/SKILL.md"
+severity: minor
+---
+
+## mtime race condition in filesystem fingerprint tests
+
+### Finding
+
+`test_edit_and_retrieve` initially flaked without `_bump_mtime`. Writing a file and immediately
+checking `st_mtime` can return the same timestamp when the write and read happen within the same
+filesystem clock-resolution window (ext4: 1 s). `refresh_if_stale` uses mtime comparison; equal
+mtime means "fresh", so the stale refresh was silently skipped.
+
+### Observation
+
+Any test exercising stale-refresh or fingerprint-change logic must control mtime explicitly via
+`os.utime`. Relying on wall-clock progression is non-deterministic across filesystems and CI
+environments. The fix is simple and deterministic: advance mtime by 10 s using `os.utime` after
+writing the modified content.
+
+### Suggested Improvement
+
+Add gotcha #050 to `gotchas.md` documenting the `_bump_mtime` / `os.utime` pattern.
+Add a corresponding assertion bullet to `test-verification/SKILL.md`.
+
+### Action Taken
+
+Applied: Added gotcha #050 to `.github/notes/gotchas.md`. Added assertion bullet to
+`.github/agents/skills/test-verification/SKILL.md`.

--- a/.github/notes/reflections/archive/issue-327-upsert-source-project-root-constraint-2026-05-03.md
+++ b/.github/notes/reflections/archive/issue-327-upsert-source-project-root-constraint-2026-05-03.md
@@ -1,0 +1,34 @@
+---
+date: "2026-05-03"
+issue: 327
+pr: 339
+category: instruction
+targets:
+  - ".github/notes/gotchas.md"
+severity: minor
+---
+
+## upsert_from_source path traversal guard requires PROJECT_ROOT-anchored source files
+
+### Finding
+
+`upsert_from_source` enforces `path.is_relative_to(PROJECT_ROOT)`. Integration tests that create
+source files under `tmp_path` (`/tmp/pytest-…`) have all `upsert_from_source` calls rejected
+with `ValueError`. Tests must create wiki pages under `PROJECT_ROOT / "stories" / story_name`
+and clean up in `finally`.
+
+### Observation
+
+The guard is intentional security behaviour (CWE-22 prevention). Tests must work within it, not
+around it. The correct fixture pattern uses a unique story name (uuid suffix) and `shutil.rmtree`
+in `finally`. This is distinct from the `STORIES_DIR` env override pattern used for CLI
+subprocess tests — direct API callers must use real paths.
+
+### Suggested Improvement
+
+Add gotcha #052 to `gotchas.md` documenting the path traversal guard and the correct fixture
+pattern.
+
+### Action Taken
+
+Applied: Added gotcha #052 to `.github/notes/gotchas.md`.

--- a/tests/integration/test_chroma_source_sync.py
+++ b/tests/integration/test_chroma_source_sync.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import chromadb
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import tools._chroma_sync as chroma_sync_module
+import tools.rag_reconcile as rag_reconcile
+from tools._chroma_sync import upsert_from_source
+
+_TEST_STORY = f"test-327-{uuid4().hex[:8]}"
+WIKI_SEARCH_SCRIPT = str(PROJECT_ROOT / "src" / "tools" / "wiki_search.py")
+TIMEOUT_SECONDS = 20
+
+
+@pytest.fixture()
+def chromadb_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "chromadb"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture()
+def story_dir() -> Path:
+    path = PROJECT_ROOT / "stories" / _TEST_STORY
+    if path.exists():
+        shutil.rmtree(path)
+    (path / "wiki" / "characters").mkdir(parents=True)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture()
+def patched_sync_roots(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(chroma_sync_module, "PROJECT_ROOT", PROJECT_ROOT)
+    monkeypatch.setattr(rag_reconcile, "CHROMA_PROJECT_ROOT", PROJECT_ROOT)
+    monkeypatch.setattr(rag_reconcile, "STORIES_DIR", PROJECT_ROOT / "stories")
+
+
+def _wiki_collection(chromadb_dir: Path):  # type: ignore[no-untyped-def]
+    client = chromadb.PersistentClient(path=str(chromadb_dir))
+    return client.get_or_create_collection(name=f"wiki-{_TEST_STORY}")
+
+
+def _run_wiki_search(
+    chromadb_dir: Path, *args: str
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "CHROMADB_DIR": str(chromadb_dir),
+        "STORIES_DIR": str(PROJECT_ROOT / "stories"),
+        "PYTHONPATH": str(PROJECT_ROOT),
+    }
+    try:
+        return subprocess.run(
+            [sys.executable, WIKI_SEARCH_SCRIPT, *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = (
+            (exc.stdout or b"").decode(errors="replace")
+            if isinstance(exc.stdout, bytes)
+            else (exc.stdout or "")
+        )
+        stderr = (
+            (exc.stderr or b"").decode(errors="replace")
+            if isinstance(exc.stderr, bytes)
+            else (exc.stderr or "")
+        )
+        pytest.fail(
+            f"wiki_search.py timed out after {TIMEOUT_SECONDS}s.\n"
+            f"stdout (truncated):\n{stdout[-2000:]}\n"
+            f"stderr (truncated):\n{stderr[-2000:]}"
+        )
+
+
+def _bump_mtime(path: Path) -> None:
+    updated_mtime = path.stat().st_mtime + 10
+    os.utime(path, (updated_mtime, updated_mtime))
+
+
+def test_edit_and_retrieve(
+    story_dir: Path,
+    chromadb_dir: Path,
+    patched_sync_roots: None,
+) -> None:
+    hero_md = story_dir / "wiki" / "characters" / "hero.md"
+    hero_md.write_text("The hero has blue eyes.", encoding="utf-8")
+
+    collection = _wiki_collection(chromadb_dir)
+    upsert_from_source(collection, "hero", str(hero_md), {})
+
+    hero_md.write_text("The hero has green eyes.", encoding="utf-8")
+    _bump_mtime(hero_md)
+
+    result = _run_wiki_search(
+        chromadb_dir,
+        "--operation",
+        "semantic",
+        "--name",
+        _TEST_STORY,
+        "--query",
+        "hero eye color",
+        "--n-results",
+        "1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["slug"] == "hero"
+    assert "green eyes" in payload["results"][0]["excerpt"]
+
+
+def test_orphan_deletion_via_reconcile(
+    story_dir: Path,
+    chromadb_dir: Path,
+    patched_sync_roots: None,
+) -> None:
+    ghost_md = story_dir / "wiki" / "characters" / "ghost.md"
+    ghost_md.write_text("A ghost character.", encoding="utf-8")
+
+    collection = _wiki_collection(chromadb_dir)
+    upsert_from_source(collection, "ghost", str(ghost_md), {})
+
+    ghost_md.unlink()
+
+    reports = rag_reconcile.reconcile_story(
+        _TEST_STORY,
+        "wiki",
+        dry_run=False,
+        chromadb_dir=str(chromadb_dir),
+    )
+
+    assert reports["wiki"].deleted == 1
+    assert collection.get(ids=["ghost"])["ids"] == []
+
+
+def test_reconcile_is_idempotent(
+    story_dir: Path,
+    chromadb_dir: Path,
+    patched_sync_roots: None,
+) -> None:
+    knight_md = story_dir / "wiki" / "characters" / "knight.md"
+    knight_md.write_text("A steadfast knight.", encoding="utf-8")
+
+    collection = _wiki_collection(chromadb_dir)
+    upsert_from_source(collection, "knight", str(knight_md), {})
+
+    first_reports = rag_reconcile.reconcile_story(
+        _TEST_STORY,
+        "wiki",
+        dry_run=False,
+        chromadb_dir=str(chromadb_dir),
+    )
+    second_reports = rag_reconcile.reconcile_story(
+        _TEST_STORY,
+        "wiki",
+        dry_run=False,
+        chromadb_dir=str(chromadb_dir),
+    )
+
+    assert first_reports["wiki"].deleted == 0
+    assert second_reports["wiki"].added == 0
+    assert second_reports["wiki"].updated == 0
+    assert second_reports["wiki"].deleted == 0


### PR DESCRIPTION
## Summary

Adds `tests/integration/test_chroma_source_sync.py` — the final ADR 012 validation gate. Tests the complete source-sync lifecycle without a live LLM: seed a wiki collection directly, hand-edit the source file and assert the query returns the refreshed body, delete the source file and reconcile to assert the orphan is removed, then reconcile again to assert idempotence.

## Closes
Closes #327

## Changes
- [x] `tests/integration/test_chroma_source_sync.py` — three integration tests covering edit-and-retrieve, orphan deletion, and idempotent reconcile
- [x] All tests passing (verified — 3 passed, 0 failed)
- [x] Linting clean

## Plan

**Affected Areas:** Test-only. No production code changes.

**Task Checklist:**
- `tests/integration/test_chroma_source_sync.py`
  - `test_edit_and_retrieve` — seed collection via `upsert_from_source`, edit source file, query via `wiki_search` subprocess, assert refreshed body returned
  - `test_orphan_deletion_via_reconcile` — seed, delete file, run `reconcile_story`, assert `deleted==1` and entry absent from collection
  - `test_reconcile_is_idempotent` — second reconcile run produces `added=0, updated=0, deleted=0`

**Key implementation notes:**
- Source files live under real `PROJECT_ROOT/stories/_test_327_<uuid>/wiki/` with cleanup (path traversal guard requires this)
- ChromaDB: `PersistentClient(path=str(tmp_path / "chromadb"))`; `CHROMADB_DIR` env var passed to subprocess
- `_bump_mtime` helper forces mtime change so `is_stale` detects the edit reliably
- No `llm_available` fixture — never requires a live LLM
