### PR TITLE
feat(recap): add recap ChromaDB index module (recaps-{story} collection)

### DIFF
--- a/.github/notes/gotchas.md
+++ b/.github/notes/gotchas.md
@@ -2085,3 +2085,59 @@ this DOM teardown race.
 
 ChromaDB ID: `gotcha-call-after-refresh-exit-dom-teardown-057`
 
+---
+
+## ChromaDB
+
+### 058 — `where` only supports exact scalar equality — prepend slugs to document body and use `where_document=$contains` for substring/slug filtering
+
+**Source:** issue #351, PR #366
+**Severity:** warning
+
+ChromaDB's `where` clause supports **only exact scalar equality** (`{"field": "value"}`). It does
+NOT support substring, prefix, list-contains, or partial-match queries on metadata fields. Any
+attempt to filter by a slug that appears as part of a comma-separated string or list stored in
+metadata will silently return zero results — no error is raised, and no warning is emitted.
+
+**Wrong — `where` substring match (always returns zero results):**
+
+```python
+# Metadata stored as: {"participants": "alice,bob,carol"}
+results = collection.query(
+    query_texts=["recap text"],
+    where={"participants": "alice"},   # exact match fails — "alice" ≠ "alice,bob,carol"
+)
+# → [] silently
+```
+
+**Right — prepend slug to document body at index time; filter with `where_document=$contains`:**
+
+```python
+# At index time: prepend all slugs to the document body
+doc_body = f"participants:{','.join(participant_slugs)} locations:{','.join(location_slugs)}\n\n{recap_text}"
+collection.upsert(
+    ids=[doc_id],
+    documents=[doc_body],
+    metadatas=[{"chapter": chapter_num, "story": story_name}],
+)
+
+# At query time: use where_document for slug filtering
+results = collection.query(
+    query_texts=["recap text"],
+    where_document={"$contains": "participants:alice"},
+)
+# → returns all documents where "alice" appears as a participant slug
+```
+
+**Why this pattern exists:** `where_document={"$contains": text}` performs a substring search
+over the full document text — the only ChromaDB filter that supports partial/membership
+matching. By prepending slugs with a `participants:` / `locations:` prefix at index time,
+callers can distinguish participant slugs from arbitrary document content.
+
+**Applies to all ChromaDB index modules:** `recap_index.py`, `wiki_search.py`, and any future
+index module (e.g. `chapter_index.py`) that needs to filter by entity membership. Reaching
+for `where={"field": slug}` is a natural first instinct but will always fail silently when the
+stored value is a concatenated list.
+
+ChromaDB ID: `gotcha-chromadb-where-exact-only-where-document-contains-058`
+

--- a/.github/notes/reflections/archive/issue-351-chromadb-where-document-slug-filter-2026-05-05.md
+++ b/.github/notes/reflections/archive/issue-351-chromadb-where-document-slug-filter-2026-05-05.md
@@ -1,0 +1,43 @@
+---
+date: "2026-05-05"
+issue: 351
+pr: 366
+category: instruction
+targets:
+  - ".github/notes/gotchas.md"
+severity: minor
+---
+
+## ChromaDB `where` only supports exact scalar equality — use `where_document=$contains` for slug filtering
+
+### Finding
+
+During PR #366 (feat/recap-chromadb-index), the Researcher surfaced that ChromaDB's `where`
+clause only supports exact scalar equality matches (`{"field": "value"}`). It does NOT support
+substring, prefix, list-contains, or partial-match queries on metadata fields. For index modules
+that need to filter by participant slug or location slug (values that may appear among a list of
+slugs), the `where` clause cannot be used reliably — the slugs must be prepended to the document
+body, and filtering done via `where_document={"$contains": slug}`.
+
+### Observation
+
+This is a non-obvious gotcha for anyone implementing new ChromaDB index modules (e.g.
+`recap_index.py`, `wiki_search.py`, future `chapter_index.py`). The ChromaDB documentation does
+not prominently warn against this; developers naturally reach for `where={"participant": "alice"}`
+expecting substring or partial-match semantics. The silent failure mode is that a metadata `where`
+query with a slug stored as part of a comma-separated string or list simply returns zero results —
+with no error, no warning, and no indication that the filter was incorrectly structured.
+
+The established pattern (prepend slugs to document body, then query via
+`where_document={"$contains": slug}`) is intentional in `recap_index.py` and `wiki_search.py`,
+but without a written gotcha, future implementors will rediscover this independently.
+
+### Suggested Improvement
+
+Add gotcha #058 to `.github/notes/gotchas.md` documenting that ChromaDB `where` is exact scalar
+equality only, and that slug filtering must use `where_document={"$contains": slug}` with the
+slug prepended to the document body at index time.
+
+### Action Taken
+
+Applied: added gotcha #058 to `.github/notes/gotchas.md`.

--- a/.github/notes/reflections/issue-351-chromadb-where-document-slug-filter-2026-05-05.md
+++ b/.github/notes/reflections/issue-351-chromadb-where-document-slug-filter-2026-05-05.md
@@ -1,0 +1,1 @@
+<!-- archived: see archive/issue-351-chromadb-where-document-slug-filter-2026-05-05.md -->

--- a/docs/features/recap-writer-agent.md
+++ b/docs/features/recap-writer-agent.md
@@ -73,6 +73,14 @@ Both JSON files contain the same three top-level keys: `events`, `compact`, and 
 
 The current implementation does not write per-stage recap savepoints. On resume, the orchestrator reloads the latest `PipelineState` snapshot and reruns recap generation for any chapter that has not yet completed the chapter loop in that snapshot.
 
+## Recap Index
+
+Issue #351 adds `src/tools/recap_index.py` as a retrieval helper for persisted chapter recaps. The module maintains one ChromaDB collection per story named `recaps-{story}` and stores one aggregate document per chapter under the stable ID `aggregate/{chapter}`.
+
+`upsert_recap(...)` writes an aggregate body that combines the chapter's `compact` and `sanitised` recap text with pipe-encoded participant and location lines. Metadata stores the chapter number, canonical story slug, `kind="chapter_aggregate"`, and the same pipe-encoded `participants` / `locations` strings so the record remains compatible with ChromaDB's scalar metadata model.
+
+`query_recap(...)` supports five composable filters against the same collection: exact chapter lookup, inclusive chapter ranges, character filter, location filter, and semantic text search. Exact chapter lookup uses `aggregate/{chapter}` directly when no other filters are present; broader retrieval paths return flattened `{id, document, metadata}` rows. `tests/unit/test_recap_index.py` covers idempotent upsert plus all query modes.
+
 ## Model And Prompt Routing
 
 `RecapWriterAgent` resolves its model role through `_build_model_config()`:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -60,6 +60,12 @@ The orchestrator also now produces intermediate story artefacts directly in the 
 | `src/tools/character_manager.py` | Create and update character sheets; write markdown bodies to sibling `.md` files and store `{"$ref": ...}` pointers in JSON |
 | `src/tools/setting_manager.py` | Create and update setting sheets; write markdown bodies to sibling `.md` files and store `{"$ref": ...}` pointers in JSON |
 | `src/tools/recap_manager.py` | Persist chapter recap data |
+| `src/tools/recap_index.py` | Upsert and query one aggregate recap document per chapter in per-story `recaps-{story}` ChromaDB collections |
+
+`src/tools/recap_index.py` is an in-process helper module rather than a user-facing CLI. It exposes two programmatic entry points for recap retrieval:
+
+- `upsert_recap(story_name: str, chapter: int, payload: dict, participants: list[str] | None = None, locations: list[str] | None = None) -> None` — validates the story slug, opens or creates the per-story `recaps-{story}` collection, and upserts one aggregate chapter document with ID `aggregate/{chapter}`. The indexed body stores `compact` plus `sanitised` recap text, while metadata stores `chapter`, `kind="chapter_aggregate"`, `story`, and pipe-encoded `participants` / `locations` values for ChromaDB scalar compatibility.
+- `query_recap(story_name: str, *, character: str | None = None, location: str | None = None, query_text: str | None = None, chapter: int | None = None, chapter_range: tuple[int, int] | None = None, n_results: int = 10) -> list[dict]` — reads from the same collection and returns flattened `{id, document, metadata}` rows. Filters compose with logical AND across exact chapter match, inclusive chapter range, document-text character and location filters, and optional semantic `query_text` retrieval.
 
 ### Generation And Review Tools
 

--- a/src/tools/recap_index.py
+++ b/src/tools/recap_index.py
@@ -1,0 +1,188 @@
+"""ChromaDB recap index helpers for per-story aggregate recap retrieval."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src = str(Path(__file__).resolve().parents[1])
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from tools._chroma_sync import upsert_from_source  # noqa: E402
+from tools._io import _validate_story_name  # noqa: E402
+
+CHROMADB_DIR = os.environ.get("CHROMADB_DIR", str(PROJECT_ROOT / ".chromadb"))
+
+
+def _split_pipe(s: str) -> list[str]:
+    """Split a pipe-joined string into non-empty parts."""
+    return [part for part in s.split("|") if part]
+
+
+def _normalize_story_name(story_name: str) -> str:
+    """Validate story name and return the canonical collection slug."""
+    return _validate_story_name(story_name).name
+
+
+def _get_or_create_collection(story_name: str) -> Any:
+    """Get or create the per-story recap collection."""
+    import chromadb  # type: ignore[import-not-found]
+
+    client = chromadb.PersistentClient(path=CHROMADB_DIR)
+    collection_name = f"recaps-{_normalize_story_name(story_name)}"
+    return client.get_or_create_collection(name=collection_name)
+
+
+def upsert_recap(
+    story_name: str,
+    chapter: int,
+    payload: dict,
+    participants: list[str] | None = None,
+    locations: list[str] | None = None,
+) -> None:
+    """Upsert one chapter aggregate recap into the story collection."""
+    collection = _get_or_create_collection(story_name)
+    doc_id = f"aggregate/{chapter}"
+    pipe_p = "|".join(participants or [])
+    pipe_l = "|".join(locations or [])
+    body = (
+        f"participants:{pipe_p}\n"
+        f"locations:{pipe_l}\n\n"
+        f"{payload.get('compact', '')}\n\n"
+        f"{payload.get('sanitised', '')}"
+    )
+    metadata = {
+        "chapter": chapter,
+        "kind": "chapter_aggregate",
+        "story": _normalize_story_name(story_name),
+        "participants": pipe_p,
+        "locations": pipe_l,
+    }
+
+    upsert_from_source(
+        collection,
+        doc_id,
+        source_path="",
+        extra_metadata=metadata,
+        body=body,
+    )
+
+
+def _build_where_clause(
+    chapter: int | None,
+    chapter_range: tuple[int, int] | None,
+) -> dict[str, Any] | None:
+    if chapter is not None:
+        return {"chapter": chapter}
+    if chapter_range is not None:
+        lo, hi = chapter_range
+        return {
+            "$and": [
+                {"chapter": {"$gte": lo}},
+                {"chapter": {"$lte": hi}},
+            ]
+        }
+    return None
+
+
+def _build_where_document_clause(
+    character: str | None,
+    location: str | None,
+) -> dict[str, Any] | None:
+    if character and location:
+        return {"$and": [{"$contains": character}, {"$contains": location}]}
+    if character:
+        return {"$contains": character}
+    if location:
+        return {"$contains": location}
+    return None
+
+
+def _flatten_query_results(result: dict[str, Any]) -> list[dict[str, Any]]:
+    ids = result.get("ids") or []
+    documents = result.get("documents") or []
+    metadatas = result.get("metadatas") or []
+
+    flat_ids = ids[0] if ids else []
+    flat_documents = documents[0] if documents else []
+    flat_metadatas = metadatas[0] if metadatas else []
+
+    rows: list[dict[str, Any]] = []
+    for index, doc_id in enumerate(flat_ids):
+        rows.append(
+            {
+                "id": doc_id,
+                "document": flat_documents[index]
+                if index < len(flat_documents)
+                else None,
+                "metadata": flat_metadatas[index]
+                if index < len(flat_metadatas)
+                else None,
+            }
+        )
+    return rows
+
+
+def _flatten_get_results(result: dict[str, Any]) -> list[dict[str, Any]]:
+    ids = result.get("ids") or []
+    documents = result.get("documents") or []
+    metadatas = result.get("metadatas") or []
+
+    rows: list[dict[str, Any]] = []
+    for index, doc_id in enumerate(ids):
+        rows.append(
+            {
+                "id": doc_id,
+                "document": documents[index] if index < len(documents) else None,
+                "metadata": metadatas[index] if index < len(metadatas) else None,
+            }
+        )
+    return rows
+
+
+def query_recap(
+    story_name: str,
+    *,
+    character: str | None = None,
+    location: str | None = None,
+    query_text: str | None = None,
+    chapter: int | None = None,
+    chapter_range: tuple[int, int] | None = None,
+    n_results: int = 10,
+) -> list[dict]:
+    """Query recap entries by chapter filters and optional semantic search."""
+    collection = _get_or_create_collection(story_name)
+    where_clause = _build_where_clause(chapter, chapter_range)
+    where_doc_clause = _build_where_document_clause(character, location)
+
+    if query_text:
+        count = collection.count()
+        if count == 0:
+            return []
+        result = collection.query(
+            query_texts=[query_text],
+            n_results=min(n_results, max(1, count)),
+            where=where_clause,
+            where_document=where_doc_clause,
+        )
+        return _flatten_query_results(result)
+
+    if chapter is not None and where_doc_clause is None and chapter_range is None:
+        result = collection.get(
+            ids=[f"aggregate/{chapter}"],
+            include=["documents", "metadatas"],
+        )
+        return _flatten_get_results(result)
+
+    get_kwargs: dict[str, Any] = {"include": ["documents", "metadatas"]}
+    if where_clause is not None:
+        get_kwargs["where"] = where_clause
+    if where_doc_clause is not None:
+        get_kwargs["where_document"] = where_doc_clause
+
+    result = collection.get(**get_kwargs)
+    return _flatten_get_results(result)

--- a/tests/unit/test_recap_index.py
+++ b/tests/unit/test_recap_index.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import chromadb
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import tools.recap_index as recap_index
+from tools.recap_index import _split_pipe, query_recap, upsert_recap
+
+
+@pytest.fixture()
+def recap_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    chromadb_dir = tmp_path / "chromadb"
+    chromadb_dir.mkdir()
+    monkeypatch.setenv("CHROMADB_DIR", str(chromadb_dir))
+    monkeypatch.setattr(recap_index, "CHROMADB_DIR", str(chromadb_dir))
+    return chromadb_dir
+
+
+@pytest.fixture()
+def collection(recap_env: Path):
+    client = chromadb.PersistentClient(path=str(recap_env))
+    return client.get_or_create_collection(name="recaps-test-story")
+
+
+def _payload(compact: str, sanitised: str) -> dict[str, str]:
+    return {"compact": compact, "sanitised": sanitised}
+
+
+def _chapters(rows: list[dict]) -> set[int]:
+    return {
+        row["metadata"]["chapter"]
+        for row in rows
+        if isinstance(row.get("metadata"), dict) and "chapter" in row["metadata"]
+    }
+
+
+def test_upsert_creates_single_aggregate_document(collection) -> None:
+    upsert_recap(
+        "test-story",
+        1,
+        _payload("ch1 compact text", "ch1 sanitised text"),
+    )
+
+    result = collection.get(ids=["aggregate/1"], include=["documents", "metadatas"])
+
+    assert result["ids"] == ["aggregate/1"]
+    assert len(result["documents"]) == 1
+    assert result["metadatas"][0]["chapter"] == 1
+    assert result["metadatas"][0]["kind"] == "chapter_aggregate"
+    assert result["metadatas"][0]["story"] == "test-story"
+
+
+def test_upsert_is_idempotent(collection) -> None:
+    payload = _payload("ch1 compact text", "ch1 sanitised text")
+
+    upsert_recap("test-story", 1, payload)
+    upsert_recap("test-story", 1, payload)
+
+    assert collection.count() == 1
+
+
+def test_query_by_character(collection) -> None:
+    upsert_recap(
+        "test-story",
+        1,
+        _payload("Amy finds a clue", "Amy finds a clue"),
+        participants=["amy"],
+    )
+    upsert_recap(
+        "test-story",
+        2,
+        _payload("Morgan reviews evidence", "Morgan reviews evidence"),
+        participants=["detective-morgan"],
+    )
+
+    result = query_recap("test-story", character="amy")
+
+    assert _chapters(result) == {1}
+
+
+def test_query_by_location(collection) -> None:
+    upsert_recap(
+        "test-story",
+        1,
+        _payload("Bathroom scene", "Bathroom scene"),
+        locations=["the-bathroom"],
+    )
+    upsert_recap(
+        "test-story",
+        2,
+        _payload("Precinct scene", "Precinct scene"),
+        locations=["precinct"],
+    )
+
+    result = query_recap("test-story", location="the-bathroom")
+
+    assert _chapters(result) == {1}
+
+
+def test_query_by_chapter(collection) -> None:
+    upsert_recap("test-story", 1, _payload("chapter one", "chapter one"))
+    upsert_recap("test-story", 2, _payload("chapter two", "chapter two"))
+
+    result = query_recap("test-story", chapter=2)
+
+    assert len(result) == 1
+    assert result[0]["id"] == "aggregate/2"
+    assert result[0]["metadata"]["chapter"] == 2
+
+
+def test_query_by_chapter_range(collection) -> None:
+    upsert_recap("test-story", 1, _payload("chapter one", "chapter one"))
+    upsert_recap("test-story", 2, _payload("chapter two", "chapter two"))
+    upsert_recap("test-story", 3, _payload("chapter three", "chapter three"))
+
+    result = query_recap("test-story", chapter_range=(1, 2))
+
+    assert _chapters(result) == {1, 2}
+
+
+def test_query_semantic(collection) -> None:
+    upsert_recap(
+        "test-story",
+        1,
+        _payload("Amy confronts Morgan in the basement", "Amy confronts Morgan"),
+    )
+    upsert_recap(
+        "test-story",
+        2,
+        _payload("Quiet breakfast before the briefing", "Quiet breakfast"),
+    )
+
+    result = query_recap("test-story", query_text="confrontation", n_results=1)
+
+    assert result
+    assert result[0]["id"] == "aggregate/1"
+
+
+def test_multiple_filters_compose_and(collection) -> None:
+    upsert_recap(
+        "test-story",
+        1,
+        _payload("Amy returns to the bathroom", "Amy returns to the bathroom"),
+        participants=["amy"],
+        locations=["the-bathroom"],
+    )
+    upsert_recap(
+        "test-story",
+        2,
+        _payload("Amy checks the precinct board", "Amy checks the precinct board"),
+        participants=["amy"],
+        locations=["precinct"],
+    )
+
+    result = query_recap("test-story", character="amy", location="the-bathroom")
+
+    assert _chapters(result) == {1}
+
+
+def test_split_pipe_drops_empty_parts() -> None:
+    assert _split_pipe("amy||the-bathroom|") == ["amy", "the-bathroom"]
+    assert _split_pipe("") == []


### PR DESCRIPTION
## Summary

Add `src/tools/recap_index.py` — new per-story `recaps-{story}` ChromaDB collection providing `upsert_recap` and `query_recap` per ADR 014. One aggregate document per chapter (`id = aggregate/{chapter}`, `kind=chapter_aggregate`) with pipe-encoded participant/location metadata. Pipe-joined slugs are prepended to the document body so `where_document=$contains` slug-filtering works correctly. Semantic, chapter, chapter-range, character, and location queries all compose with AND semantics.

## Closes
Closes #351

## Changes
- [x] Implementation complete (`src/tools/recap_index.py`)
- [x] All tests passing (780 passed, 0 failed)
- [x] Linting clean (ruff + mypy)

## Plan

**Implementation:**
- `_split_pipe(s)` — splits pipe-joined string, filters empty strings
- `_get_or_create_collection(story_name)` — creates/gets `recaps-{story_name}` PersistentClient
- `upsert_recap(story_name, chapter, payload, participants, locations)` — one aggregate doc per chapter, idempotent
- `query_recap(story_name, *, character, location, query_text, chapter, chapter_range, n_results)` — all filters compose AND

**Verification tests (`tests/unit/test_recap_index.py`, 9 tests):**
- `test_upsert_creates_single_aggregate_document`
- `test_upsert_is_idempotent`
- `test_query_by_character`
- `test_query_by_location`
- `test_query_by_chapter`
- `test_query_by_chapter_range`
- `test_query_semantic`
- `test_multiple_filters_compose_and`
- `test_split_pipe_drops_empty_parts`
