### PR TITLE
feat(wiki): add per-type wiki extraction prompts for all _TYPE_TO_DIR types

### DIFF
--- a/prompts/wiki/extract_factions_from_chapter.md
+++ b/prompts/wiki/extract_factions_from_chapter.md
@@ -1,0 +1,45 @@
+# Extract Factions from Chapter
+
+You are extracting factions from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate faction page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Faction Name",
+    "type": "faction",
+    "aliases": [],
+    "description": "What this faction is and what role it plays.",
+    "confidence": "verified",
+    "frontmatter": {
+      "alignment": "neutral",
+      "leader": "Character Name or empty string"
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only factions explicitly established in the chapter text.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and grounded in what the chapter states.
+- Set `frontmatter.alignment` only from explicit chapter evidence. If not explicit, use `neutral`.
+- Set `frontmatter.leader` only when the chapter explicitly identifies one. Otherwise use an empty string.
+- Return `[]` when no faction entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_items_from_chapter.md
+++ b/prompts/wiki/extract_items_from_chapter.md
@@ -1,0 +1,45 @@
+# Extract Items from Chapter
+
+You are extracting items from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate item page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Item Name",
+    "type": "item",
+    "aliases": [],
+    "description": "What this item is, its properties, significance.",
+    "confidence": "verified",
+    "frontmatter": {
+      "owner": "slug-of-owner or empty string",
+      "status": "intact"
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only items explicitly established in the chapter text.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and grounded in what the chapter states.
+- Set `frontmatter.owner` only when the chapter explicitly identifies the owner. Use a kebab-case slug for that owner. Otherwise use an empty string.
+- Set `frontmatter.status` from explicit chapter evidence when possible. If the chapter does not establish a different state, use `intact`.
+- Return `[]` when no item entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_plot_threads_from_chapter.md
+++ b/prompts/wiki/extract_plot_threads_from_chapter.md
@@ -1,0 +1,44 @@
+# Extract Plot Threads from Chapter
+
+You are extracting plot threads from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate plot thread page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Thread Name",
+    "type": "plot_thread",
+    "aliases": [],
+    "description": "What this plot thread is about.",
+    "confidence": "verified",
+    "frontmatter": {
+      "status": "active"
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only plot threads explicitly established in the chapter text.
+- Use exact type `plot_thread`.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and grounded in what the chapter states.
+- Set `frontmatter.status` to one of `active`, `resolved`, or `dormant`, based only on explicit chapter evidence. If the chapter does not clearly establish another state, use `active`.
+- Return `[]` when no plot thread entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_relationships_from_chapter.md
+++ b/prompts/wiki/extract_relationships_from_chapter.md
@@ -1,0 +1,46 @@
+# Extract Relationships from Chapter
+
+You are extracting relationships from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate relationship page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Entity A ↔ Entity B",
+    "type": "relationship",
+    "aliases": [],
+    "description": "Nature of the relationship.",
+    "confidence": "verified",
+    "frontmatter": {
+      "participants": ["entity-a-slug", "entity-b-slug"],
+      "relationship_type": "ally"
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only relationships explicitly established in the chapter text.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Format `name` exactly as `Entity A ↔ Entity B` using the `↔` symbol.
+- Set `frontmatter.participants` to exactly two kebab-case slugs derived from the participant entity names.
+- Set `frontmatter.relationship_type` only from explicit chapter evidence. Keep it short and factual, such as `ally`, `enemy`, `family`, `romantic`, or `mentor` when the chapter clearly supports that label.
+- Keep descriptions concise and factual.
+- Return `[]` when no relationship entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_themes_from_chapter.md
+++ b/prompts/wiki/extract_themes_from_chapter.md
@@ -1,0 +1,41 @@
+# Extract Themes from Chapter
+
+You are extracting themes from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate theme page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Theme Name",
+    "type": "theme",
+    "aliases": [],
+    "description": "How this theme manifests in the chapter.",
+    "confidence": "verified",
+    "frontmatter": {}
+  }
+]
+```
+
+## Rules
+
+- Extract only themes explicitly established in the chapter text.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and tied to explicit chapter evidence.
+- Do not infer broad thematic meaning unless the chapter directly supports it.
+- Return `[]` when no theme entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_timeline_from_chapter.md
+++ b/prompts/wiki/extract_timeline_from_chapter.md
@@ -1,0 +1,48 @@
+# Extract Timeline from Chapter
+
+You are extracting timeline entries from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate timeline entry page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Short Event Description at Time",
+    "type": "timeline_entry",
+    "aliases": [],
+    "description": "What happened.",
+    "confidence": "verified",
+    "frontmatter": {
+      "timestamp": "",
+      "participants": [],
+      "chapter": 1
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only timeline entries explicitly established in the chapter text.
+- Use exact type `timeline_entry`.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise and factual.
+- Set `frontmatter.timestamp` to an ISO-8601 or narrative date/time string only when the chapter explicitly provides or clearly states it. Otherwise use an empty string.
+- Set `frontmatter.participants` to a list of kebab-case character slugs only for characters explicitly involved in the event. Use `[]` when none are explicit.
+- Set `frontmatter.chapter` to the integer chapter number if the chapter text explicitly identifies it or contains a clear chapter heading. If no chapter number can be determined from the chapter text, use `0`.
+- Return `[]` when no timeline entry entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_world_rules_from_chapter.md
+++ b/prompts/wiki/extract_world_rules_from_chapter.md
@@ -1,0 +1,41 @@
+# Extract World Rules from Chapter
+
+You are extracting world rules from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate world rule page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Rule Name",
+    "type": "world_rule",
+    "aliases": [],
+    "description": "The rule as it appears in the chapter.",
+    "confidence": "verified",
+    "frontmatter": {}
+  }
+]
+```
+
+## Rules
+
+- Extract only world rules explicitly established in the chapter text.
+- Use exact type `world_rule`.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and limited to the rule as the chapter states it.
+- Return `[]` when no world rule entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/tests/unit/test_wiki_extraction_prompts.py
+++ b/tests/unit/test_wiki_extraction_prompts.py
@@ -1,0 +1,129 @@
+"""Verification tests for wiki extraction prompt templates."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+PROMPTS_DIR = PROJECT_ROOT / "prompts"
+WIKI_PROMPTS_DIR = PROMPTS_DIR / "wiki"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from infrastructure.prompts.prompt_loader import PromptLoader
+
+
+PROMPT_IDS = [
+    "wiki/extract_factions_from_chapter",
+    "wiki/extract_items_from_chapter",
+    "wiki/extract_plot_threads_from_chapter",
+    "wiki/extract_world_rules_from_chapter",
+    "wiki/extract_themes_from_chapter",
+    "wiki/extract_relationships_from_chapter",
+    "wiki/extract_timeline_from_chapter",
+]
+
+PROMPT_FILES = [
+    "extract_factions_from_chapter.md",
+    "extract_items_from_chapter.md",
+    "extract_plot_threads_from_chapter.md",
+    "extract_world_rules_from_chapter.md",
+    "extract_themes_from_chapter.md",
+    "extract_relationships_from_chapter.md",
+    "extract_timeline_from_chapter.md",
+]
+
+SAMPLE_CHAPTER_TEXT = "Sample chapter text. Mara finds the key at dawn."
+SAMPLE_EXISTING_PAGES_INDEX = '[{"name": "Mara", "type": "character"}]'
+
+
+def _loader() -> PromptLoader:
+    return PromptLoader(prompts_dir=str(PROMPTS_DIR))
+
+
+def _load_prompt(prompt_id: str) -> str:
+    return _loader().load_prompt(
+        prompt_id,
+        {
+            "chapter_text": SAMPLE_CHAPTER_TEXT,
+            "existing_pages_index": SAMPLE_EXISTING_PAGES_INDEX,
+        },
+    )
+
+
+class TestWikiExtractionPrompts:
+    def test_extract_factions_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_factions_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_extract_items_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_items_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_extract_plot_threads_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_plot_threads_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_extract_world_rules_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_world_rules_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_extract_themes_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_themes_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_extract_relationships_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_relationships_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_extract_timeline_loads_without_error(self) -> None:
+        content = _load_prompt("wiki/extract_timeline_from_chapter")
+
+        assert len(content) > 0
+        assert "{chapter_text}" not in content
+        assert "{existing_pages_index}" not in content
+
+    def test_all_prompts_contain_chapter_text_placeholder(self) -> None:
+        for prompt_file in PROMPT_FILES:
+            content = (WIKI_PROMPTS_DIR / prompt_file).read_text(encoding="utf-8")
+            assert "{chapter_text}" in content, f"Missing chapter_text in {prompt_file}"
+
+    def test_all_prompts_contain_existing_pages_index_placeholder(self) -> None:
+        for prompt_file in PROMPT_FILES:
+            content = (WIKI_PROMPTS_DIR / prompt_file).read_text(encoding="utf-8")
+            assert "{existing_pages_index}" in content, (
+                f"Missing existing_pages_index in {prompt_file}"
+            )
+
+    def test_chapter_text_variable_is_substituted(self) -> None:
+        for prompt_id in PROMPT_IDS:
+            content = _load_prompt(prompt_id)
+            assert SAMPLE_CHAPTER_TEXT in content
+            assert "{chapter_text}" not in content
+
+    def test_existing_pages_index_variable_is_substituted(self) -> None:
+        for prompt_id in PROMPT_IDS:
+            content = _load_prompt(prompt_id)
+            assert SAMPLE_EXISTING_PAGES_INDEX in content
+            assert "{existing_pages_index}" not in content


### PR DESCRIPTION
## Summary

Adds seven dedicated per-type wiki extraction prompts, one for each `_TYPE_TO_DIR` type that did not previously have a standalone extraction prompt. Each prompt accepts `{chapter_text}` and `{existing_pages_index}` as template variables, returns a strict JSON array of candidate page objects, and returns `[]` when no entities of that type are found in the chapter prose.

## Closes

Closes #354

## Changes

- [ ] `prompts/wiki/extract_factions_from_chapter.md` — new
- [ ] `prompts/wiki/extract_items_from_chapter.md` — new
- [ ] `prompts/wiki/extract_plot_threads_from_chapter.md` — new
- [ ] `prompts/wiki/extract_world_rules_from_chapter.md` — new
- [ ] `prompts/wiki/extract_themes_from_chapter.md` — new
- [ ] `prompts/wiki/extract_relationships_from_chapter.md` — new
- [ ] `prompts/wiki/extract_timeline_from_chapter.md` — new
- [ ] `tests/unit/test_wiki_extraction_prompts.py` — 11 unit tests
- [ ] All tests passing (11 passed, 0 failed)
- [ ] Linting clean (ruff + mypy)

## Plan

**Summary:** Add one extraction prompt per `_TYPE_TO_DIR` type (`faction`, `item`, `plot_thread`, `world_rule`, `theme`, `relationship`, `timeline_entry`). Each prompt uses `{chapter_text}` and `{existing_pages_index}` template variables, returns a JSON array with type-specific frontmatter schema, and returns `[]` when no entities of that type are present.

**Task Checklist:**
- [x] Create `prompts/wiki/extract_factions_from_chapter.md`
- [x] Create `prompts/wiki/extract_items_from_chapter.md`
- [x] Create `prompts/wiki/extract_plot_threads_from_chapter.md`
- [x] Create `prompts/wiki/extract_world_rules_from_chapter.md`
- [x] Create `prompts/wiki/extract_themes_from_chapter.md`
- [x] Create `prompts/wiki/extract_relationships_from_chapter.md`
- [x] Create `prompts/wiki/extract_timeline_from_chapter.md`
- [x] Write `tests/unit/test_wiki_extraction_prompts.py` (11 tests)
- [x] All tests pass