### PR TITLE
feat(wiki): page-body-aware merge prompt + update_wiki_full_pass driver

### DIFF
--- a/prompts/wiki/extract_characters_from_chapter.md
+++ b/prompts/wiki/extract_characters_from_chapter.md
@@ -1,0 +1,50 @@
+# Extract Characters from Chapter
+
+You are extracting characters from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate character page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Character Name",
+    "type": "character",
+    "aliases": [],
+    "description": "Who this character is and what role they play in the chapter.",
+    "confidence": "verified",
+    "frontmatter": {
+      "gender": "unknown",
+      "role": "Primary role in story or chapter",
+      "status": "active",
+      "first_appearance": 1
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only characters explicitly established in the chapter text.
+- Focus on names, roles, physical descriptions, and relationships explicitly mentioned.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and grounded in what the chapter states.
+- Set `frontmatter.gender` only from explicit chapter evidence. If not explicit, use `unknown`.
+- Set `frontmatter.role` to the clearest explicit role or function shown in the chapter. If unclear, use an empty string.
+- Set `frontmatter.status` only from explicit chapter evidence. If not explicit, use `active`.
+- Set `frontmatter.first_appearance` only when the chapter clearly establishes it. Otherwise use the current chapter if implied by first introduction.
+- Return `[]` when no character entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_events_from_chapter.md
+++ b/prompts/wiki/extract_events_from_chapter.md
@@ -1,0 +1,49 @@
+# Extract Events from Chapter
+
+You are extracting events from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate event page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Event Name",
+    "type": "event",
+    "aliases": [],
+    "description": "What happened and why it matters.",
+    "confidence": "verified",
+    "frontmatter": {
+      "event_type": "turning-point",
+      "status": "completed",
+      "chapter": 1,
+      "first_appearance": 1
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only key plot events, turning points, or significant occurrences explicitly established in the chapter text.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and grounded in what the chapter states.
+- Set `frontmatter.event_type` only from explicit chapter evidence. If not explicit, use an empty string.
+- Set `frontmatter.status` only from explicit chapter evidence. If not explicit, use `completed`.
+- Set `frontmatter.chapter` to the chapter in which the event occurs when explicit from context.
+- Set `frontmatter.first_appearance` only when the chapter clearly establishes it. Otherwise use the current chapter if implied by first introduction.
+- Return `[]` when no event entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/extract_locations_from_chapter.md
+++ b/prompts/wiki/extract_locations_from_chapter.md
@@ -1,0 +1,48 @@
+# Extract Locations from Chapter
+
+You are extracting locations from a completed chapter.
+
+<EXISTING_PAGES>
+{existing_pages_index}
+</EXISTING_PAGES>
+
+<CHAPTER_TEXT>
+{chapter_text}
+</CHAPTER_TEXT>
+
+## Task
+
+Return a JSON array of candidate location page objects extracted from the chapter.
+
+## Output schema
+
+```json
+[
+  {
+    "name": "Location Name",
+    "type": "location",
+    "aliases": [],
+    "description": "What this place is and why it matters in the chapter.",
+    "confidence": "verified",
+    "frontmatter": {
+      "location_type": "city",
+      "status": "active",
+      "first_appearance": 1
+    }
+  }
+]
+```
+
+## Rules
+
+- Extract only locations explicitly established in the chapter text.
+- Focus on places, settings, and geographic references that matter to the story.
+- Use `verified` confidence only. This operates on completed chapter text.
+- Do not invent facts not stated in the chapter.
+- Do not create duplicates of entries already listed in `existing_pages_index`.
+- Keep descriptions concise, factual, and grounded in what the chapter states.
+- Set `frontmatter.location_type` only from explicit chapter evidence. If not explicit, use an empty string.
+- Set `frontmatter.status` only from explicit chapter evidence. If not explicit, use `active`.
+- Set `frontmatter.first_appearance` only when the chapter clearly establishes it. Otherwise use the current chapter if implied by first introduction.
+- Return `[]` when no location entities are found in the chapter.
+- Return valid JSON array only. No markdown fences. No commentary.

--- a/prompts/wiki/merge_page.md
+++ b/prompts/wiki/merge_page.md
@@ -1,0 +1,42 @@
+# Merge Wiki Page Patch
+
+You are updating an existing wiki page using a newly extracted candidate.
+
+<EXISTING_PAGE>
+{existing_page_body}
+</EXISTING_PAGE>
+
+<NEW_CANDIDATE>
+{new_candidate}
+</NEW_CANDIDATE>
+
+## Task
+
+Return a JSON patch describing only the changes needed to merge the new candidate into the existing page.
+
+## Output schema
+
+```json
+{
+  "frontmatter_delta": {"key": "new_value"},
+  "body_append": "Text to append to the end of the page body.",
+  "body_sections_replace": [
+    {"heading": "## Section Name", "new_content": "Replacement section body text."}
+  ],
+  "aliases_add": ["alias1"],
+  "no_change": false
+}
+```
+
+## Rules
+
+- Emit a structured patch only. Do not rewrite or reproduce the full page.
+- Never replace the whole page body. Use only `frontmatter_delta`, `body_append`, `body_sections_replace`, and `aliases_add`.
+- Omit fields that do not need changes.
+- If no update is needed, return exactly `{"no_change": true}`.
+- Keep existing content unless the new candidate clearly extends it or corrects it.
+- Use `body_append` for net-new facts that belong at the end of the current body.
+- Use `body_sections_replace` only when an existing section should be refreshed in place. Set `heading` to the exact Markdown heading text to replace.
+- Use `aliases_add` only for genuinely new aliases not already present.
+- Use `frontmatter_delta` only for specific fields that should be added or changed.
+- Return valid JSON object only. No markdown fences. No commentary.

--- a/src/tools/_wiki_api.py
+++ b/src/tools/_wiki_api.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any
@@ -14,7 +17,9 @@ from tools._wiki import (
     match_entities_in_text,
     parse_frontmatter,
     read_index,
+    render_frontmatter,
     slugify,
+    write_index,
 )
 from tools.wiki_update import run_batch
 
@@ -42,6 +47,18 @@ _TYPE_NORMALIZATION = {
     "relationships": "relationship",
     "items": "item",
     "factions": "faction",
+}
+
+_TYPE_TO_PROMPT = {
+    "character": "characters",
+    "location": "locations",
+    "event": "events",
+    "faction": "factions",
+    "item": "items",
+    "plot_thread": "plot_threads",
+    "theme": "themes",
+    "world_rule": "world_rules",
+    "relationship": "relationships",
 }
 
 _CONFIDENCE_ORDER = {"speculative": 0, "planned": 1, "verified": 2}
@@ -267,6 +284,183 @@ def _read_compact_page(story_dir: Path, slug: str) -> dict[str, Any] | None:
     return None
 
 
+def _read_full_page_body(
+    story_dir: Path, slug: str
+) -> tuple[dict[str, Any], str] | None:
+    wiki_dir = get_wiki_dir(story_dir)
+    if not wiki_dir.exists():
+        return None
+
+    resolved_wiki_dir = wiki_dir.resolve()
+    for page_path in wiki_dir.rglob(f"{slug}.md"):
+        if not page_path.resolve().is_relative_to(resolved_wiki_dir):
+            continue
+        raw_text = page_path.read_text()
+        metadata, _body = parse_frontmatter(raw_text)
+        return metadata, raw_text
+    return None
+
+
+def _extract_type_candidates(
+    story_name: str,
+    page_type: str,
+    chapter_text: str,
+    index_entries: list[dict[str, Any]],
+    *,
+    model: str | None = None,
+    base_url: str | None = None,
+) -> list[dict[str, Any]]:
+    _ = story_name
+    prompt_suffix = _TYPE_TO_PROMPT.get(page_type)
+    if prompt_suffix is None:
+        raise ValueError(f"unsupported page type: {page_type}")
+
+    filtered_entries = [
+        entry for entry in index_entries if entry.get("type") == page_type
+    ]
+    prompt = _load_prompt(
+        f"wiki/extract_{prompt_suffix}_from_chapter",
+        {
+            "chapter_text": chapter_text,
+            "existing_pages_index": json.dumps(
+                filtered_entries,
+                indent=2,
+                ensure_ascii=True,
+            ),
+        },
+    )
+    result = _parse_json_response(
+        _chat_completion(prompt, model=model, base_url=base_url),
+        f"{page_type} extraction",
+    )
+    if not isinstance(result, list):
+        raise ValueError(f"{page_type} extraction must return a JSON array")
+    return [item for item in result if isinstance(item, dict)]
+
+
+def _replace_markdown_section(body: str, heading: str, new_content: str) -> str:
+    lines = body.splitlines()
+    heading_text = heading.strip()
+    start_index: int | None = None
+
+    for index, line in enumerate(lines):
+        if line.strip() == heading_text:
+            start_index = index
+            break
+
+    replacement_lines = [heading_text]
+    stripped_content = new_content.strip()
+    if stripped_content:
+        replacement_lines.extend(["", *stripped_content.splitlines()])
+
+    if start_index is None:
+        if body.strip():
+            return body.rstrip("\n") + "\n\n" + "\n".join(replacement_lines) + "\n"
+        return "\n".join(replacement_lines) + "\n"
+
+    end_index = len(lines)
+    for index in range(start_index + 1, len(lines)):
+        if lines[index].startswith("#"):
+            end_index = index
+            break
+
+    updated_lines = lines[:start_index] + replacement_lines + lines[end_index:]
+    updated_body = "\n".join(updated_lines).rstrip("\n")
+    return updated_body + "\n"
+
+
+def _apply_merge_patch(story_dir: Path, slug: str, patch: dict[str, Any]) -> bool:
+    if patch.get("no_change") is True:
+        return False
+
+    wiki_dir = get_wiki_dir(story_dir)
+    resolved_wiki_dir = wiki_dir.resolve()
+    page_path: Path | None = None
+    for candidate_path in wiki_dir.rglob(f"{slug}.md"):
+        if candidate_path.resolve().is_relative_to(resolved_wiki_dir):
+            page_path = candidate_path
+            break
+
+    if page_path is None:
+        raise ValueError(f"page '{slug}' not found for merge")
+
+    original_text = page_path.read_text()
+    metadata, body = parse_frontmatter(original_text)
+
+    frontmatter_delta = patch.get("frontmatter_delta")
+    if isinstance(frontmatter_delta, dict):
+        metadata.update(frontmatter_delta)
+
+    aliases_add = patch.get("aliases_add")
+    if isinstance(aliases_add, list):
+        existing_aliases = metadata.get("aliases", [])
+        if not isinstance(existing_aliases, list):
+            existing_aliases = []
+        merged_aliases: list[str] = []
+        for alias in [*existing_aliases, *aliases_add]:
+            if isinstance(alias, str) and alias.strip() and alias not in merged_aliases:
+                merged_aliases.append(alias)
+        metadata["aliases"] = merged_aliases
+
+    body_append = patch.get("body_append")
+    if isinstance(body_append, str) and body_append.strip():
+        if body.strip():
+            body = body.rstrip("\n") + "\n\n" + body_append.strip() + "\n"
+        else:
+            body = body_append.strip() + "\n"
+
+    body_sections_replace = patch.get("body_sections_replace")
+    if isinstance(body_sections_replace, list):
+        for section_patch in body_sections_replace:
+            if not isinstance(section_patch, dict):
+                continue
+            heading = section_patch.get("heading")
+            new_content = section_patch.get("new_content")
+            if (
+                isinstance(heading, str)
+                and heading.strip()
+                and isinstance(new_content, str)
+            ):
+                body = _replace_markdown_section(body, heading, new_content)
+
+    candidate_text = render_frontmatter(metadata, body.rstrip("\n"))
+    if candidate_text == original_text:
+        return False
+
+    version = metadata.get("version", 0)
+    if not isinstance(version, int):
+        version = 0
+    metadata["version"] = version + 1
+    metadata["last_updated"] = datetime.now(timezone.utc).isoformat()
+
+    new_text = render_frontmatter(metadata, body.rstrip("\n"))
+
+    _atomic_write(page_path, new_text)
+
+    index_entries = read_index(wiki_dir)
+    index_changed = False
+    for entry in index_entries:
+        if entry.get("slug") != slug:
+            continue
+        name = metadata.get("name")
+        aliases = metadata.get("aliases")
+        if isinstance(name, str) and entry.get("name") != name:
+            entry["name"] = name
+            index_changed = True
+        if isinstance(aliases, list):
+            normalized_aliases = [
+                alias for alias in aliases if isinstance(alias, str) and alias.strip()
+            ]
+            if entry.get("aliases") != normalized_aliases:
+                entry["aliases"] = normalized_aliases
+                index_changed = True
+        break
+    if index_changed:
+        write_index(wiki_dir, index_entries)
+
+    return True
+
+
 def _merge_update_entries(
     state_changes: Any,
     new_aliases: Any,
@@ -474,4 +668,157 @@ def update_wiki_from_chapter(
         **summary,
         "new_slugs": [create["slug"] for create in creates],
         "updated_slugs": [update["slug"] for update in updates],
+    }
+
+
+def update_wiki_full_pass(
+    story_name: str,
+    chapter: int,
+    chapter_text: str,
+    *,
+    model: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    story_dir = _validate_story_name(story_name)
+    wiki_dir = get_wiki_dir(story_dir)
+    index_entries = read_index(wiki_dir) if wiki_dir.exists() else []
+
+    pass_a_types = list(_TYPE_TO_PROMPT.keys())
+    type_candidates: dict[str, list[dict[str, Any]]] = {
+        page_type: [] for page_type in pass_a_types
+    }
+
+    if pass_a_types:
+        with ThreadPoolExecutor(max_workers=min(9, len(pass_a_types))) as executor:
+            future_to_type = {
+                executor.submit(
+                    _extract_type_candidates,
+                    story_name,
+                    page_type,
+                    chapter_text,
+                    index_entries,
+                    model=model,
+                    base_url=base_url,
+                ): page_type
+                for page_type in pass_a_types
+            }
+            for future in as_completed(future_to_type):
+                page_type = future_to_type[future]
+                try:
+                    type_candidates[page_type] = future.result()
+                except Exception as exc:
+                    logging.warning(
+                        "[Wiki] WARNING type=%s extraction failed: %s",
+                        page_type,
+                        exc,
+                    )
+                    type_candidates[page_type] = []
+
+    for page_type in pass_a_types:
+        type_index = [
+            entry for entry in index_entries if entry.get("type") == page_type
+        ]
+        alias_matches = match_entities_in_text(chapter_text, type_index)
+        if not type_candidates[page_type] and alias_matches:
+            matched_names = [
+                match.get("name", match.get("slug", "?")) for match in alias_matches
+            ]
+            logging.warning(
+                "[Wiki] WARNING type=%s 0 candidates but aliases matched: %s",
+                page_type,
+                ", ".join(matched_names),
+            )
+
+    per_type_stats = {
+        page_type: {"created": 0, "updated": 0} for page_type in pass_a_types
+    }
+    cache = _load_extract_cache(story_dir)
+
+    try:
+        for page_type, candidates in type_candidates.items():
+            for candidate in candidates:
+                if not isinstance(candidate, dict):
+                    continue
+
+                candidate_name = candidate.get("name")
+                if not isinstance(candidate_name, str) or not candidate_name.strip():
+                    logging.warning(
+                        "[Wiki] WARNING type=%s candidate missing name; skipped",
+                        page_type,
+                    )
+                    continue
+
+                slug = slugify(candidate_name)
+                full_page = _read_full_page_body(story_dir, slug)
+
+                if full_page is None:
+                    entity = _normalize_entity(
+                        candidate,
+                        default_confidence="inferred",
+                        first_appearance=chapter,
+                    )
+                    entity_with_slug = {**entity, "slug": slug}
+                    detail_levels = _generate_detail_levels(
+                        entity_with_slug,
+                        model=model,
+                        cache=cache,
+                        story_dir=story_dir,
+                        base_url=base_url,
+                    )
+                    create_entry = _build_create_entry(entity, detail_levels)
+                    run_batch(
+                        story_name,
+                        {
+                            "creates": [create_entry],
+                            "updates": [],
+                            "timeline_events": [],
+                        },
+                    )
+                    per_type_stats[page_type]["created"] += 1
+                    index_entries.append(
+                        {
+                            "name": entity["name"],
+                            "slug": slug,
+                            "type": entity["type"],
+                            "aliases": entity["aliases"],
+                        }
+                    )
+                    continue
+
+                _existing_metadata, raw_page_text = full_page
+                merge_prompt = _load_prompt(
+                    "wiki/merge_page",
+                    {
+                        "existing_page_body": raw_page_text,
+                        "new_candidate": json.dumps(
+                            candidate,
+                            indent=2,
+                            ensure_ascii=True,
+                        ),
+                    },
+                )
+                raw_response = _chat_completion(
+                    merge_prompt,
+                    model=model,
+                    base_url=base_url,
+                )
+                patch = _parse_json_response(raw_response, "merge page")
+                if not isinstance(patch, dict):
+                    raise ValueError("merge page must return a JSON object")
+                if patch.get("no_change"):
+                    continue
+                changed = _apply_merge_patch(story_dir, slug, patch)
+                if changed:
+                    per_type_stats[page_type]["updated"] += 1
+                    refreshed_index = read_index(wiki_dir) if wiki_dir.exists() else []
+                    index_entries = refreshed_index
+    finally:
+        _delete_extract_cache(story_dir)
+
+    total_created = sum(stats["created"] for stats in per_type_stats.values())
+    total_updated = sum(stats["updated"] for stats in per_type_stats.values())
+    return {
+        "per_type": per_type_stats,
+        "total_created": total_created,
+        "total_updated": total_updated,
     }

--- a/tests/integration/test_wiki_full_pass.py
+++ b/tests/integration/test_wiki_full_pass.py
@@ -1,0 +1,298 @@
+"""Integration tests for update_wiki_full_pass."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from tools import _io, _wiki_api, wiki_update  # noqa: E402
+from tools._wiki import render_frontmatter, write_index  # noqa: E402
+
+
+def _init_wiki(story_dir: Path) -> None:
+    wiki_dir = story_dir / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    for subdir in [
+        "characters",
+        "locations",
+        "events",
+        "factions",
+        "items",
+        "plot-threads",
+        "world-rules",
+        "themes",
+        "relationships",
+        "timeline",
+        "chapters",
+    ]:
+        (wiki_dir / subdir).mkdir(exist_ok=True)
+    (wiki_dir / "log.md").write_text("# Wiki Change Log\n", encoding="utf-8")
+    (wiki_dir / "timeline" / "main-timeline.md").write_text(
+        "# Main Timeline\n\n",
+        encoding="utf-8",
+    )
+    write_index(wiki_dir, [])
+
+
+def _write_page(
+    story_dir: Path,
+    *,
+    subdir: str,
+    slug: str,
+    metadata: dict[str, object],
+    body: str,
+) -> None:
+    page_path = story_dir / "wiki" / subdir / f"{slug}.md"
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    page_path.write_text(
+        render_frontmatter(metadata, body),
+        encoding="utf-8",
+    )
+
+
+def _fake_chat_completion_factory(
+    *,
+    character_candidates: list[dict[str, object]] | None = None,
+    merge_patch: dict[str, object] | None = None,
+    detail_levels: dict[str, str] | None = None,
+):
+    character_payload = json.dumps(character_candidates or [])
+    merge_payload = json.dumps(merge_patch or {"no_change": True})
+    detail_payload = json.dumps(
+        detail_levels
+        or {
+            "l1": "Short detail",
+            "l2": "Medium detail",
+            "l3": "Long detail",
+        }
+    )
+
+    def _fake_chat_completion(
+        prompt: str,
+        *,
+        model: str | None = None,
+        base_url: str | None = None,
+    ) -> str:
+        assert model is None
+        assert base_url is None
+        if "Extract Characters from Chapter" in prompt:
+            return character_payload
+        if "Merge Wiki Page Patch" in prompt:
+            return merge_payload
+        if "Generate Wiki Detail Levels" in prompt:
+            return detail_payload
+        if "Extract " in prompt and "from Chapter" in prompt:
+            return "[]"
+        raise AssertionError(f"Unexpected LLM prompt: {prompt[:200]}")
+
+    return _fake_chat_completion
+
+
+@pytest.fixture()
+def story_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    stories_dir = tmp_path / "stories"
+    chromadb_dir = tmp_path / "chromadb"
+    story_dir = stories_dir / "test-story"
+    story_dir.mkdir(parents=True)
+    chromadb_dir.mkdir(parents=True)
+    _init_wiki(story_dir)
+
+    monkeypatch.setenv("STORIES_DIR", str(stories_dir))
+    monkeypatch.setenv("CHROMADB_DIR", str(chromadb_dir))
+    monkeypatch.setattr(_io, "STORIES_DIR", stories_dir)
+    monkeypatch.setattr(wiki_update, "CHROMADB_DIR", str(chromadb_dir))
+    return story_dir
+
+
+class TestWikiFullPass:
+    def test_full_pass_returns_per_type_stats(
+        self,
+        story_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            _wiki_api,
+            "_chat_completion",
+            _fake_chat_completion_factory(),
+        )
+
+        result = _wiki_api.update_wiki_full_pass(
+            "test-story",
+            1,
+            "Some chapter text",
+        )
+
+        assert set(result) == {"per_type", "total_created", "total_updated"}
+        assert result["total_created"] == 0
+        assert result["total_updated"] == 0
+        per_type = result["per_type"]
+        expected_types = {"character", "location", "faction", "item"}
+        assert expected_types <= set(per_type)
+        for stats in per_type.values():
+            assert stats == {"created": 0, "updated": 0}
+
+    def test_full_pass_new_entity_creates_page(
+        self,
+        story_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            _wiki_api,
+            "_chat_completion",
+            _fake_chat_completion_factory(
+                character_candidates=[
+                    {
+                        "name": "Alice",
+                        "type": "character",
+                        "aliases": [],
+                        "description": "Alice leads the expedition.",
+                        "confidence": "verified",
+                        "frontmatter": {"role": "leader", "status": "active"},
+                    }
+                ],
+                detail_levels={
+                    "l1": "Alice leads the expedition.",
+                    "l2": "Alice is the active expedition leader.",
+                    "l3": "Alice is a verified character who leads the expedition.",
+                },
+            ),
+        )
+
+        result = _wiki_api.update_wiki_full_pass(
+            "test-story",
+            1,
+            "Alice leads the team into the ruins.",
+        )
+
+        assert result["total_created"] >= 1
+        assert result["total_updated"] == 0
+        created_page = story_env / "wiki" / "characters" / "alice.md"
+        assert created_page.exists()
+        page_text = created_page.read_text(encoding="utf-8")
+        assert "name: Alice" in page_text
+        assert "Alice leads the expedition." in page_text
+
+    def test_full_pass_existing_entity_uses_merge(
+        self,
+        story_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_page(
+            story_env,
+            subdir="characters",
+            slug="alice",
+            metadata={
+                "type": "character",
+                "name": "Alice",
+                "slug": "alice",
+                "aliases": [],
+                "confidence": "verified",
+                "first_appearance": 1,
+                "version": 1,
+            },
+            body="Alice already has a wiki page.",
+        )
+        write_index(
+            story_env / "wiki",
+            [
+                {
+                    "name": "Alice",
+                    "slug": "alice",
+                    "type": "character",
+                    "aliases": [],
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            _wiki_api,
+            "_chat_completion",
+            _fake_chat_completion_factory(
+                character_candidates=[
+                    {
+                        "name": "Alice",
+                        "type": "character",
+                        "aliases": [],
+                        "description": "Alice appears again.",
+                        "confidence": "verified",
+                        "frontmatter": {"role": "leader"},
+                    }
+                ],
+                merge_patch={"no_change": True},
+            ),
+        )
+
+        result = _wiki_api.update_wiki_full_pass(
+            "test-story",
+            1,
+            "Alice appears again in the chapter.",
+        )
+
+        assert result["total_created"] == 0
+        assert result["total_updated"] == 0
+        assert (story_env / "wiki" / "characters" / "alice.md").exists()
+
+    def test_full_pass_zero_result_alias_warning(
+        self,
+        story_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _write_page(
+            story_env,
+            subdir="characters",
+            slug="alice",
+            metadata={
+                "type": "character",
+                "name": "Alice",
+                "slug": "alice",
+                "aliases": ["Al"],
+                "confidence": "verified",
+                "first_appearance": 1,
+                "version": 1,
+            },
+            body="Alice already has a wiki page.",
+        )
+        write_index(
+            story_env / "wiki",
+            [
+                {
+                    "name": "Alice",
+                    "slug": "alice",
+                    "type": "character",
+                    "aliases": ["Al"],
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            _wiki_api,
+            "_chat_completion",
+            _fake_chat_completion_factory(),
+        )
+        caplog.set_level(logging.WARNING)
+
+        result = _wiki_api.update_wiki_full_pass(
+            "test-story",
+            1,
+            "Alice walks into the archive.",
+        )
+
+        assert result["total_created"] == 0
+        assert result["total_updated"] == 0
+        assert any(
+            record.levelno == logging.WARNING
+            and "WARNING" in record.message
+            and "0 candidates" in record.message
+            and "Alice" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary

Replace the single-shot `_prepare_chapter_update` omnibus extraction with a two-pass architecture. Pass A runs all available per-type extraction prompts in parallel (using `ThreadPoolExecutor`). Pass B feeds each candidate's full existing page body plus the new candidate to a new `prompts/wiki/merge_page.md` prompt that emits a structured patch. New pages (no existing body) bypass the merge prompt and go directly to the creation flow. Zero-result + alias-match mismatches emit `logging.warning`. A new public `update_wiki_full_pass` function drives both passes and returns per-type stats.

## Closes
Closes #355

## Changes
- [x] Implementation complete
- [x] All tests passing (verified)
- [x] Linting clean

## Plan

**Affected Areas**: Python domain logic; Prompt templates. ChromaDB schema change: no.

**Task Checklist** (ordered by dependency):

1. `prompts/wiki/extract_characters_from_chapter.md` — new per-type prompt (follows Task 4 pattern)
2. `prompts/wiki/extract_locations_from_chapter.md` — new per-type prompt
3. `prompts/wiki/extract_events_from_chapter.md` — new per-type prompt
4. `prompts/wiki/merge_page.md` — new merge prompt; LLM emits structured patch, not full replacement
5. `src/tools/_wiki_api.py`:
   - `_read_full_page_body(story_dir, slug) -> tuple[dict, str] | None`
   - `_extract_type_candidates(story_name, type_name, chapter_text, index_entries, ...) -> list[dict]`
   - `_apply_merge_patch(story_dir, slug, patch) -> bool`
   - `update_wiki_full_pass(story_name, chapter, chapter_text, *, model, base_url) -> dict`
   - Kept `update_wiki_from_chapter` and `_prepare_chapter_update` intact (backward compat)
6. `tests/integration/test_wiki_full_pass.py` — 4 integration tests

**Verification**:
- 4 new integration tests: 4 passed, 0 failed (0.42s)
- Lint: ✅ ruff clean
- Format: ✅ ruff format clean
- Types: ✅ mypy 0 issues in 76 source files