### PR TITLE
feat(wiki): switch WikiMaintainerAgent to update_wiki_full_pass; surface per-type stats

### DIFF
--- a/src/presentation/agents/wiki_maintainer.py
+++ b/src/presentation/agents/wiki_maintainer.py
@@ -14,7 +14,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
-from tools._wiki_api import update_wiki_from_chapter
+from tools._wiki_api import update_wiki_full_pass
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -63,7 +63,7 @@ class WikiMaintainerAgent:
 
         try:
             summary = await asyncio.to_thread(
-                update_wiki_from_chapter,
+                update_wiki_full_pass,
                 story_name,
                 chapter_number,
                 chapter_content,
@@ -75,33 +75,43 @@ class WikiMaintainerAgent:
                 f"Wiki update failed for story={story_name!r} chapter={chapter_number}: {exc}"
             ) from exc
 
-        new_slugs: list[str] = summary.get("new_slugs", [])
-        updated_slugs: list[str] = summary.get("updated_slugs", [])
+        per_type = summary.get("per_type") or {}
+        active_parts: list[str] = []
 
-        for slug in new_slugs:
+        for page_type, stats in per_type.items():
+            if not isinstance(page_type, str) or not isinstance(stats, dict):
+                continue
+
+            created = stats.get("created", 0)
+            updated = stats.get("updated", 0)
+            if not isinstance(created, int) or not isinstance(updated, int):
+                continue
+            if created <= 0 and updated <= 0:
+                continue
+
             await self.wiki_bus.emit(
                 WikiContextEvent(
                     phase="wiki",
                     event_type="entity_match",
-                    content=f"Created wiki page: {slug}",
-                    metadata={"slug": slug, "action": "create"},
+                    content=f"{page_type}: +{created}/~{updated}",
+                    metadata={
+                        "type": page_type,
+                        "created": created,
+                        "updated": updated,
+                    },
                 )
             )
+            active_parts.append(f"{page_type}: +{created}/~{updated}")
 
-        for slug in updated_slugs:
-            await self.wiki_bus.emit(
-                WikiContextEvent(
-                    phase="wiki",
-                    event_type="entity_match",
-                    content=f"Updated wiki page: {slug}",
-                    metadata={"slug": slug, "action": "update"},
-                )
+        if active_parts:
+            await self.bus.emit(
+                f"[Wiki] chapter {chapter_number} — {'; '.join(active_parts)}"
             )
 
         return WikiUpdateBatch(
             story_name=story_name,
             chapter_number=chapter_number,
-            updated_pages=updated_slugs,
-            new_pages=new_slugs,
+            updated_pages=[],
+            new_pages=[],
             savepoint_id=None,
         )

--- a/src/tools/_wiki_api.py
+++ b/src/tools/_wiki_api.py
@@ -641,6 +641,8 @@ def update_wiki_from_chapter(
 ) -> dict[str, Any]:
     """Run wiki update for a chapter from chapter text string.
 
+    Deprecated: use update_wiki_full_pass instead.
+
     This is the programmatic API used by WikiMaintainerAgent.
     Unlike cmd_update_from_chapter, this accepts chapter text directly
     instead of requiring a file path.

--- a/tests/unit/test_wiki_maintainer.py
+++ b/tests/unit/test_wiki_maintainer.py
@@ -15,12 +15,12 @@ from presentation.pipeline_primitives import WikiContextEvent
 
 
 _FAKE_SUMMARY = {
-    "created": 2,
-    "updated": 1,
-    "timeline_events": 0,
-    "entity_counts": {},
-    "new_slugs": ["priya", "ember-port"],
-    "updated_slugs": ["vale"],
+    "per_type": {
+        "character": {"created": 2, "updated": 0},
+        "location": {"created": 0, "updated": 1},
+    },
+    "total_created": 2,
+    "total_updated": 1,
 }
 
 
@@ -72,7 +72,7 @@ async def test_run_returns_populated_wiki_update_batch() -> None:
     agent, _ = _build_agent()
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         return_value=_FAKE_SUMMARY,
     ):
         result = await agent.run("test-story", 3, "Chapter text")
@@ -80,8 +80,8 @@ async def test_run_returns_populated_wiki_update_batch() -> None:
     assert isinstance(result, WikiUpdateBatch)
     assert result.story_name == "test-story"
     assert result.chapter_number == 3
-    assert result.new_pages == ["priya", "ember-port"]
-    assert result.updated_pages == ["vale"]
+    assert result.new_pages == []
+    assert result.updated_pages == []
     assert result.savepoint_id is None
 
 
@@ -89,16 +89,16 @@ async def test_run_returns_populated_wiki_update_batch() -> None:
 async def test_run_emits_wiki_context_events_for_each_page() -> None:
     agent, wiki_bus = _build_agent()
     summary = {
-        "created": 1,
-        "updated": 1,
-        "timeline_events": 0,
-        "entity_counts": {},
-        "new_slugs": ["priya"],
-        "updated_slugs": ["vale"],
+        "per_type": {
+            "character": {"created": 2, "updated": 0},
+            "location": {"created": 0, "updated": 1},
+        },
+        "total_created": 2,
+        "total_updated": 1,
     }
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         return_value=summary,
     ):
         await agent.run("test-story", 2, "Chapter text")
@@ -112,14 +112,14 @@ async def test_run_emits_wiki_context_events_for_each_page() -> None:
     assert wiki_bus.events[1] == WikiContextEvent(
         phase="wiki",
         event_type="entity_match",
-        content="Created wiki page: priya",
-        metadata={"slug": "priya", "action": "create"},
+        content="character: +2/~0",
+        metadata={"type": "character", "created": 2, "updated": 0},
     )
     assert wiki_bus.events[2] == WikiContextEvent(
         phase="wiki",
         event_type="entity_match",
-        content="Updated wiki page: vale",
-        metadata={"slug": "vale", "action": "update"},
+        content="location: +0/~1",
+        metadata={"type": "location", "created": 0, "updated": 1},
     )
 
 
@@ -127,16 +127,16 @@ async def test_run_emits_wiki_context_events_for_each_page() -> None:
 async def test_run_no_pages_returns_empty_batch() -> None:
     agent, wiki_bus = _build_agent()
     summary = {
-        "created": 0,
-        "updated": 0,
-        "timeline_events": 0,
-        "entity_counts": {},
-        "new_slugs": [],
-        "updated_slugs": [],
+        "per_type": {
+            "character": {"created": 0, "updated": 0},
+            "location": {"created": 0, "updated": 0},
+        },
+        "total_created": 0,
+        "total_updated": 0,
     }
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         return_value=summary,
     ):
         result = await agent.run("test-story", 4, "Chapter text")
@@ -162,7 +162,7 @@ async def test_run_does_not_call_provider_stream_text() -> None:
     agent, _ = _build_agent(provider=_UnexpectedProvider())
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         return_value=_FAKE_SUMMARY,
     ):
         await agent.run("test-story", 1, "Chapter text")
@@ -175,7 +175,7 @@ async def test_run_uses_model_config_from_eval_model() -> None:
     )
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         return_value=_FAKE_SUMMARY,
     ) as mock_update:
         await agent.run("test-story", 5, "Chapter text")
@@ -196,7 +196,7 @@ async def test_run_passes_base_url_when_host_is_configured() -> None:
     )
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         return_value=_FAKE_SUMMARY,
     ) as mock_update:
         await agent.run("test-story", 5, "Chapter text")
@@ -215,7 +215,7 @@ async def test_run_raises_runtime_error_with_context_on_failure() -> None:
     agent, _ = _build_agent()
 
     with patch(
-        "presentation.agents.wiki_maintainer.update_wiki_from_chapter",
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
         side_effect=ValueError("wiki not initialised"),
     ):
         with pytest.raises(RuntimeError) as exc_info:
@@ -225,3 +225,77 @@ async def test_run_raises_runtime_error_with_context_on_failure() -> None:
     assert "test-story" in message
     assert "5" in message
     assert "wiki not initialised" in message
+
+
+@pytest.mark.asyncio
+async def test_run_emits_bus_summary_line_with_active_types() -> None:
+    agent, _ = _build_agent()
+
+    with patch(
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
+        return_value=_FAKE_SUMMARY,
+    ):
+        await agent.run("test-story", 6, "Chapter text")
+
+    assert agent.bus.tokens == ["[Wiki] chapter 6 — character: +2/~0; location: +0/~1"]
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_emit_bus_summary_when_no_changes() -> None:
+    agent, _ = _build_agent()
+    summary = {
+        "per_type": {
+            "character": {"created": 0, "updated": 0},
+            "location": {"created": 0, "updated": 0},
+        },
+        "total_created": 0,
+        "total_updated": 0,
+    }
+
+    with patch(
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
+        return_value=summary,
+    ):
+        await agent.run("test-story", 7, "Chapter text")
+
+    assert agent.bus.tokens == []
+
+
+@pytest.mark.asyncio
+async def test_run_wiki_bus_only_gets_events_for_nonzero_types() -> None:
+    agent, wiki_bus = _build_agent()
+    summary = {
+        "per_type": {
+            "character": {"created": 2, "updated": 0},
+            "location": {"created": 0, "updated": 0},
+            "thread": {"created": 0, "updated": 1},
+        },
+        "total_created": 2,
+        "total_updated": 1,
+    }
+
+    with patch(
+        "presentation.agents.wiki_maintainer.update_wiki_full_pass",
+        return_value=summary,
+    ):
+        await agent.run("test-story", 8, "Chapter text")
+
+    assert wiki_bus.events == [
+        WikiContextEvent(
+            phase="wiki",
+            event_type="wikilink_traversal",
+            content="Processing chapter 8 wiki updates",
+        ),
+        WikiContextEvent(
+            phase="wiki",
+            event_type="entity_match",
+            content="character: +2/~0",
+            metadata={"type": "character", "created": 2, "updated": 0},
+        ),
+        WikiContextEvent(
+            phase="wiki",
+            event_type="entity_match",
+            content="thread: +0/~1",
+            metadata={"type": "thread", "created": 0, "updated": 1},
+        ),
+    ]


### PR DESCRIPTION
## Summary

Switches `WikiMaintainerAgent.run()` from the old `update_wiki_from_chapter` API to `update_wiki_full_pass` (introduced in #355), and surfaces per-type wiki activity stats on both event buses after each chapter completes.

## Closes
Closes #356

## Changes

- **`src/presentation/agents/wiki_maintainer.py`**: imports and calls `update_wiki_full_pass`; emits one `WikiContextEvent` per active page type on `wiki_bus`; emits a human-readable summary line on `bus` (e.g. `[Wiki] chapter 3 — character: +2/~1; location: +0/~1`); returns `WikiUpdateBatch` with empty slug lists (full-pass API tracks counts, not slugs).
- **`src/tools/_wiki_api.py`**: docstring on `update_wiki_from_chapter` marked deprecated, pointing callers to `update_wiki_full_pass`. Implementation unchanged; shim kept for `wiki_extract.py` re-export compatibility.
- **`tests/unit/test_wiki_maintainer.py`**: all existing tests updated for new patch target and return shape; 3 new tests added covering bus summary emission, zero-change suppression, and per-type filtering.

## Verification

- [x] Implementation complete
- [x] All 10 tests passing (`pytest tests/unit/test_wiki_maintainer.py -v` → 10 passed in 0.07s)
- [x] Linting clean (`ruff check`, `ruff format`, `mypy`)

## Plan

**Task Checklist:**
- [x] Switch `update_wiki_from_chapter` → `update_wiki_full_pass` in `wiki_maintainer.py`
- [x] Emit per-type `WikiContextEvent` on `wiki_bus` for non-zero types
- [x] Emit human-readable summary line on `bus`
- [x] Deprecate `update_wiki_from_chapter` in `_wiki_api.py`
- [x] Update and extend `test_wiki_maintainer.py`
