### PR TITLE
feat(context): add assemble_context helper (wiki + recap retrieval for all agents)

### DIFF
--- a/src/tools/context_assembly.py
+++ b/src/tools/context_assembly.py
@@ -1,0 +1,258 @@
+"""Context assembly helper — single entry point for wiki + recap retrieval."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Literal
+
+from domain.exceptions import StoryGenerationError
+from tools._llm import count_tokens
+from tools.recap_index import query_recap
+from tools.wiki_snapshot import get_snapshot
+
+# ---------------------------------------------------------------------------
+# Per-scope wiki budget caps (tokens)
+# ---------------------------------------------------------------------------
+_SCOPE_WIKI_BUDGET: dict[str, int] = {
+    "outline": 6000,
+    "chapter": 12000,
+    "scene": 8000,
+    "consistency": 10000,
+    "recap": 2000,
+    "metadata": 4000,
+    "final_edit": 10000,
+}
+
+# Scopes where an empty wiki snapshot is expected (no warning emitted)
+_INITIAL_SCOPES: frozenset[str] = frozenset({"outline"})
+
+# Scopes where ChromaDB unavailability is fatal
+_FATAL_CHROMA_SCOPES: frozenset[str] = frozenset({"chapter", "consistency"})
+
+
+def assemble_context(
+    story_name: str,
+    *,
+    scope: Literal[
+        "outline",
+        "chapter",
+        "scene",
+        "consistency",
+        "recap",
+        "metadata",
+        "final_edit",
+    ],
+    focus: str,
+    chapter: int | None = None,
+    scene: int | None = None,
+    pov_character: str | None = None,
+    primary_location: str | None = None,
+    characters: tuple[str, ...] = (),
+    locations: tuple[str, ...] = (),
+    keywords: tuple[str, ...] = (),
+    recap_window: tuple[str, int] = ("character", 3),
+    token_budget: int = 15000,
+) -> dict:  # {"wiki_snapshot": str, "recap_snippets": list[str]}
+    """Assemble wiki + recap context for an agent.
+
+    Internally calls `wiki_snapshot.get_snapshot` and
+    `recap_index.query_recap` with parameters determined by `scope`.
+    The token budget is split: wiki_snapshot <= 70%, recap_snippets <= 30%.
+    """
+    wiki_budget = min(_SCOPE_WIKI_BUDGET[scope], int(token_budget * 0.7))
+    recap_budget = int(token_budget * 0.3)
+
+    # --- Wiki snapshot ---
+    wiki_text: str = _retrieve_wiki(
+        story_name=story_name,
+        scope=scope,
+        focus=focus,
+        chapter=chapter,
+        scene=scene,
+        pov_character=pov_character,
+        primary_location=primary_location,
+        characters=characters,
+        locations=locations,
+        wiki_budget=wiki_budget,
+    )
+
+    # --- Recap snippets ---
+    recap_snippets: list[str] = _retrieve_recap(
+        story_name=story_name,
+        scope=scope,
+        focus=focus,
+        chapter=chapter,
+        characters=characters,
+        locations=locations,
+        recap_window=recap_window,
+        recap_budget=recap_budget,
+    )
+
+    return {"wiki_snapshot": wiki_text, "recap_snippets": recap_snippets}
+
+
+def _retrieve_wiki(
+    *,
+    story_name: str,
+    scope: str,
+    focus: str,
+    chapter: int | None,
+    scene: int | None,
+    pov_character: str | None,
+    primary_location: str | None,
+    characters: tuple[str, ...],
+    locations: tuple[str, ...],
+    wiki_budget: int,
+) -> str:
+    """Call get_snapshot and handle empty/error conditions."""
+    result = get_snapshot(
+        story_name=story_name,
+        chapter=chapter or 0,
+        scene=scene or 0,
+        outline=focus,
+        pov_character=pov_character,
+        characters=list(characters) if characters else None,
+        primary_location=primary_location,
+        locations=list(locations) if locations else None,
+        budget=wiki_budget,
+    )
+
+    if result is None:
+        if scope in _FATAL_CHROMA_SCOPES:
+            raise StoryGenerationError(
+                f"Wiki snapshot unavailable for story={story_name!r}, scope={scope!r}"
+            )
+        if scope not in _INITIAL_SCOPES:
+            print(
+                f"[ContextAssembly] Warning: wiki snapshot empty for"
+                f" story={story_name!r}, scope={scope!r}",
+                file=sys.stderr,
+            )
+        return ""
+
+    return result
+
+
+def _retrieve_recap(
+    *,
+    story_name: str,
+    scope: str,
+    focus: str,
+    chapter: int | None,
+    characters: tuple[str, ...],
+    locations: tuple[str, ...],
+    recap_window: tuple[str, int],
+    recap_budget: int,
+) -> list[str]:
+    """Retrieve recap entries according to recap_window strategy."""
+    strategy, n = recap_window
+    if strategy == "none" or n == 0:
+        return []
+
+    raw: list[dict[str, Any]] = []
+    try:
+        raw = _fetch_recap_raw(
+            story_name=story_name,
+            strategy=strategy,
+            n=n,
+            focus=focus,
+            chapter=chapter,
+            characters=characters,
+            locations=locations,
+        )
+    except Exception as exc:
+        if scope in _FATAL_CHROMA_SCOPES:
+            raise StoryGenerationError(
+                f"Recap retrieval failed for story={story_name!r},"
+                f" scope={scope!r}: {exc}"
+            ) from exc
+        print(
+            f"[ContextAssembly] Warning: recap retrieval error for"
+            f" scope={scope!r}: {exc}",
+            file=sys.stderr,
+        )
+        return []
+
+    return _apply_recap_budget(raw, recap_budget)
+
+
+def _fetch_recap_raw(
+    *,
+    story_name: str,
+    strategy: str,
+    n: int,
+    focus: str,
+    chapter: int | None,
+    characters: tuple[str, ...],
+    locations: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    """Fetch raw recap dicts for the given strategy."""
+    if strategy == "character":
+        seen: set[str] = set()
+        rows: list[dict[str, Any]] = []
+        for slug in characters:
+            for row in query_recap(story_name, character=slug):
+                if row["id"] not in seen:
+                    seen.add(row["id"])
+                    rows.append(row)
+        rows.sort(
+            key=lambda r: (r.get("metadata") or {}).get("chapter", 0),
+            reverse=True,
+        )
+        return rows[:n]
+
+    if strategy == "chapter":
+        if chapter is not None and chapter > 1:
+            lo = max(1, chapter - n)
+            hi = chapter - 1
+            rows = query_recap(story_name, chapter_range=(lo, hi))
+        else:
+            rows = query_recap(story_name)
+        rows.sort(
+            key=lambda r: (r.get("metadata") or {}).get("chapter", 0),
+            reverse=True,
+        )
+        return rows[:n]
+
+    if strategy == "location":
+        seen2: set[str] = set()
+        rows2: list[dict[str, Any]] = []
+        for slug in locations:
+            for row in query_recap(story_name, location=slug):
+                if row["id"] not in seen2:
+                    seen2.add(row["id"])
+                    rows2.append(row)
+        rows2.sort(
+            key=lambda r: (r.get("metadata") or {}).get("chapter", 0),
+            reverse=True,
+        )
+        return rows2[:n]
+
+    if strategy == "semantic":
+        return query_recap(story_name, query_text=focus, n_results=n)
+
+    print(
+        f"[ContextAssembly] Warning: unknown recap_window strategy {strategy!r},"
+        " skipping",
+        file=sys.stderr,
+    )
+    return []
+
+
+def _apply_recap_budget(
+    rows: list[dict[str, Any]],
+    recap_budget: int,
+) -> list[str]:
+    """Extract document text from rows, capping at recap_budget tokens."""
+    snippets: list[str] = []
+    used_tokens = 0
+    for row in rows:
+        doc = row.get("document") or ""
+        if not doc:
+            continue
+        doc_tokens = count_tokens(doc)
+        if used_tokens + doc_tokens > recap_budget:
+            break
+        snippets.append(doc)
+        used_tokens += doc_tokens
+    return snippets

--- a/tests/unit/test_context_assembly.py
+++ b/tests/unit/test_context_assembly.py
@@ -1,0 +1,357 @@
+import sys
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from domain.exceptions import StoryGenerationError
+from tools.context_assembly import assemble_context
+
+
+def _recap_row(
+    row_id: str,
+    document: str,
+    *,
+    chapter: int = 1,
+) -> dict:
+    return {
+        "id": row_id,
+        "document": document,
+        "metadata": {
+            "chapter": chapter,
+            "kind": "aggregate",
+            "story": "test-story",
+            "participants": "",
+            "locations": "",
+        },
+    }
+
+
+def test_returns_dict_with_expected_keys() -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki\nContent"):
+        with patch(
+            "tools.context_assembly.query_recap",
+            return_value=[_recap_row("aggregate/1", "alpha beta gamma", chapter=1)],
+        ):
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="a scene",
+            )
+
+    assert set(result) == {"wiki_snapshot", "recap_snippets"}
+    assert isinstance(result["wiki_snapshot"], str)
+    assert isinstance(result["recap_snippets"], list)
+
+
+def test_wiki_budget_capped_at_scope_default() -> None:
+    with patch(
+        "tools.context_assembly.get_snapshot", return_value="# Wiki"
+    ) as mock_snap:
+        with patch("tools.context_assembly.query_recap", return_value=[]):
+            assemble_context(
+                "test-story",
+                scope="outline",
+                focus="outline focus",
+                recap_window=("none", 0),
+                token_budget=100000,
+            )
+
+    assert mock_snap.call_args.kwargs["budget"] == 6000
+
+
+def test_wiki_budget_capped_by_token_budget_70_percent() -> None:
+    with patch(
+        "tools.context_assembly.get_snapshot", return_value="# Wiki"
+    ) as mock_snap:
+        with patch("tools.context_assembly.query_recap", return_value=[]):
+            assemble_context(
+                "test-story",
+                scope="chapter",
+                focus="chapter focus",
+                recap_window=("none", 0),
+                token_budget=10000,
+            )
+
+    assert mock_snap.call_args.kwargs["budget"] == 7000
+
+
+def test_recap_budget_is_30_percent_of_token_budget() -> None:
+    rows = [
+        _recap_row("aggregate/1", "alpha beta gamma", chapter=3),
+        _recap_row("aggregate/2", "delta epsilon zeta", chapter=2),
+        _recap_row("aggregate/3", "eta theta iota", chapter=1),
+    ]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch("tools.context_assembly.query_recap", return_value=rows):
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="scene focus",
+                recap_window=("semantic", 3),
+                token_budget=20,
+            )
+
+    assert result["recap_snippets"] == [
+        "alpha beta gamma",
+        "delta epsilon zeta",
+    ]
+
+
+def test_empty_wiki_non_initial_scope_emits_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value=None):
+        with patch("tools.context_assembly.query_recap", return_value=[]):
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="scene focus",
+                recap_window=("none", 0),
+            )
+
+    captured = capsys.readouterr()
+    assert result["wiki_snapshot"] == ""
+    assert "wiki snapshot empty" in captured.err
+    assert "scope='scene'" in captured.err
+
+
+def test_empty_wiki_initial_scope_no_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value=None):
+        with patch("tools.context_assembly.query_recap", return_value=[]):
+            result = assemble_context(
+                "test-story",
+                scope="outline",
+                focus="outline focus",
+                recap_window=("none", 0),
+            )
+
+    captured = capsys.readouterr()
+    assert result["wiki_snapshot"] == ""
+    assert captured.err == ""
+
+
+def test_fatal_scope_wiki_none_raises_story_generation_error() -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value=None):
+        with patch("tools.context_assembly.query_recap", return_value=[]):
+            with pytest.raises(StoryGenerationError, match="Wiki snapshot unavailable"):
+                assemble_context(
+                    "test-story",
+                    scope="chapter",
+                    focus="chapter focus",
+                    recap_window=("none", 0),
+                )
+
+
+def test_fatal_scope_recap_exception_raises_story_generation_error() -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap",
+            side_effect=RuntimeError("chroma offline"),
+        ):
+            with pytest.raises(StoryGenerationError, match="Recap retrieval failed"):
+                assemble_context(
+                    "test-story",
+                    scope="consistency",
+                    focus="consistency focus",
+                    recap_window=("semantic", 3),
+                )
+
+
+def test_non_fatal_scope_recap_exception_returns_empty_list() -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap",
+            side_effect=RuntimeError("chroma offline"),
+        ):
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="scene focus",
+                recap_window=("semantic", 3),
+            )
+
+    assert result["wiki_snapshot"] == "# Wiki"
+    assert result["recap_snippets"] == []
+
+
+def test_recap_window_none_returns_empty_list() -> None:
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch("tools.context_assembly.query_recap") as mock_query:
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="scene focus",
+                recap_window=("none", 0),
+            )
+
+    assert result["recap_snippets"] == []
+    mock_query.assert_not_called()
+
+
+def test_recap_window_semantic_calls_query_with_query_text() -> None:
+    rows = [_recap_row("aggregate/1", "alpha beta gamma", chapter=1)]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap", return_value=rows
+        ) as mock_query:
+            assemble_context(
+                "test-story",
+                scope="scene",
+                focus="search terms",
+                recap_window=("semantic", 3),
+            )
+
+    mock_query.assert_called_once_with(
+        "test-story",
+        query_text="search terms",
+        n_results=3,
+    )
+
+
+def test_recap_window_character_deduplicates() -> None:
+    alice_rows = [
+        _recap_row("aggregate/shared", "shared doc", chapter=4),
+        _recap_row("aggregate/alice", "alice only", chapter=2),
+    ]
+    bob_rows = [
+        _recap_row("aggregate/shared", "shared doc", chapter=4),
+        _recap_row("aggregate/bob", "bob only", chapter=3),
+    ]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap",
+            side_effect=[alice_rows, bob_rows],
+        ) as mock_query:
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="character focus",
+                characters=("alice", "bob"),
+                recap_window=("character", 3),
+                token_budget=30,
+            )
+
+    assert result["recap_snippets"] == ["shared doc", "bob only", "alice only"]
+    assert mock_query.call_args_list == [
+        call("test-story", character="alice"),
+        call("test-story", character="bob"),
+    ]
+
+
+def test_recap_window_chapter_uses_chapter_range() -> None:
+    rows = [_recap_row("aggregate/1", "alpha beta gamma", chapter=4)]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap", return_value=rows
+        ) as mock_query:
+            assemble_context(
+                "test-story",
+                scope="scene",
+                focus="chapter focus",
+                chapter=5,
+                recap_window=("chapter", 3),
+            )
+
+    mock_query.assert_called_once_with("test-story", chapter_range=(2, 4))
+
+
+def test_recap_window_chapter_fallback_no_chapter() -> None:
+    rows = [_recap_row("aggregate/1", "alpha beta gamma", chapter=1)]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap", return_value=rows
+        ) as mock_query:
+            assemble_context(
+                "test-story",
+                scope="scene",
+                focus="chapter focus",
+                chapter=None,
+                recap_window=("chapter", 3),
+            )
+
+    mock_query.assert_called_once_with("test-story")
+
+
+def test_recap_window_location_queries_per_location_slug() -> None:
+    tavern_rows = [_recap_row("aggregate/tavern", "tavern doc", chapter=2)]
+    docks_rows = [_recap_row("aggregate/docks", "docks doc", chapter=3)]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch(
+            "tools.context_assembly.query_recap",
+            side_effect=[tavern_rows, docks_rows],
+        ) as mock_query:
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="location focus",
+                locations=("tavern", "docks"),
+                recap_window=("location", 2),
+            )
+
+    assert result["recap_snippets"] == ["docks doc", "tavern doc"]
+    assert mock_query.call_args_list == [
+        call("test-story", location="tavern"),
+        call("test-story", location="docks"),
+    ]
+
+
+def test_recap_budget_truncates_snippets() -> None:
+    rows = [
+        _recap_row("aggregate/1", "alpha beta", chapter=3),
+        _recap_row("aggregate/2", "gamma delta", chapter=2),
+    ]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch("tools.context_assembly.query_recap", return_value=rows):
+            result = assemble_context(
+                "test-story",
+                scope="scene",
+                focus="scene focus",
+                recap_window=("semantic", 2),
+                token_budget=12,
+            )
+
+    assert result["recap_snippets"] == ["alpha beta"]
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "outline",
+        "chapter",
+        "scene",
+        "consistency",
+        "recap",
+        "metadata",
+        "final_edit",
+    ],
+)
+def test_all_scopes_return_valid_structure(scope: str) -> None:
+    rows = [_recap_row("aggregate/1", "alpha beta gamma", chapter=1)]
+
+    with patch("tools.context_assembly.get_snapshot", return_value="# Wiki"):
+        with patch("tools.context_assembly.query_recap", return_value=rows):
+            result = assemble_context(
+                "test-story",
+                scope=scope,
+                focus=f"{scope} focus",
+            )
+
+    assert set(result) == {"wiki_snapshot", "recap_snippets"}
+    assert isinstance(result["wiki_snapshot"], str)
+    assert isinstance(result["recap_snippets"], list)


### PR DESCRIPTION
## Summary

Adds `src/tools/context_assembly.py` exposing a single `assemble_context` function that every wiki/recap-aware agent can call instead of invoking `get_snapshot` and `query_recap` independently. This is the single chokepoint through which all agents get wiki + recap context, unblocking Tasks 8, 9, and 10.

## Closes

Closes #357

## Changes

- [x] `src/tools/context_assembly.py` — new module with `assemble_context` and private helpers
- [x] `tests/unit/test_context_assembly.py` — 23 unit tests covering all scopes, all `recap_window` strategies, budget enforcement, warning emission, and `StoryGenerationError` raise conditions
- [x] All tests passing (23/23 verified)
- [x] Linting clean (ruff + mypy)

## Plan

**Summary:** New `assemble_context` helper that wraps `get_snapshot` and `query_recap` with scope-based token budget splitting (wiki ≤ 70%, recap ≤ 30%), five `recap_window` strategies (character/chapter/location/semantic/none), fatal error propagation for chapter/consistency scopes, and degraded-mode warnings for all others.

**Task Checklist:**
- [x] `src/tools/context_assembly.py` — implement `assemble_context`, `_retrieve_wiki`, `_retrieve_recap`, `_fetch_recap_raw`, `_apply_recap_budget`
- [x] `tests/unit/test_context_assembly.py` — 23 tests, all passing