### PR TITLE
feat(agents): add wiki + recap context to consistency checker and outline planner

### DIFF
--- a/prompts/chapter_review/consistency_check_direct.md
+++ b/prompts/chapter_review/consistency_check_direct.md
@@ -19,6 +19,24 @@ Each scene is delineated with `--- Scene N ---` markers when available. Use thes
 {outline}
 </OUTLINE>
 
+## Wiki Context (verified entity facts)
+
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+## Relationships
+
+<WIKI_RELATIONSHIPS>
+{wiki_relationships}
+</WIKI_RELATIONSHIPS>
+
+## Recap Context (prior chapter aggregates)
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 ## Scene Definitions
 
 When present, each entry defines the intended narrative scope of that scene: its `key_events`, `ending`, and `lead_in_to_next_scene`.

--- a/prompts/outline/create_chunk.md
+++ b/prompts/outline/create_chunk.md
@@ -10,6 +10,12 @@ You are a talented fiction writer creating a story skeleton. Your task is to gen
 {base_context}
 </BASE_CONTEXT>
 
+## Wiki Context (established story facts)
+
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
 <CHUNK_INFO>
 Chapters to generate: {chunk_start} to {chunk_end}
 Total story chapters: {total_chapters}

--- a/prompts/outline/create_direct.md
+++ b/prompts/outline/create_direct.md
@@ -17,6 +17,12 @@ You are a talented fiction writer creating a complete story structure. Your task
 {base_context}
 </BASE_CONTEXT>
 
+## Wiki Context (established story facts)
+
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
 ## OBJECTIVE
 Create a comprehensive outline for exactly {desired_chapters} chapters that:
 - Maps the complete story arc from beginning to end

--- a/prompts/outline/create_skeleton.md
+++ b/prompts/outline/create_skeleton.md
@@ -14,6 +14,12 @@ You are a talented fiction writer creating a story structure. Your task is to cr
 {base_context}
 </BASE_CONTEXT>
 
+## Wiki Context (established story facts)
+
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
 ## OBJECTIVE
 Create a comprehensive skeleton outline for {desired_chapters} chapters that:
 - Maps the complete story arc from beginning to end

--- a/src/presentation/agents/consistency_checker.py
+++ b/src/presentation/agents/consistency_checker.py
@@ -13,6 +13,7 @@ from domain.value_objects.model_config import ModelConfig
 from infrastructure.prompts.prompt_loader import PromptLoader
 from tools._io import STORIES_DIR
 from tools._persist import read_markdown_ref
+from tools.context_assembly import assemble_context
 from presentation.pipeline_primitives import (
     TokenStreamBus,
     WikiContextBus,
@@ -248,6 +249,16 @@ class ConsistencyCheckerAgent:
         delineated = self._build_delineated_content(
             story_name, chapter_number, chapter_content
         )
+        ctx = assemble_context(
+            story_name,
+            scope="consistency",
+            focus=outline or chapter_content[:500],
+            chapter=chapter_number,
+            recap_window=("chapter", 3),
+        )
+        wiki_context: str = ctx["wiki_snapshot"]
+        recap_context: str = "\n\n".join(ctx["recap_snippets"])
+        wiki_relationships: str = ""
         scene_definitions = self._load_scene_definitions(story_name, chapter_number)
         system_prompt = loader.load_prompt(
             "chapter_review/consistency_check_direct",
@@ -256,6 +267,9 @@ class ConsistencyCheckerAgent:
                 "story_name": story_name,
                 "chapter_number": str(chapter_number),
                 "outline": outline,
+                "wiki_context": wiki_context,
+                "recap_context": recap_context,
+                "wiki_relationships": wiki_relationships,
                 "scene_definitions": scene_definitions,
             },
         )

--- a/src/presentation/agents/outline_planner.py
+++ b/src/presentation/agents/outline_planner.py
@@ -17,6 +17,7 @@ from presentation.pipeline_primitives import (
     WikiContextEvent,
 )
 from tools._io import STORIES_DIR, _validate_story_name
+from tools.context_assembly import assemble_context
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -41,6 +42,14 @@ def _build_outline_pacing_variables(desired_chapters: int) -> dict[str, str]:
         "climax_end": str(climax_end),
         "resolution_start": str(resolution_start),
     }
+
+
+def _has_approved_chapters(story_name: str) -> bool:
+    """Return True if the story has any written chapter files."""
+    chapters_dir = STORIES_DIR / story_name / "chapters"
+    if not chapters_dir.exists():
+        return False
+    return any(chapters_dir.iterdir())
 
 
 def _parse_chapter_outlines(text: str, wanted_chapters: int) -> list[dict[str, Any]]:
@@ -197,6 +206,7 @@ class OutlinePlannerAgent:
         settings: GenerationSettings,
         base_context: str,
         story_elements: str,
+        wiki_context: str = "",
         feedback: str = "",
         critic_context: str = "",
     ) -> OutlineResult:
@@ -236,6 +246,7 @@ class OutlinePlannerAgent:
                 variables={
                     "story_elements": story_elements,
                     "base_context": base_context,
+                    "wiki_context": wiki_context,
                     "chunk_start": str(chunk_start),
                     "chunk_end": str(chunk_end),
                     "total_chapters": str(desired_chapters),
@@ -352,6 +363,17 @@ class OutlinePlannerAgent:
 
         desired_chapters = settings.wanted_chapters
         pacing_variables = _build_outline_pacing_variables(desired_chapters)
+        is_continuation = feedback is not None or _has_approved_chapters(story_name)
+        if is_continuation:
+            _ctx = assemble_context(
+                story_name,
+                scope="outline",
+                focus=story_prompt,
+                recap_window=("chapter", 10),
+            )
+            wiki_context = _ctx["wiki_snapshot"]
+        else:
+            wiki_context = ""
 
         loader = self._loader
         if not settings.expand_outline:
@@ -361,6 +383,7 @@ class OutlinePlannerAgent:
                     "prompt": prompt,
                     "story_elements": story_elements,
                     "base_context": base_context,
+                    "wiki_context": wiki_context,
                     **pacing_variables,
                 },
             )
@@ -392,6 +415,7 @@ class OutlinePlannerAgent:
                 settings,
                 base_context,
                 story_elements,
+                wiki_context=wiki_context,
                 feedback=feedback or "",
                 critic_context=critic_context,
             )
@@ -406,6 +430,7 @@ class OutlinePlannerAgent:
                 "prompt": prompt,
                 "story_elements": story_elements,
                 "base_context": base_context,
+                "wiki_context": wiki_context,
                 **pacing_variables,
             },
         )

--- a/tests/unit/test_consistency_checker.py
+++ b/tests/unit/test_consistency_checker.py
@@ -275,6 +275,82 @@ async def test_run_does_not_truncate_chapter_content() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_calls_assemble_context_with_consistency_scope() -> None:
+    response = '{"issues": [], "has_critical_findings": false}'
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = ConsistencyCheckerAgent(
+        provider=_ProviderStub([response]),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with (
+        patch(
+            "presentation.agents.consistency_checker.assemble_context",
+            return_value={"wiki_snapshot": "wiki info", "recap_snippets": ["recap 1"]},
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system prompt",
+        ),
+    ):
+        await agent.run("my-story", 2, "chapter content")
+
+    bus.close()
+
+    mock_assemble_context.assert_called_once_with(
+        "my-story",
+        scope="consistency",
+        focus="chapter content",
+        chapter=2,
+        recap_window=("chapter", 3),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_passes_wiki_and_recap_to_prompt() -> None:
+    captured_variables: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if variables is not None:
+            captured_variables.update(variables)
+        return "system prompt"
+
+    response = '{"issues": [], "has_critical_findings": false}'
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = ConsistencyCheckerAgent(
+        provider=_ProviderStub([response]),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with (
+        patch(
+            "presentation.agents.consistency_checker.assemble_context",
+            return_value={
+                "wiki_snapshot": "WIKI_DATA",
+                "recap_snippets": ["RECAP1", "RECAP2"],
+            },
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run("my-story", 2, "chapter content")
+
+    bus.close()
+
+    assert captured_variables["wiki_context"] == "WIKI_DATA"
+    assert captured_variables["recap_context"] == "RECAP1\n\nRECAP2"
+    assert captured_variables["wiki_relationships"] == ""
+
+
+@pytest.mark.asyncio
 async def test_consistency_checker_outline_plumbed() -> None:
     captured: dict[str, str] = {}
     outline_result = OutlineResult(

--- a/tests/unit/test_outline_planner_wiki.py
+++ b/tests/unit/test_outline_planner_wiki.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.outline_planner import OutlinePlannerAgent
+
+
+async def _async_gen(tokens: list[str]):
+    for token in tokens:
+        yield token
+
+
+class _StubBus:
+    async def emit(self, msg):
+        pass
+
+    def close(self):
+        pass
+
+
+class _StubWikiBus:
+    async def emit(self, event):
+        pass
+
+    def close(self):
+        pass
+
+
+def _make_agent() -> OutlinePlannerAgent:
+    provider = MagicMock()
+    provider.stream_text = MagicMock(
+        return_value=_async_gen(["### Chapter 1: Title\nSummary text\n"])
+    )
+    return OutlinePlannerAgent(provider, {}, _StubBus(), _StubWikiBus())
+
+
+def _settings() -> GenerationSettings:
+    return GenerationSettings.from_dict({"expand_outline": False, "wanted_chapters": 5})
+
+
+@pytest.mark.asyncio
+async def test_run_calls_assemble_context_on_feedback_run() -> None:
+    agent = _make_agent()
+
+    with (
+        patch(
+            "presentation.agents.outline_planner.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": []},
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system prompt",
+        ),
+    ):
+        await agent.run(
+            "my-story",
+            "story prompt",
+            _settings(),
+            feedback="please revise",
+        )
+
+    mock_assemble_context.assert_called_once_with(
+        "my-story",
+        scope="outline",
+        focus="story prompt",
+        recap_window=("chapter", 10),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_calls_assemble_context_on_continuation() -> None:
+    agent = _make_agent()
+
+    with (
+        patch(
+            "presentation.agents.outline_planner._has_approved_chapters",
+            return_value=True,
+        ),
+        patch(
+            "presentation.agents.outline_planner.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": []},
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system prompt",
+        ),
+    ):
+        await agent.run("my-story", "story prompt", _settings(), feedback=None)
+
+    mock_assemble_context.assert_called_once_with(
+        "my-story",
+        scope="outline",
+        focus="story prompt",
+        recap_window=("chapter", 10),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_skips_assemble_context_on_initial_run() -> None:
+    agent = _make_agent()
+
+    with (
+        patch(
+            "presentation.agents.outline_planner._has_approved_chapters",
+            return_value=False,
+        ),
+        patch(
+            "presentation.agents.outline_planner.assemble_context",
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system prompt",
+        ),
+    ):
+        await agent.run("my-story", "story prompt", _settings(), feedback=None)
+
+    mock_assemble_context.assert_not_called()


### PR DESCRIPTION
## Summary

Wires `assemble_context()` into `ConsistencyCheckerAgent` and `OutlinePlannerAgent`, completing Task 8 of the Wiki Source-of-Truth Consolidation plan. The consistency checker now validates chapter drafts against authoritative wiki state instead of just the outline. The outline planner receives wiki snapshot on continuation/revision runs.

## Closes
Closes #358

## Changes
- [x] `ConsistencyCheckerAgent.run()` calls `assemble_context(scope="consistency")` and passes `wiki_context`, `recap_context`, `wiki_relationships` to the consistency prompt
- [x] `OutlinePlannerAgent.run()` calls `assemble_context(scope="outline")` on revision (`feedback != None`) and continuation (`_has_approved_chapters()`) runs; skips wiki on initial run
- [x] `_has_approved_chapters()` helper added to detect continuation from chapters directory
- [x] `_run_chunked()` wired with `wiki_context` parameter
- [x] `prompts/chapter_review/consistency_check_direct.md` — added `{wiki_context}`, `{wiki_relationships}`, `{recap_context}` blocks
- [x] `prompts/outline/create_direct.md`, `create_skeleton.md`, `create_chunk.md` — added `{wiki_context}` block (renders as empty on initial run)
- [x] 5 new unit tests covering `assemble_context` call and prompt variable plumbing
- [x] All 22 tests pass, lint clean, mypy clean

## Plan

**Summary:** Add wiki + recap context retrieval to the two highest-priority consumers. ConsistencyCheckerAgent uses `scope="consistency"` (fatal if ChromaDB unavailable, graceful if wiki empty). OutlinePlannerAgent uses `scope="outline"` (non-fatal) only on non-initial runs.

**Affected Areas:** Python domain logic; no ChromaDB schema change.

**Task Checklist:**
- [x] Add `assemble_context` import to consistency_checker.py
- [x] Assemble and inject wiki/recap context in `ConsistencyCheckerAgent.run()`
- [x] Update consistency prompt template with new variables
- [x] Add `assemble_context` import to outline_planner.py
- [x] Add `_has_approved_chapters()` helper
- [x] Wire wiki_context into all outline prompt calls (create_direct, create_skeleton, create_chunk via _run_chunked)
- [x] Update outline prompt templates with `{wiki_context}` variable
- [x] Write verification tests (22 passed)

**Risks & Edge Cases:**
- `scope="consistency"` is a fatal ChromaDB scope — `StoryGenerationError` propagates if ChromaDB unavailable (by design)
- Chapter 1 with empty wiki returns `""` without raising (non-fatal empty case)
- `wiki_relationships` is always `""` in this implementation (sub-block extraction deferred to a future task)