### PR TITLE
feat(agents): add wiki + recap context to recap writer and chapter writer

### DIFF
--- a/prompts/chapters/create_synopsis.md
+++ b/prompts/chapters/create_synopsis.md
@@ -21,6 +21,10 @@ And here is the last chapter synopsis:
 <PREVIOUS_CHAPTER>
 {previous_chapter}
 </PREVIOUS_CHAPTER>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
 _note: if this is empty, then this is the first chapter.
 
 IMPORTANT: 

--- a/prompts/chapters/write_chapter_direct.md
+++ b/prompts/chapters/write_chapter_direct.md
@@ -26,6 +26,11 @@ You are a skilled fiction writer composing a complete chapter of a long-form nar
 {next_chapter_summary}
 </NEXT_CHAPTER>
 
+## Recap History
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 ## CHARACTER & SETTING CONTEXT
 {character_context_block}
 

--- a/prompts/extract_chapter_events.md
+++ b/prompts/extract_chapter_events.md
@@ -10,6 +10,14 @@ Extract events from provided chapter content. Follow these instructions exactly.
 {chapter_content}
 </CHAPTER_CONTENT>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RELATED_RECAP_HISTORY>
+{related_recap_history}
+</RELATED_RECAP_HISTORY>
+
 ## MANDATORY PROCESS
 
 1. **Find each scene** in the chapter outline
@@ -68,5 +76,16 @@ Extract events from provided chapter content. Follow these instructions exactly.
 - Find scenes
 - Describe what happens
 - Output JSON
+
+## Input
+
+1. **Previous Chapter Recap**
+2. **Chapter Content**
+3. **Wiki Context** (canonical character names/slugs for tagging participants)
+4. **Related Recap History** (recent chapter aggregates for consistency context)
+
+## Processing Note
+
+Use {wiki_context} for canonical character names when tagging participants. Use {related_recap_history} to avoid duplicating events already captured in prior chapter recaps.
 
 **OUTPUT ONLY THE JSON ARRAY. NO OTHER TEXT.**

--- a/prompts/multistep/scene/create_content_final.md
+++ b/prompts/multistep/scene/create_content_final.md
@@ -78,6 +78,10 @@ The previous scene's prose ends with the following passage. Your scene must begi
 
 {base_context}
 
+<RECAP_CONTEXT>
+{scene_recap_context}
+</RECAP_CONTEXT>
+
 ## Final Instructions
 1. Write AT LEAST 1000 words of pure scene content
 2. Begin by smoothly continuing from the previous scene

--- a/prompts/multistep/scene/create_content_first.md
+++ b/prompts/multistep/scene/create_content_first.md
@@ -68,6 +68,10 @@ This is scene {scene_index} of {scene_total}. No prior scenes have been written 
 
 {base_context}
 
+<RECAP_CONTEXT>
+{scene_recap_context}
+</RECAP_CONTEXT>
+
 ## Final Instructions
 1. Write AT LEAST 1000 words of pure scene content
 2. Begin the chapter with an engaging opening

--- a/prompts/multistep/scene/create_content_middle.md
+++ b/prompts/multistep/scene/create_content_middle.md
@@ -79,6 +79,10 @@ The previous scene's prose ends with the following passage. Your scene must begi
 
 {base_context}
 
+<RECAP_CONTEXT>
+{scene_recap_context}
+</RECAP_CONTEXT>
+
 ## Final Instructions
 1. Write AT LEAST 1000 words of pure scene content
 2. Begin by smoothly continuing from the previous scene

--- a/prompts/recap/sanitize.md
+++ b/prompts/recap/sanitize.md
@@ -16,6 +16,10 @@ You are a story recap formatter. Your job is to take messy recap data and format
 {story_start_date}
 </STORY_START_DATE>
 
+<RELATED_RECAP_HISTORY>
+{related_recap_history}
+</RELATED_RECAP_HISTORY>
+
 ## Output Format
 Format the combined recap into this JSON structure:
 
@@ -122,6 +126,7 @@ Format the combined recap into this JSON structure:
 - Merge similar events that happen close together
 - Keep the most detailed version of each event
 - When merging, preserve the most important details from each
+- Use {related_recap_history} to ensure the new recap does not duplicate events already captured in prior chapter recaps
 
 ### 5. JSON Standards
 - Use valid JSON syntax throughout

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -26,7 +26,6 @@ from typing import Any, AsyncIterator, cast
 
 from application.interfaces.model_provider import ModelProvider
 from application.pipeline.handoffs import ChapterDraft, OutlineResult, PipelineState
-from domain.exceptions import StoryGenerationError
 from domain.value_objects.generation_settings import GenerationSettings
 from domain.value_objects.model_config import ModelConfig
 from infrastructure.prompts.prompt_loader import PromptLoader
@@ -40,7 +39,7 @@ from presentation.pipeline_primitives import (
 )
 from tools._io import STORIES_DIR, _atomic_write, _validate_story_name
 from tools._persist import read_markdown_ref
-from tools.wiki_snapshot import get_snapshot
+from tools.context_assembly import assemble_context
 
 
 def _savepoint_path(story_name: str) -> Path:
@@ -166,35 +165,46 @@ class ChapterWriterAgent:
             if isinstance(outline_result.story_elements, dict)
             else (outline_result.story_elements or "")
         )
-        wiki_snapshot: str | None = None
-        if (STORIES_DIR / story_name / "wiki").exists():
-            try:
-                wiki_snapshot = get_snapshot(
-                    story_name=story_name,
-                    chapter=chapter_number,
-                    scene=0,
-                    outline=chapter_summary,
-                )
-            except Exception as exc:
-                await self.bus.emit(
-                    f"\n[Wiki] snapshot failed ({type(exc).__name__}: {exc})\n"
-                )
-        if wiki_snapshot:
-            base_context = wiki_snapshot
-            character_context = ""
-            setting_context = ""
-            await self.wiki_bus.emit(
-                WikiContextEvent(
-                    phase="chapter",
-                    event_type="semantic_search",
-                    content=f"Wiki snapshot assembled for chapter {chapter_number}",
-                )
+        _pov_character: str | None = None
+        _primary_location: str | None = None
+        _chapter_characters: tuple[str, ...] = ()
+        if isinstance(chapter_outline, dict):
+            _ch_chars = chapter_outline.get("characters") or []
+            if isinstance(_ch_chars, list) and _ch_chars:
+                _pov_character = str(_ch_chars[0])
+                _chapter_characters = tuple(str(c) for c in _ch_chars)
+            _primary_location = (
+                chapter_outline.get("primary_location")
+                or chapter_outline.get("setting")
+                or chapter_outline.get("location")
+                or None
             )
-        else:
-            raise StoryGenerationError(
-                f"Wiki snapshot unavailable for story '{story_name}' chapter {chapter_number}. "
-                "Run the wiki-generation phase before writing chapters."
+
+        _chapter_ctx = assemble_context(
+            story_name,
+            scope="chapter",
+            focus=chapter_summary,
+            chapter=chapter_number,
+            pov_character=_pov_character,
+            primary_location=_primary_location,
+            characters=_chapter_characters,
+            recap_window=("character", 5),
+        )
+        base_context = _chapter_ctx["wiki_snapshot"]
+        recap_context = (
+            "\n\n".join(_chapter_ctx["recap_snippets"])
+            if _chapter_ctx["recap_snippets"]
+            else ""
+        )
+        character_context = ""
+        setting_context = ""
+        await self.wiki_bus.emit(
+            WikiContextEvent(
+                phase="chapter",
+                event_type="semantic_search",
+                content=f"Wiki snapshot assembled for chapter {chapter_number}",
             )
+        )
 
         previous_chapter_recap = ""
         if chapter_number > 1:
@@ -243,6 +253,7 @@ class ChapterWriterAgent:
                 chapter_summary=chapter_summary,
                 story_elements=actual_story_elements,
                 base_context=base_context,
+                recap_context=recap_context,
                 previous_chapter_recap=previous_chapter_recap,
                 next_chapter_summary=next_chapter_summary,
                 settings=settings,
@@ -297,6 +308,7 @@ class ChapterWriterAgent:
             chapter_summary=chapter_summary,
             story_elements=actual_story_elements,
             base_context=base_context,
+            recap_context=recap_context,
             previous_chapter_summary=previous_chapter_recap,
             next_chapter_summary=next_chapter_summary,
             character_context=character_context,
@@ -338,6 +350,7 @@ class ChapterWriterAgent:
         next_chapter_summary: str,
         settings: GenerationSettings,
         previous_chapter_recap: str = "",
+        recap_context: str = "",
         state: PipelineState | None = None,
     ) -> str:
         """Run synopsis → scene-decomposition → per-scene drafting.
@@ -387,6 +400,7 @@ class ChapterWriterAgent:
                     "story_elements": story_elements,
                     "base_context": base_context,
                     "previous_chapter": previous_chapter_recap,
+                    "recap_context": recap_context,
                 },
             )
             try:
@@ -537,35 +551,38 @@ class ChapterWriterAgent:
             else:
                 scenes_completed_summary = "(none yet — this is the opening scene)"
 
-            scene_base_context = base_context  # default: chapter-level context
+            scene_base_context = base_context
+            scene_recap_context = recap_context
+            _scene_pov = (
+                scene.get("characters", [None])[0] if scene.get("characters") else None
+            )
+            _scene_chars = tuple(
+                scene.get("characters", [])[1:] if scene.get("characters") else []
+            )
+            _scene_location = scene.get("setting") or scene.get("location") or None
+            _scene_focus = (
+                scene.get("description", "")
+                or scene.get("summary", "")
+                or chapter_summary
+            )
             try:
-                scene_snapshot = get_snapshot(
-                    story_name=story_name,
+                _scene_ctx = assemble_context(
+                    story_name,
+                    scope="scene",
+                    focus=_scene_focus,
                     chapter=chapter_number,
                     scene=index,
-                    outline=(
-                        scene.get("description", "")
-                        or scene.get("summary", "")
-                        or chapter_summary
-                    ),
-                    pov_character=(
-                        scene.get("characters", [None])[0]
-                        if scene.get("characters")
-                        else None
-                    ),
-                    characters=(
-                        scene.get("characters", [])[1:]
-                        if scene.get("characters")
-                        else None
-                    ),
-                    primary_location=(
-                        scene.get("setting") or scene.get("location") or None
-                    ),
+                    pov_character=_scene_pov,
+                    primary_location=_scene_location,
+                    characters=_scene_chars,
+                    recap_window=("character", 3),
                 )
-                if scene_snapshot:
-                    scene_base_context = scene_snapshot
+                if _scene_ctx["wiki_snapshot"]:
+                    scene_base_context = _scene_ctx["wiki_snapshot"]
+                if _scene_ctx["recap_snippets"]:
+                    scene_recap_context = "\n\n".join(_scene_ctx["recap_snippets"])
             except Exception:
-                pass  # silently fall back to chapter-level base_context
+                pass
 
             scene_prompt = loader.load_prompt(
                 scene_prompt_key,
@@ -576,6 +593,7 @@ class ChapterWriterAgent:
                     "scene_total": str(total_scenes),
                     "previous_scene_tail": prev_tail,
                     "scenes_completed_summary": scenes_completed_summary,
+                    "scene_recap_context": scene_recap_context,
                 },
             )
             try:
@@ -744,6 +762,7 @@ class ChapterWriterAgent:
         setting_context: str,
         settings: GenerationSettings,
         feedback: str | None,
+        recap_context: str = "",
     ) -> str:
         loader = self._loader
         character_context_block = (
@@ -769,6 +788,7 @@ class ChapterWriterAgent:
                 "next_chapter_summary": next_chapter_summary,
                 "character_context_block": character_context_block,
                 "setting_context_block": setting_context_block,
+                "recap_context": recap_context,
             },
         )
         if feedback:

--- a/src/presentation/agents/recap_writer.py
+++ b/src/presentation/agents/recap_writer.py
@@ -15,6 +15,9 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from tools._io import STORIES_DIR
+from tools._wiki import get_wiki_dir, match_entities_in_text, read_index
+from tools.context_assembly import assemble_context
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -84,6 +87,34 @@ class RecapWriterAgent:
             )
         )
 
+        _char_slugs: tuple[str, ...] = ()
+        _wiki_context: str = ""
+        _related_recap_history: str = ""
+        try:
+            _wiki_dir = get_wiki_dir(STORIES_DIR / story_name)
+            _index_entries = read_index(_wiki_dir)
+            _char_entries = [e for e in _index_entries if e.get("type") == "character"]
+            _matched = match_entities_in_text(chapter_content, _char_entries)
+            _char_slugs = tuple(e["slug"] for e in _matched)
+        except Exception:
+            pass
+
+        try:
+            _ctx = assemble_context(
+                story_name,
+                scope="recap",
+                focus=chapter_content[:2000],
+                chapter=chapter_number,
+                characters=_char_slugs,
+                recap_window=("character", 5),
+            )
+            _wiki_context = _ctx["wiki_snapshot"]
+            _recap_snippets = _ctx["recap_snippets"]
+            if _recap_snippets:
+                _related_recap_history = "\n\n".join(_recap_snippets)
+        except Exception:
+            pass
+
         model_config = _build_model_config(
             self.config,
             "recap_writer",
@@ -96,6 +127,8 @@ class RecapWriterAgent:
             {
                 "chapter_content": chapter_content,
                 "previous_chapter_recap": previous_recap,
+                "wiki_context": _wiki_context,
+                "related_recap_history": _related_recap_history,
             },
             model_config,
             settings,
@@ -162,6 +195,7 @@ class RecapWriterAgent:
                     "recap": compact,
                     "story_start_date": story_start_date,
                     "previous_chapter_recap": previous_recap,
+                    "related_recap_history": _related_recap_history,
                 },
                 model_config,
                 settings,

--- a/tests/unit/test_chapter_writer_agent.py
+++ b/tests/unit/test_chapter_writer_agent.py
@@ -13,6 +13,7 @@ if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
 from application.pipeline.handoffs import OutlineResult
+from domain.exceptions import StoryGenerationError
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.chapter_writer import ChapterWriterAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
@@ -111,7 +112,8 @@ async def _run_agent(
     responses: list[str],
     recaps: dict[str, object] | None = None,
     settings: GenerationSettings | None = None,
-    wiki_snapshot: str | None = "## Wiki Context\nTest context",
+    assemble_context_result: dict[str, object] | None = None,
+    assemble_context_side_effect: object | None = None,
 ) -> tuple[object, list[str], list[str]]:
     provider, captured_systems = _make_provider(responses)
     bus = TokenStreamBus()
@@ -131,8 +133,13 @@ async def _run_agent(
         patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
         patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
         patch(
-            "presentation.agents.chapter_writer.get_snapshot",
-            return_value=wiki_snapshot,
+            "presentation.agents.chapter_writer.assemble_context",
+            side_effect=assemble_context_side_effect,
+            return_value=assemble_context_result
+            or {
+                "wiki_snapshot": "## Wiki Context\nTest context",
+                "recap_snippets": [],
+            },
         ),
     ):
         loader = loader_cls.return_value
@@ -277,13 +284,16 @@ async def test_scene_pipeline_false_uses_direct_path(tmp_path: Path) -> None:
 async def test_chapter_writer_uses_wiki_snapshot_when_available(
     tmp_path: Path,
 ) -> None:
-    """When get_snapshot returns content, it becomes base_context."""
+    """When assemble_context returns content, it becomes base_context."""
     draft, captured_systems, _ = await _run_agent(
         tmp_path,
         chapter_number=1,
         outline_result=_outline_result(chapters=1),
         responses=_scene_pipeline_responses(scene_count=2),
-        wiki_snapshot="## Wiki Context\ncharacter info",
+        assemble_context_result={
+            "wiki_snapshot": "## Wiki Context\ncharacter info",
+            "recap_snippets": [],
+        },
     )
 
     assert any("## Wiki Context" in prompt for prompt in captured_systems)
@@ -291,17 +301,75 @@ async def test_chapter_writer_uses_wiki_snapshot_when_available(
 
 
 @pytest.mark.asyncio
-async def test_chapter_writer_raises_when_wiki_snapshot_returns_none(
+async def test_wiki_snapshot_failure_raises_story_generation_error(
     tmp_path: Path,
 ) -> None:
-    """When get_snapshot returns None, StoryGenerationError is raised."""
-    from domain.exceptions import StoryGenerationError
-
-    with pytest.raises(StoryGenerationError, match="Wiki snapshot unavailable"):
+    with pytest.raises(StoryGenerationError, match="no wiki"):
         await _run_agent(
             tmp_path,
             chapter_number=1,
             outline_result=_outline_result(chapters=1),
             responses=_scene_pipeline_responses(scene_count=2),
-            wiki_snapshot=None,
+            assemble_context_side_effect=StoryGenerationError("no wiki"),
         )
+
+
+@pytest.mark.asyncio
+async def test_recap_context_injected_in_chapter_prompts(tmp_path: Path) -> None:
+    _, captured_systems, _ = await _run_agent(
+        tmp_path,
+        chapter_number=2,
+        outline_result=_outline_result(),
+        responses=_scene_pipeline_responses(scene_count=2),
+        recaps={"1": {"compact": "prior chapter recap"}},
+        assemble_context_result={
+            "wiki_snapshot": "wiki text",
+            "recap_snippets": ["historic event 1", "historic event 2"],
+        },
+    )
+
+    assert any("historic event 1" in prompt for prompt in captured_systems)
+    assert any("historic event 2" in prompt for prompt in captured_systems)
+    assert any("prior chapter recap" in prompt for prompt in captured_systems)
+
+
+@pytest.mark.asyncio
+async def test_assemble_context_called_with_chapter_scope(tmp_path: Path) -> None:
+    provider, _ = _make_provider(_scene_pipeline_responses(scene_count=2))
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    config = {
+        "models": {
+            "chapter_writer": "openai-compat://test",
+            "chapter_outline_writer": "openai-compat://test",
+            "scene_writer": "openai-compat://test",
+        }
+    }
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+        patch(
+            "presentation.agents.chapter_writer.assemble_context",
+            return_value={"wiki_snapshot": "## Wiki", "recap_snippets": []},
+        ) as assemble_mock,
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
+        await agent.run(
+            story_name="test-story",
+            chapter_number=2,
+            outline_result=_outline_result(),
+            settings=_settings(),
+        )
+
+    assert assemble_mock.call_args_list[0].args == ("test-story",)
+    assert assemble_mock.call_args_list[0].kwargs == {
+        "scope": "chapter",
+        "focus": "Chapter 2 summary",
+        "chapter": 2,
+        "pov_character": None,
+        "primary_location": None,
+        "characters": (),
+        "recap_window": ("character", 5),
+    }

--- a/tests/unit/test_chapter_writer_scene_pipeline.py
+++ b/tests/unit/test_chapter_writer_scene_pipeline.py
@@ -22,18 +22,20 @@ from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
 
 
 @pytest.fixture(autouse=True)
-def _default_wiki_snapshot(tmp_path: Path):
-    """Create wiki dir and stub get_snapshot for all tests in this module.
+def stub_assemble_context(monkeypatch, tmp_path: Path):
+    """Create wiki dir and stub assemble_context for all tests in this module.
 
-    Tests that patch get_snapshot explicitly will override this stub.
+    Tests that patch assemble_context explicitly will override this stub.
     """
     wiki_dir = tmp_path / "test-story" / "wiki"
     wiki_dir.mkdir(parents=True, exist_ok=True)
-    with patch(
-        "presentation.agents.chapter_writer.get_snapshot",
-        return_value="## Wiki Context\nTest context",
-    ):
-        yield
+    monkeypatch.setattr(
+        "presentation.agents.chapter_writer.assemble_context",
+        lambda *args, **kwargs: {
+            "wiki_snapshot": "## Stub Wiki Context",
+            "recap_snippets": [],
+        },
+    )
 
 
 def _outline_result() -> OutlineResult:
@@ -226,8 +228,11 @@ async def test_scene_snapshot_appears_in_base_context(tmp_path: Path) -> None:
     with (
         patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
         patch(
-            "presentation.agents.chapter_writer.get_snapshot",
-            return_value="WIKI_SNAPSHOT_CONTENT",
+            "presentation.agents.chapter_writer.assemble_context",
+            return_value={
+                "wiki_snapshot": "WIKI_SNAPSHOT_CONTENT",
+                "recap_snippets": [],
+            },
         ),
     ):
         draft = await agent.run(
@@ -418,14 +423,64 @@ def test_extract_json_array_returns_empty_on_garbage() -> None:
     assert _extract_json_array("[malformed") == []
 
 
+@pytest.mark.asyncio
+async def test_scene_prompt_receives_scene_recap_context(tmp_path: Path) -> None:
+    provider, captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            json.dumps(
+                [
+                    {"title": "Opening", "description": "Hero arrives."},
+                    {"title": "Climax", "description": "Hero wins."},
+                ]
+            ),
+            "Scene 1 prose body.",
+            "Scene 2 prose body.",
+        ]
+    )
+
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    config = {
+        "models": {
+            "chapter_writer": "openai-compat://test",
+            "chapter_outline_writer": "openai-compat://test",
+            "scene_writer": "openai-compat://test",
+        }
+    }
+
+    def assemble_side_effect(*args, **kwargs):
+        if kwargs.get("scope") == "scene":
+            return {
+                "wiki_snapshot": "scene wiki",
+                "recap_snippets": ["scene recap A"],
+            }
+        return {
+            "wiki_snapshot": "wiki",
+            "recap_snippets": [],
+        }
+
+    agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
+    with (
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+        patch(
+            "presentation.agents.chapter_writer.assemble_context",
+            side_effect=assemble_side_effect,
+        ),
+    ):
+        await agent.run("test-story", 1, _outline_result(), _settings())
+
+    assert any("scene recap A" in prompt for prompt in captured)
+
+
 def test_extract_json_array_filters_non_dict_entries() -> None:
     payload = '[{"title": "A"}, "stray string", 42, {"title": "B"}]'
     assert _extract_json_array(payload) == [{"title": "A"}, {"title": "B"}]
 
 
 @pytest.mark.asyncio
-async def test_scene_pipeline_calls_get_snapshot_per_scene(tmp_path: Path) -> None:
-    """get_snapshot is called for each scene in the pipeline (plus chapter level)."""
+async def test_scene_pipeline_calls_assemble_context_per_scene(tmp_path: Path) -> None:
+    """assemble_context runs at chapter scope and again for each scene."""
     wiki_dir = tmp_path / "test-story" / "wiki"
     wiki_dir.mkdir(parents=True, exist_ok=True)
 
@@ -455,33 +510,35 @@ async def test_scene_pipeline_calls_get_snapshot_per_scene(tmp_path: Path) -> No
 
     call_count = 0
 
-    def _snapshot_side_effect(**kwargs):
+    def _assemble_side_effect(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        return f"## Wiki snapshot {call_count}"
+        return {
+            "wiki_snapshot": f"## Wiki snapshot {call_count}",
+            "recap_snippets": [],
+        }
 
     with (
         patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
         patch(
-            "presentation.agents.chapter_writer.get_snapshot",
-            side_effect=_snapshot_side_effect,
+            "presentation.agents.chapter_writer.assemble_context",
+            side_effect=_assemble_side_effect,
         ),
     ):
         draft = await agent.run("test-story", 1, _outline_result(), _settings())
 
-    # Chapter-level call (scene=0) + 2 per-scene calls = 3 total.
-    assert call_count >= 2
+    assert call_count == 3
     assert draft.content
 
 
 @pytest.mark.asyncio
-async def test_scene_pipeline_falls_back_per_scene_when_wiki_unavailable(
+async def test_scene_pipeline_falls_back_per_scene_when_scene_context_unavailable(
     tmp_path: Path,
 ) -> None:
-    """When get_snapshot returns None for per-scene calls, generation still produces output.
+    """When scene-scope assembly fails, generation still produces output.
 
-    The chapter-level snapshot (scene=0) returns valid content; per-scene calls
-    return None to exercise the graceful fallback path in the scene pipeline.
+    The chapter-level context returns valid content; per-scene calls raise to
+    exercise the graceful fallback path in the scene pipeline.
     """
     scenes_payload = json.dumps(
         [{"title": "Only Scene", "description": "The one and only beat."}]
@@ -505,19 +562,20 @@ async def test_scene_pipeline_falls_back_per_scene_when_wiki_unavailable(
 
     call_count = 0
 
-    def _side_effect(**kwargs):
+    def _side_effect(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        # Chapter-level call (scene=0) returns valid content.
-        # Per-scene calls (scene>0) return None to test graceful fallback.
-        return (
-            "## Wiki Context\nChapter context" if kwargs.get("scene", 0) == 0 else None
-        )
+        if kwargs.get("scope") == "chapter":
+            return {
+                "wiki_snapshot": "## Wiki Context\nChapter context",
+                "recap_snippets": [],
+            }
+        raise RuntimeError("scene context unavailable")
 
     with (
         patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
         patch(
-            "presentation.agents.chapter_writer.get_snapshot",
+            "presentation.agents.chapter_writer.assemble_context",
             side_effect=_side_effect,
         ),
     ):

--- a/tests/unit/test_recap_writer_agent.py
+++ b/tests/unit/test_recap_writer_agent.py
@@ -237,3 +237,174 @@ async def test_run_accepts_empty_previous_recap_and_start_date() -> None:
 
     assert isinstance(result, dict)
     assert result["events"] == "events text"
+
+
+@pytest.mark.asyncio
+async def test_assemble_context_called_with_recap_scope(tmp_path: Path) -> None:
+    provider = _ProviderStub(
+        [
+            "events text",
+            "timed events",
+            "enriched events",
+            '{"events": ["formatted"]}',
+            "compact recap",
+            "sanitised recap",
+        ]
+    )
+    bus = _StubBus()
+    wiki_bus = _StubWikiBus()
+    agent = RecapWriterAgent(provider, {}, bus, wiki_bus)
+    settings = GenerationSettings.from_dict({})
+
+    with (
+        patch(
+            "presentation.agents.recap_writer.assemble_context",
+            return_value={
+                "wiki_snapshot": "wiki text",
+                "recap_snippets": ["recap A", "recap B"],
+            },
+        ) as assemble_mock,
+        patch(
+            "presentation.agents.recap_writer.read_index",
+            return_value=[
+                {
+                    "name": "Alice",
+                    "slug": "alice",
+                    "type": "character",
+                    "aliases": [],
+                }
+            ],
+        ),
+        patch(
+            "presentation.agents.recap_writer.match_entities_in_text",
+            return_value=[
+                {
+                    "name": "Alice",
+                    "slug": "alice",
+                    "type": "character",
+                    "aliases": [],
+                }
+            ],
+        ),
+        patch("presentation.agents.recap_writer.STORIES_DIR", tmp_path),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+    ):
+        await agent.run(
+            "my-story",
+            3,
+            "Alice appeared in the chapter",
+            "prev recap",
+            "2024-01-15",
+            settings,
+        )
+
+    assemble_mock.assert_called_once_with(
+        "my-story",
+        scope="recap",
+        focus="Alice appeared in the chapter",
+        chapter=3,
+        characters=("alice",),
+        recap_window=("character", 5),
+    )
+
+
+@pytest.mark.asyncio
+async def test_related_recap_history_injected_in_extract_events_prompt() -> None:
+    provider = _ProviderStub(
+        [
+            "events text",
+            "timed events",
+            "enriched events",
+            '{"events": ["formatted"]}',
+            "compact recap",
+            "sanitised recap",
+        ]
+    )
+    bus = _StubBus()
+    wiki_bus = _StubWikiBus()
+    agent = RecapWriterAgent(provider, {}, bus, wiki_bus)
+    captured_variables: dict[str, object] = {}
+
+    def capture_prompt(name: str, variables: dict[str, object] | None = None) -> str:
+        if name == "extract_chapter_events":
+            captured_variables.update(variables or {})
+        return f"prompt::{name}"
+
+    with (
+        patch(
+            "presentation.agents.recap_writer.assemble_context",
+            return_value={
+                "wiki_snapshot": "",
+                "recap_snippets": ["prior event 1", "prior event 2"],
+            },
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run(
+            "my-story",
+            3,
+            "chapter body",
+            "prev recap",
+            "2024-01-15",
+            GenerationSettings.from_dict({}),
+        )
+
+    assert captured_variables["related_recap_history"] == "prior event 1\n\nprior event 2"
+
+
+@pytest.mark.asyncio
+async def test_related_recap_history_injected_in_sanitize_prompt() -> None:
+    provider = _ProviderStub(
+        [
+            "events text",
+            "timed events",
+            "enriched events",
+            '{"events": ["formatted"]}',
+            "compact recap",
+            "sanitised recap",
+        ]
+    )
+    bus = _StubBus()
+    wiki_bus = _StubWikiBus()
+    agent = RecapWriterAgent(provider, {}, bus, wiki_bus)
+    captured_variables: dict[str, object] = {}
+
+    def capture_prompt(name: str, variables: dict[str, object] | None = None) -> str:
+        if name == "recap/sanitize":
+            captured_variables.update(variables or {})
+        return f"prompt::{name}"
+
+    with (
+        patch(
+            "presentation.agents.recap_writer.assemble_context",
+            return_value={
+                "wiki_snapshot": "",
+                "recap_snippets": ["prior event"],
+            },
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run(
+            "my-story",
+            3,
+            "chapter body",
+            "prev recap",
+            "2024-01-15",
+            GenerationSettings.from_dict(
+                {
+                    "use_multi_stage_recap_sanitizer": True,
+                    "use_improved_recap_sanitizer": True,
+                }
+            ),
+        )
+
+    assert "prior event" in str(captured_variables["related_recap_history"])


### PR DESCRIPTION
## Summary

Integrates `assemble_context` into `RecapWriterAgent` and `ChapterWriterAgent`, giving both agents broader temporal context (wiki snapshot + recap history) beyond just the immediately prior chapter.

## Closes
Closes #359

## Changes

### RecapWriterAgent
- Detects characters in chapter prose via alias match against wiki index
- Calls `assemble_context(scope="recap", recap_window=("character", 5))` to retrieve recent chapter aggregates for involved characters
- Passes `{related_recap_history}` (joined recap snippets) and `{wiki_context}` (slim L1 wiki snapshot) to `extract_chapter_events` stage
- Passes `{related_recap_history}` to `recap/sanitize` stage — prevents cross-chapter duplication

### ChapterWriterAgent
- Replaces direct `get_snapshot` calls with `assemble_context`:
  - Chapter-level: `scope="chapter"`, `recap_window=("character", 5)` — gets wiki snapshot AND recap history in one call
  - Scene-level: `scope="scene"`, `recap_window=("character", 3)` — gets scene-scoped wiki AND recap snippets
- Threads `recap_context` through synopsis generation (`create_synopsis`), direct drafting (`write_chapter_direct`)
- Threads `scene_recap_context` through all scene content prompts (`create_content_first/middle/final`)
- Wiki snapshot failure still raises `StoryGenerationError` (regression guard preserved — "chapter" is a fatal scope in `assemble_context`)

### Prompt updates
- `prompts/extract_chapter_events.md` — added `{wiki_context}` and `{related_recap_history}` blocks
- `prompts/recap/sanitize.md` — added `{related_recap_history}` block
- `prompts/chapters/write_chapter_direct.md` — added `{recap_context}` section
- `prompts/chapters/create_synopsis.md` — added `{recap_context}` section
- `prompts/multistep/scene/create_content_{first,middle,final}.md` — added `{scene_recap_context}` block

## Checklist
- [x] Implementation complete
- [x] All tests passing (35 passed, 0 failed)
- [x] Linting clean (`ruff` + `mypy`)

## Plan

**Summary:** Add `assemble_context` to `RecapWriterAgent` and `ChapterWriterAgent`. Both agents previously used narrow context (just-prior-chapter or direct wiki snapshot). This task wires the context assembly helper from Task 7 (#357) to give them broader temporal coverage.

**Affected Areas:** Python domain logic — agents; Prompt templates; No ChromaDB schema change.

**Task Checklist:**
- [x] `src/presentation/agents/recap_writer.py` — character detection + assemble_context(scope="recap")
- [x] `src/presentation/agents/chapter_writer.py` — replace get_snapshot with assemble_context for chapter and scene levels
- [x] `prompts/extract_chapter_events.md`, `prompts/recap/sanitize.md` — add recap history variables
- [x] `prompts/chapters/*.md`, `prompts/multistep/scene/*.md` — add recap_context variables
- [x] `tests/unit/test_recap_writer_agent.py` — 3 new tests
- [x] `tests/unit/test_chapter_writer_agent.py` — 3 new tests, updated fixture
- [x] `tests/unit/test_chapter_writer_scene_pipeline.py` — 3 new tests, updated fixture
