### PR TITLE
feat(agents): add wiki + recap context to story metadata and final editor agents

### DIFF
--- a/prompts/final_edit/edit_chapter_direct.md
+++ b/prompts/final_edit/edit_chapter_direct.md
@@ -11,6 +11,16 @@ You are a senior prose editor performing a final polish pass on a single chapter
 {prior_chapters_summary}
 </PRIOR_CHAPTERS>
 
+## Wiki Context
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+## Recap Context
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 ## Chapter Text
 <CHAPTER_TEXT>
 {chapter_text}

--- a/prompts/outline/create_summary.md
+++ b/prompts/outline/create_summary.md
@@ -10,6 +10,16 @@ Based on this story outline and chapters, generate a compelling summary:
 {chapter_content}
 </CHAPTER_CONTENT>
 
+## Wiki Context
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+## Recap Context
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 Generate a summary that:
 - Captures the main plot and themes
 - Is engaging and hooks the reader

--- a/prompts/outline/create_tags.md
+++ b/prompts/outline/create_tags.md
@@ -10,6 +10,16 @@ Based on this story outline and first chapter, generate relevant tags:
 {first_chapter}
 </FIRST_CHAPTER>
 
+## Wiki Context
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+## Recap Context
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 Generate a list of tags that describe:
 - Genre and subgenre
 - Themes and topics

--- a/prompts/outline/create_title.md
+++ b/prompts/outline/create_title.md
@@ -10,6 +10,16 @@ Based on this story outline and first chapter, generate a compelling title:
 {first_chapter}
 </FIRST_CHAPTER>
 
+## Wiki Context
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+## Recap Context
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 Generate a title that captures the essence of this story. The title should be:
 - Engaging and memorable
 - Appropriate for the genre and tone

--- a/src/presentation/agents/final_editor.py
+++ b/src/presentation/agents/final_editor.py
@@ -14,6 +14,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from tools.context_assembly import assemble_context
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -71,6 +72,18 @@ class FinalEditorAgent:
             )
         )
 
+        _ctx = assemble_context(
+            draft.story_name,
+            scope="final_edit",
+            focus=draft.synopsis or draft.content[:500],
+            chapter=chapter_number,
+            recap_window=("chapter", 3),
+        )
+        wiki_context: str = _ctx["wiki_snapshot"]
+        recap_context: str = (
+            "\n\n".join(_ctx["recap_snippets"]) if _ctx["recap_snippets"] else ""
+        )
+
         if settings.enable_scrubbing:
             prose_prompt = self._loader.load_prompt(
                 "final_edit/prose_scrub",
@@ -124,6 +137,8 @@ class FinalEditorAgent:
                 "prior_chapters_summary": prior_summary,
                 "prose_findings": prose_findings,
                 "voice_findings": voice_findings,
+                "wiki_context": wiki_context,
+                "recap_context": recap_context,
             },
         )
 

--- a/src/presentation/agents/story_metadata.py
+++ b/src/presentation/agents/story_metadata.py
@@ -16,6 +16,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from tools.context_assembly import assemble_context
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -103,6 +104,18 @@ class StoryMetadataAgent:
             )
         )
 
+        _ctx = assemble_context(
+            story_name,
+            scope="metadata",
+            focus=outline_text[:500] if outline_text else "",
+            recap_window=("chapter", 20),
+            token_budget=20000,
+        )
+        wiki_context: str = _ctx["wiki_snapshot"]
+        recap_context: str = (
+            "\n\n".join(_ctx["recap_snippets"]) if _ctx["recap_snippets"] else ""
+        )
+
         model_config = _build_model_config(
             self.config, "story_metadata", "openai-compat://default"
         )
@@ -112,7 +125,12 @@ class StoryMetadataAgent:
         try:
             prompt = self._loader.load_prompt(
                 "outline/create_title",
-                {"outline": outline_text, "first_chapter": first_chapter},
+                {
+                    "outline": outline_text,
+                    "first_chapter": first_chapter,
+                    "wiki_context": wiki_context,
+                    "recap_context": recap_context,
+                },
             )
             response = await self.provider.generate_text(
                 [{"role": "user", "content": prompt}],
@@ -130,7 +148,12 @@ class StoryMetadataAgent:
         try:
             prompt = self._loader.load_prompt(
                 "outline/create_summary",
-                {"outline": outline_text, "chapter_content": first_chapter},
+                {
+                    "outline": outline_text,
+                    "chapter_content": first_chapter,
+                    "wiki_context": wiki_context,
+                    "recap_context": recap_context,
+                },
             )
             response = await self.provider.generate_text(
                 [{"role": "user", "content": prompt}],
@@ -148,7 +171,12 @@ class StoryMetadataAgent:
         try:
             prompt = self._loader.load_prompt(
                 "outline/create_tags",
-                {"outline": outline_text, "first_chapter": first_chapter},
+                {
+                    "outline": outline_text,
+                    "first_chapter": first_chapter,
+                    "wiki_context": wiki_context,
+                    "recap_context": recap_context,
+                },
             )
             response = await self.provider.generate_text(
                 [{"role": "user", "content": prompt}],

--- a/tests/unit/test_final_editor_agent.py
+++ b/tests/unit/test_final_editor_agent.py
@@ -64,10 +64,16 @@ async def test_scrubbing_enabled_invokes_prose_scrub_and_voice_pass() -> None:
         wiki_bus=wiki_bus,
     )
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        return_value="system",
-    ) as mock_load_prompt:
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system",
+        ) as mock_load_prompt,
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
         await agent.run(
             "s",
             [_draft(1)],
@@ -105,9 +111,15 @@ async def test_scrubbing_enabled_passes_findings_to_edit_chapter_direct() -> Non
             captured_edit_variables.update(variables or {})
         return "system"
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=capture_prompt,
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         await agent.run(
             "s",
@@ -138,10 +150,16 @@ async def test_scrubbing_disabled_skips_stage1_calls_only_edit_chapter_direct() 
             captured_edit_variables.update(variables or {})
         return "system"
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=capture_prompt,
-    ) as mock_load_prompt:
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ) as mock_load_prompt,
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
         await agent.run(
             "s",
             [_draft(1)],
@@ -171,9 +189,15 @@ async def test_edit_single_chapter_returns_chapter_draft() -> None:
         wiki_bus=wiki_bus,
     )
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        return_value="system",
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system",
+        ),
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         result = await agent.edit_single_chapter(
             _draft(1),
@@ -219,11 +243,17 @@ async def test_run_delegates_to_edit_single_chapter() -> None:
     )
     chapters = [_draft(1), _draft(2)]
 
-    with patch.object(
-        agent,
-        "edit_single_chapter",
-        new=AsyncMock(side_effect=chapters),
-    ) as edit_single:
+    with (
+        patch.object(
+            agent,
+            "edit_single_chapter",
+            new=AsyncMock(side_effect=chapters),
+        ) as edit_single,
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
         result = await agent.run(
             "s",
             chapters,
@@ -235,3 +265,86 @@ async def test_run_delegates_to_edit_single_chapter() -> None:
 
     assert edit_single.await_count == 2
     assert result.edited_chapters == chapters
+
+
+@pytest.mark.asyncio
+async def test_edit_single_chapter_calls_assemble_context_with_final_edit_scope() -> (
+    None
+):
+    """FinalEditorAgent calls assemble_context with scope='final_edit'."""
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = FinalEditorAgent(
+        provider=_ProviderStub("polished"),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="system",
+        ),
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "wiki data", "recap_snippets": ["recap 1"]},
+        ) as mock_ctx,
+    ):
+        await agent.run(
+            "s",
+            [_draft(1)],
+            GenerationSettings.from_dict({}),
+        )
+
+    bus.close()
+    wiki_bus.close()
+
+    mock_ctx.assert_called_once()
+    call_kwargs = mock_ctx.call_args
+    assert call_kwargs.args[0] == "s"
+    assert call_kwargs.kwargs["scope"] == "final_edit"
+    assert call_kwargs.kwargs["chapter"] == 1
+    assert call_kwargs.kwargs["recap_window"] == ("chapter", 3)
+
+
+@pytest.mark.asyncio
+async def test_edit_single_chapter_passes_wiki_recap_to_edit_chapter_direct() -> None:
+    """wiki_context and recap_context are passed to final_edit/edit_chapter_direct prompt."""
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    agent = FinalEditorAgent(
+        provider=_ProviderStub("polished"),
+        config={},
+        bus=bus,
+        wiki_bus=wiki_bus,
+    )
+
+    captured_edit_variables: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if name == "final_edit/edit_chapter_direct":
+            captured_edit_variables.update(variables or {})
+        return "system"
+
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "wiki data", "recap_snippets": ["recap 1"]},
+        ),
+    ):
+        await agent.run(
+            "s",
+            [_draft(1)],
+            GenerationSettings.from_dict({}),
+        )
+
+    bus.close()
+    wiki_bus.close()
+
+    assert captured_edit_variables.get("wiki_context") == "wiki data"
+    assert captured_edit_variables.get("recap_context") == "recap 1"

--- a/tests/unit/test_recap_writer_agent.py
+++ b/tests/unit/test_recap_writer_agent.py
@@ -355,7 +355,9 @@ async def test_related_recap_history_injected_in_extract_events_prompt() -> None
             GenerationSettings.from_dict({}),
         )
 
-    assert captured_variables["related_recap_history"] == "prior event 1\n\nprior event 2"
+    assert (
+        captured_variables["related_recap_history"] == "prior event 1\n\nprior event 2"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_story_metadata.py
+++ b/tests/unit/test_story_metadata.py
@@ -51,9 +51,15 @@ async def test_run_phase1_no_chapter_content() -> None:
     wiki_bus = _StubWikiBus()
     agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=lambda name, variables=None: f"prompt::{name}",
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         result = await agent.run(
             "my-story",
@@ -78,9 +84,15 @@ async def test_run_phase2_with_chapter_content() -> None:
     wiki_bus = _StubWikiBus()
     agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=lambda name, variables=None: f"prompt::{name}",
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         result = await agent.run(
             "my-story",
@@ -102,9 +114,15 @@ async def test_run_graceful_degradation_title_fails() -> None:
     wiki_bus = _StubWikiBus()
     agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=lambda name, variables=None: f"prompt::{name}",
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         result = await agent.run(
             "my-story",
@@ -125,9 +143,15 @@ async def test_run_graceful_degradation_all_fail() -> None:
     wiki_bus = _StubWikiBus()
     agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=lambda name, variables=None: f"prompt::{name}",
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         result = await agent.run(
             "my-story",
@@ -160,9 +184,15 @@ async def test_run_emits_phase_messages() -> None:
     wiki_bus = _StubWikiBus()
     agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
 
-    with patch(
-        "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-        side_effect=lambda name, variables=None: f"prompt::{name}",
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
     ):
         await agent.run(
             "my-story",
@@ -172,3 +202,72 @@ async def test_run_emits_phase_messages() -> None:
         )
 
     assert any("[Metadata]" in message for message in bus.messages)
+
+
+@pytest.mark.asyncio
+async def test_run_calls_assemble_context_with_metadata_scope() -> None:
+    """StoryMetadataAgent.run() calls assemble_context with scope='metadata'."""
+    provider = _ProviderStub(["T", "S", '["t"]'])
+    bus = _StubBus()
+    wiki_bus = _StubWikiBus()
+    agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
+
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=lambda name, variables=None: f"prompt::{name}",
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "wiki data", "recap_snippets": ["recap 1"]},
+        ) as mock_ctx,
+    ):
+        await agent.run(
+            "my-story",
+            "outline text",
+            "",
+            GenerationSettings.from_dict({}),
+        )
+
+    mock_ctx.assert_called_once()
+    call_kwargs = mock_ctx.call_args
+    assert call_kwargs.args[0] == "my-story"
+    assert call_kwargs.kwargs["scope"] == "metadata"
+    assert call_kwargs.kwargs["recap_window"] == ("chapter", 20)
+
+
+@pytest.mark.asyncio
+async def test_run_passes_wiki_and_recap_context_to_prompts() -> None:
+    """wiki_context and recap_context from assemble_context are passed to load_prompt."""
+    provider = _ProviderStub(["T", "S", '["t"]'])
+    bus = _StubBus()
+    wiki_bus = _StubWikiBus()
+    agent = StoryMetadataAgent(provider, {}, bus, wiki_bus)
+
+    captured_variables: list[dict] = []
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if variables:
+            captured_variables.append(dict(variables))
+        return f"prompt::{name}"
+
+    with (
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+        patch(
+            "presentation.agents.story_metadata.assemble_context",
+            return_value={"wiki_snapshot": "wiki data", "recap_snippets": ["recap 1"]},
+        ),
+    ):
+        await agent.run(
+            "my-story",
+            "outline text",
+            "",
+            GenerationSettings.from_dict({}),
+        )
+
+    assert all("wiki_context" in v for v in captured_variables)
+    assert all("recap_context" in v for v in captured_variables)
+    assert all(v["wiki_context"] == "wiki data" for v in captured_variables)


### PR DESCRIPTION
## Summary

Adds wiki and recap context retrieval to `StoryMetadataAgent` and `FinalEditorAgent` via the existing `assemble_context()` helper. Both agents now call `assemble_context` before generating prompts, passing `{wiki_context}` and `{recap_context}` as template variables to their respective prompt templates.

## Closes
Closes #360

## Changes

- **`StoryMetadataAgent.run()`** — calls `assemble_context(scope="metadata", recap_window=("chapter", 20), token_budget=20000)` before title/summary/tags generation; passes `wiki_context` and `recap_context` to all three prompt loads (`create_title`, `create_summary`, `create_tags`)
- **`FinalEditorAgent.edit_single_chapter()`** — calls `assemble_context(scope="final_edit", chapter=N, recap_window=("chapter", 3))` per chapter; passes `wiki_context` and `recap_context` to `edit_chapter_direct` prompt
- **`prompts/outline/create_title.md`** — added `{wiki_context}` and `{recap_context}` placeholders
- **`prompts/outline/create_summary.md`** — added `{wiki_context}` and `{recap_context}` placeholders
- **`prompts/outline/create_tags.md`** — added `{wiki_context}` and `{recap_context}` placeholders
- **`prompts/final_edit/edit_chapter_direct.md`** — added `{wiki_context}` and `{recap_context}` placeholders
- **Tests** — updated existing tests to patch `assemble_context` (preventing ChromaDB calls in unit tests); added 4 new tests verifying scope, recap_window, and variable injection for both agents

## Plan

- [x] `StoryMetadataAgent` calls `assemble_context(scope="metadata", ...)`
- [x] Metadata prompts receive `{wiki_context}` and `{recap_context}`
- [x] `FinalEditorAgent` calls `assemble_context(scope="final_edit", ...)` per chapter
- [x] Final editor prompt receives chapter-scoped wiki + recap context (3-chapter window)
- [x] Unit tests confirm both agents call `assemble_context` with the correct scope
- [x] All 18 tests passing, lint clean, mypy clean