### PR TITLE
docs: documentation refresh for wiki consolidation (ADRs, manual, tools, copilot-instructions)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 | ------------ | ---------- |
 | **Backend**  | Python 3.x (domain logic in `src/`) |
 | **Frontend** | CLI-only — Python CLI (`src/presentation/cli/main.py`) |
-| **Database** | ChromaDB (vector search, per-story collections), JSON files on disk (story state, savepoints) |
+| **Database** | ChromaDB (vector search, `wiki-{story}` and `recaps-{story}` per-story collections), JSON files on disk (story state, savepoints) |
 | **Testing**  | pytest (`tests/`) |
 | **Styling**  | N/A |
 | **HTTP**     | OpenAI-compatible REST API (local LLM inference), httpx |
@@ -26,6 +26,7 @@
 - Tools are Python scripts in `src/tools/` — no TypeScript or subprocess wrappers
 - **Progressive wiki memory system** ([ADR 004](docs/planning/adr/004-progressive-wiki-memory-system.md)): structured markdown pages with YAML frontmatter in `stories/<name>/wiki/`
 - **Three-stage context retrieval pipeline** ([ADR 005](docs/planning/adr/005-hybrid-wiki-context-retrieval-pipeline.md)): entity matching → metadata query → semantic search → wikilink traversal → detail level selection → structured assembly
+- **Wiki as entity source of truth** ([ADR 014](docs/planning/adr/014-wiki-as-entity-source-of-truth.md)): `wiki-generation` phase replaces character/setting sheet phases; `stories/` directories contain no `characters/` or `settings/` subdirectories; two ChromaDB collections per story — `wiki-{story}` and `recaps-{story}`
 
 ### Testing
 

--- a/.github/notes/audits/2026-05-05-wiki-consolidation-status.md
+++ b/.github/notes/audits/2026-05-05-wiki-consolidation-status.md
@@ -227,21 +227,22 @@ The retrieval pipeline is well-engineered, but the corpus it queries is impoveri
 
 ---
 
-## Recommended Actions (in priority order)
+## Resolution — Tasks 0–11 Complete
 
-1. **Fix [F-C-02]**. In `_coerce_event_list`, strip `\`\`\`json` / `\`\`\`` fences before `json.loads`, and tolerate trailing prose. Add an integration test that runs the full recap → sync → wiki path with realistic LLM-style fenced output. Backfill `breaking-amy` events to validate.
-2. **Fix [F-C-01]**. Decide one of:
-   - **(A — preferred per ADR 004)** Push sheet chunk markdown and recap markdown directly into the `wiki-{story}` collection as `type: character_chunk | setting_chunk | recap_compact | recap_sanitised | recap_events` documents, so semantic search retrieves them. Drop the `stories-{story}` collection entirely. Update T2/T3 wiki snapshot logic to filter on wiki page types only.
-   - **(B — minimum viable)** Wire the existing `outline_chapter/character_manager.index_character()` (or an equivalent thin helper) into `_generate_character_sheets`/`_generate_setting_sheets`/recap-write step, populating the `stories-{story}` collection. Then have `wiki_snapshot` query both `wiki-{story}` and `stories-{story}` (less clean — perpetuates the split).
-3. **Fix [F-W-02]**. At minimum, have `ConsistencyCheckerAgent` and `RecapWriterAgent` request a wiki snapshot (cheap one — POV character + primary location only) before composing their prompts.
-4. **Address [F-C-03]**. After wiki bootstrap, write a migration step that diffs sheet count against wiki page count per type, and fails the phase if any sheet was dropped. Or — if A above is adopted — bypass the lossy entity-extraction step entirely by upserting sheet chunks directly.
-5. **Resolve [F-W-04]**. Either delete `src/application/strategies/outline_chapter/` (the dead strategy) or rewire the strategy factory.
-6. **Backfill tool [F-I-03]**. Provide `python -m tools.backfill_wiki --story breaking-amy` that re-runs sheet→wiki extraction and recap→event sync for all existing chapters.
+All critical and warning findings from this audit were resolved through the Wiki Source-of-Truth Consolidation project ([PRD](../../../docs/planning/wiki-source-of-truth-consolidation/prd.md), [tasks](../../../docs/planning/wiki-source-of-truth-consolidation/tasks.md)):
 
----
+| Finding | Resolution | Issue |
+| ------- | ---------- | ----- |
+| [F-C-01] Sheets/recaps not in ChromaDB | Sheets retired; wiki-generation produces direct wiki pages; recaps indexed via `recaps-{story}` collection | #351 (Task 3), #352 (Task 1) |
+| [F-C-02] Recap→wiki event sync silently dead | `_coerce_event_list` fixed to strip fences and surface parse errors | #350 (Task 0) |
+| [F-C-03] Sheet/wiki page count divergence | Sheet phases removed entirely; wiki-generation is the sole entity creation path | #351 (Task 3) |
+| [F-W-01] Recap compact/sanitised not searchable | Indexed via `recap_index.upsert_recap` into `recaps-{story}` ChromaDB collection | #353 (Task 2) |
+| [F-W-02] Wiki consulted only by chapter writer | `assemble_context` wired into consistency checker, recap writer, outline planner, chapter writer, story metadata, final editor | #357, #358, #359, #360 (Tasks 7–10) |
+| [F-W-03] Sheet fallback re-introduces stale data | `_build_entity_context` deleted; wiki absence raises `StoryGenerationError` | #351 (Task 3) |
+| [F-W-04] Dead `outline_chapter/` strategy package | Package deleted; `stories-{story}` collection retired | #361 (Task 11) |
+| [F-W-05] Two parallel ChromaDB schemas | `stories-{story}` collection removed; only `wiki-{story}` and `recaps-{story}` remain | #361 (Task 11) |
+| [F-I-01] WikiMaintainerAgent ignores existing page bodies | Per-type extraction + page-body-aware merge prompt implemented | #354, #355, #356 (Tasks 4–6) |
+| [F-I-02] Recap writer returns fenced LLM text unparsed | Fixed in Task 0 (`_coerce_event_list`); recap index upserts parsed payloads | #350, #353 (Tasks 0, 2) |
+| [F-I-03] No backfill tool | Explicitly out of scope per ADR 014 §5; existing stories to be regenerated | — |
 
-## Actions Taken
-
-- Notes written: `.github/notes/audits/2026-05-05-wiki-consolidation-status.md`
-- ChromaDB: findings ready for embed into `audits` collection (pending user approval)
-- Issues created: **none** — pending user instruction on hand-off to Orchestrator
+Documentation refreshed in issue #362 (Task 12).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -363,25 +363,6 @@ stories/my-first-story/
 ├── output/
 │   ├── story.md                  # Final assembled manuscript
 │   └── story_edited.md           # Post-final-edit manuscript (optional)
-├── characters/
-│   ├── yuki-tanaka-oduya.json    # Character sheet metadata + {"$ref": ...} pointers
-│   ├── yuki-tanaka-oduya/
-│   │   ├── sheet.md              # Full markdown body
-│   │   ├── summary.md            # Summary markdown body
-│   │   ├── abridged.md           # Prompt-safe markdown body
-│   │   └── chunks/
-│   │       └── ...               # One markdown file per character chunk
-│   ├── commander-voss.json
-│   └── ...
-├── settings/
-│   ├── europa-research-base.json # Setting sheet metadata + {"$ref": ...} pointers
-│   ├── europa-research-base/
-│   │   ├── sheet.md
-│   │   ├── summary.md
-│   │   ├── abridged.md
-│   │   └── chunks/
-│   │       └── ...               # One markdown file per setting chunk
-│   └── ...
 ├── savepoints/
 │   ├── pipeline_state.json       # Resume state (single JSON file)
 │   ├── outline_complete          # Milestone marker
@@ -421,11 +402,11 @@ The story generation pipeline is divided into primary phases. Each phase writes 
 The current restored pipeline runs in this order:
 
 ```text
-Init -> Story Foundation -> Outline -> [Outline Critique] -> Narrative Arc Analysis -> Characters & Settings -> Wiki Initialization -> Wiki Bootstrap -> Chapter Loop -> Final Edit -> Assembly
+Init -> Story Foundation -> Outline -> [Outline Critique] -> Narrative Arc Analysis -> Wiki Generation -> Wiki Initialization -> Wiki Bootstrap -> Chapter Loop -> Final Edit -> Assembly
 ```
 
 - **Foundation** extracts the story's base context, story start date, and story elements from the prompt before outline generation begins. Those fields seed `OutlineResult` and survive savepoints and resume.
-- **Outline Structure** turns the prompt plus foundation context into the chapter-by-chapter outline, using either direct, expanded, or chunked outline generation depending on the active settings. The approved outline becomes the structural source for downstream character, setting, wiki, and chapter work.
+- **Outline Structure** turns the prompt plus foundation context into the chapter-by-chapter outline, using either direct, expanded, or chunked outline generation depending on the active settings. The approved outline becomes the structural source for downstream wiki generation, wiki bootstrap, and chapter work.
 - **Outline Critique** runs the outline review loop when `enable_outline_critique` is enabled. The outline phase now checkpoints the draft and critique sub-steps separately, so resume can return to the approval gate or skip critique when those artefacts are already persisted.
 - **Chapter Loop (Recap -> Chapter Write)** carries forward recap context from the prior approved chapter, writes the next chapter from the outline plus accumulated story state, then updates wiki pages, refreshes metadata, and writes the new recap for the following chapter. Drafting, consistency, wiki update, recap, and Chapter 1 metadata refresh are now resumable as separate chapter-local ledger items.
 - **Final Edit** performs the last prose-polish pass across approved chapters, optionally running scrub and voice-consistency diagnostics before editing. Each edited chapter is now checkpointed independently before assembly writes the final manuscript.
@@ -452,14 +433,18 @@ In addition to the primary phases, the orchestrator now runs three advisory meta
                  │   Analysis      │
                  └─────────────────┘
                       │
-          ┌─────────────────────────────┼─────────────────────────────┐
-          ▼                             ▼                             ▼
-      ┌────────────┐                ┌──────────┐                  ┌───────────┐
-      │ Characters │                │ Settings │                  │ Wiki Init │
-      │  (sheets)  │                │ (sheets) │                  │           │
-      └────────────┘                └──────────┘                  └───────────┘
-          │                             │                             │
-          └─────────────────────────────┴─────────────────────────────┘
+                │
+                ▼
+              ┌──────────────────┐
+              │  Wiki Generation │
+              │ (characters &    │
+              │  locations)      │
+              └──────────────────┘
+                │
+                ▼
+              ┌──────────────────┐
+              │   Wiki Init      │
+              └──────────────────┘
                       │
                       ▼
                  ┌──────────────────┐
@@ -554,28 +539,21 @@ In addition to the primary phases, the orchestrator now runs three advisory meta
 
 **Approximate duration:** 2–5 minutes
 
-### Phase 5: Characters & Settings
+### Phase 5: Wiki Generation
 
 **What the system does:**
-- Extracts character names from the approved outline and generates one JSON sheet per character
-- Extracts setting/location names from the approved outline and generates one JSON sheet per setting
-- Caches extracted names to `stories/<name>/characters/_names.json` and `stories/<name>/settings/_names.json` before the per-entity loop continues
-- Uses the work-item ledger inside `pipeline_state.json` to checkpoint each base sheet, each chunk, each abridged write, and each summary write
-- Uses orchestrator helpers rather than standalone character or setting presentation agents
-- If name extraction returns invalid JSON, the phase degrades gracefully and the pipeline continues
+- For each character named in the approved outline, invokes a direct-to-wiki prompt that produces a full wiki page with YAML frontmatter, L1 summary (≤ 300 chars), L2 abridged dossier (~1500 chars), and L3 full-body sections.
+- For each location named in the approved outline, generates an equivalent wiki location page.
+- Writes pages directly via `wiki_update.run_batch` create payloads; no intermediate sheet artefacts are created on disk.
+- Uses the work-item ledger inside `pipeline_state.json` to checkpoint each page write individually.
 
 **Resume behavior:**
-- Already-cached name lists are loaded from `_names.json` instead of being re-extracted
-- Completed character and setting JSON files are read back from disk
-- Resume continues from the next missing chunk or summary step instead of restarting the whole phase
+- Already-written wiki pages are skipped (idempotent by slug); a partial run resumes from the next missing entity.
 
 **Artefacts produced:**
-- `stories/<name>/savepoints/characters`
-- `stories/<name>/savepoints/settings`
-- `stories/<name>/characters/_names.json`
-- `stories/<name>/characters/<slug>.json` (one per character)
-- `stories/<name>/settings/_names.json`
-- `stories/<name>/settings/<slug>.json` (one per setting)
+- `stories/<name>/wiki/characters/<slug>.md` (one per outline character)
+- `stories/<name>/wiki/locations/<slug>.md` (one per outline location)
+- `stories/<name>/savepoints/pipeline_state.json` with wiki-generation ledger items
 
 **User action needed:** None
 
@@ -604,7 +582,7 @@ In addition to the primary phases, the orchestrator now runs three advisory meta
 Runs immediately after wiki initialization and before the chapter loop.
 
 What this phase does:
-- Calls `_list_wiki_entities()` in `src/tools/wiki_extract.py` to extract and deduplicate entities from `characters/*.json` and `settings/*.json` first, using outline extraction only when the saved outline text is non-empty
+- Calls `_list_wiki_entities()` in `src/tools/wiki_extract.py` to extract and deduplicate additional entities from the outline (factions, items, plot threads, world rules, themes, relationships, and timeline entries) not already created by the `wiki-generation` phase
 - Drives `_bootstrap_single_wiki_entity()` in a per-entity loop so each created wiki page has its own ledger item
 - Skips already-completed work items and already-existing wiki slugs for idempotent reruns
 - Leaves `bootstrap_wiki_from_story()` available for direct CLI or ad-hoc one-shot bootstrap usage
@@ -621,11 +599,11 @@ What this phase does:
 
 **What the system does:**
 - For each chapter (1 to `wanted_chapters`):
-  1. **Scene Generation (7b)** — Prefers the chapter's detailed outline block when available; forwards the prior chapter recap from `state.recaps[str(N-1)]` (preferring `compact`, then `sanitised`, then `events`); and generates chapter text via the `chapter-writer` agent. Before building the chapter prompt, `ChapterWriterAgent` calls `get_snapshot()` in `src/tools/wiki_snapshot.py` with the chapter summary as the retrieval query; when the story has a populated wiki collection in ChromaDB, that token-budgeted wiki snapshot becomes the primary `base_context` for the chapter. Only when no snapshot is available does the agent fall back to `_build_entity_context()` and load flat character and setting sheet summaries from disk. For each individual scene, a second `get_snapshot()` call is made with the scene description, POV character, characters, and primary location; the result replaces `base_context` at the scene level and falls back silently when the wiki is absent or retrieval returns nothing. If `scene_generation_pipeline: true`, the agent expands the chapter into `stories/<name>/chapters/chapter_<N>_scenes.json`, then drafts scenes sequentially with position-aware prompts for first, middle, and final scenes. Each completed scene is written to `stories/<name>/chapters/chapter_<N>/scene_<M>.md` before the corresponding work item is marked done. Otherwise, the full chapter is generated in one LLM call. Once the draft is approved, `stories/<name>/chapters/chapter_<N>.md` is written before `chapter-<N>/draft` is recorded.
+  1. **Scene Generation (7b)** — Prefers the chapter's detailed outline block when available; forwards the prior chapter recap from `state.recaps[str(N-1)]` (preferring `compact`, then `sanitised`, then `events`); and generates chapter text via the `chapter-writer` agent. Before building the chapter prompt, `ChapterWriterAgent` calls `get_snapshot()` in `src/tools/wiki_snapshot.py` with the chapter summary as the retrieval query; when the story has a populated wiki collection in ChromaDB, that token-budgeted wiki snapshot becomes the primary `base_context` for the chapter. Wiki snapshot absence raises `StoryGenerationError` — there is no sheet fallback. For each individual scene, a second `get_snapshot()` call is made with the scene description, POV character, characters, and primary location; the result replaces `base_context` at the scene level. If `scene_generation_pipeline: true`, the agent expands the chapter into `stories/<name>/chapters/chapter_<N>_scenes.json`, then drafts scenes sequentially with position-aware prompts for first, middle, and final scenes. Each completed scene is written to `stories/<name>/chapters/chapter_<N>/scene_<M>.md` before the corresponding work item is marked done. Otherwise, the full chapter is generated in one LLM call. Once the draft is approved, `stories/<name>/chapters/chapter_<N>.md` is written before `chapter-<N>/draft` is recorded.
   2. **Approval Gate** — Presents the chapter for user approval (interactive mode only)
   3. **Consistency Check (7e)** — Runs `consistency_checker`; findings stream to the token bus but do not block chapter persistence
   4. **Chapter Persistence** — Appends the approved draft to `state.approved_chapters` and writes `stories/<name>/chapters/chapter_<N>.md`
-  5. **Wiki Update (7c)** — Calls `WikiMaintainerAgent` to extract structured data and persist wiki pages; failures are logged and do not block the loop. This is now the sole post-chapter entity state management step; character and setting sheet JSON files remain Phase 5 bootstrap inputs and chapter-writer fallback material.
+  5. **Wiki Update (7c)** — Calls `WikiMaintainerAgent` to extract structured data and persist wiki pages; failures are logged and do not block the loop. This is now the sole post-chapter entity state management step.
   6. **Recap Generation (7d)** — Calls `RecapWriterAgent` after wiki maintenance. The default path runs six LLM stages (`extract_chapter_events` → `recap/assign_event_timing` → `recap/enrich_event_details` → `recap/format_json` → `recap/compact_events` → optional `recap/sanitize`). When `use_multi_stage_recap_sanitizer: false`, the agent takes the short path (`extract_chapter_events` → `recap/format_json`). On success, the orchestrator writes the recap bodies to `stories/<name>/chapters/chapter_<N>/recap_events.md`, `recap_compact.md`, and `recap_sanitised.md`, then stores `{"$ref": ...}` pointers for those files in both `state.recaps[str(N)]` and `chapter_<N>_recap.json`. It then creates or updates wiki `event` pages from the recap `events` payload, populating `timestamp`, `participants`, `importance`, `emotional_state`, `causal_context`, and `chapter_provenance` alongside the verified event body. Recap failures are advisory and do not block later chapters.
   7. **Metadata Refresh (`metadata-chapter-1`)** — Immediately after Chapter 1 is approved, the orchestrator re-runs `StoryMetadataAgent` with the approved Chapter 1 prose. This refresh is advisory, updates `OutlineResult.title` plus `OutlineResult.tags` on success, and rewrites `stories/<name>/metadata.json`.
   8. **Savepoint (7h)** — Saves a chapter-level savepoint (`chapter-{N}`); after the last chapter, the orchestrator also marks `chapter-loop`
@@ -1094,8 +1072,8 @@ Reusable prompt content used by the Python-native pipeline lives in these locati
 - `prompts/final_edit/` — Final editing direct-generation prompts
 - `prompts/chapter_review/` — Consistency checking and review direct-generation prompts
 - `prompts/skills/` — Reusable skill reference material
-- `prompts/characters/` — Character sheet direct-generation prompts
-- `prompts/settings/` — Setting/location direct-generation prompts
+- `prompts/characters/` — Legacy character-sheet prompts kept as reference; not loaded by the active pipeline
+- `prompts/settings/` — Legacy setting-sheet prompts kept as reference; not loaded by the active pipeline
 - `prompts/scenes/` — Scene generation direct-generation prompts
 - `prompts/wiki/` — Wiki extraction and maintenance direct-generation prompts
 
@@ -1131,10 +1109,10 @@ Phase 4: Narrative Arc Analysis
   → Persist `state.arc_result` and write `arc_analysis_complete`
   → On agent error, emit skip message and continue
 
-Phase 5: Characters & Settings
-  → Extract character and setting names from outline
-  → Generate one JSON sheet per entity, then enrich it with `summary`, `abridged`, and per-aspect `chunks`
-  → Write per-entity JSON sheets to `stories/<name>/characters/` and `settings/`
+Phase 5: Wiki Generation
+  → Extract character and location names from outline
+  → Generate one wiki page per entity directly under `stories/<name>/wiki/`
+  → Checkpoint each page write in the work-item ledger
   → If name extraction returns invalid JSON, phase degrades gracefully
 
 Phase 6: Wiki Initialization
@@ -1144,7 +1122,7 @@ Phase 6: Wiki Initialization
 
 Phase 7: Wiki Bootstrap
   → Call `bootstrap_wiki_from_story()` after wiki init and before chapter generation
-  → Seed wiki pages from the outline savepoint plus character and setting sheets
+  → Seed remaining non-character and non-location wiki pages from the outline savepoint
   → Skip existing slugs so resume and rerun stay idempotent
   → Mark `wiki_populated` even if bootstrap raises, then continue pipeline
 
@@ -1201,7 +1179,8 @@ llm-story-writer/
 │       ├── scene_writer.py
 │       ├── critique_runner.py
 │       ├── recap_manager.py
-│       ├── rag_query.py
+│       ├── context_assembly.py
+│       ├── wiki_generation.py
 │       └── ...
 │
 ├── prompts/                  # 100+ prompt templates
@@ -1225,10 +1204,10 @@ llm-story-writer/
 │   │   ├── narrative-arc/
 │   │   └── ...
 │   ├── chapters/             # Chapter generation prompts
-│   ├── characters/          # Character sheet prompts
+│   ├── characters/          # Legacy character-sheet prompts retained as reference
 │   ├── outline/              # Outline generation prompts
 │   ├── scenes/              # Scene generation prompts
-│   ├── settings/            # Setting/location prompts
+│   ├── settings/            # Legacy setting prompts retained as reference
 │   ├── recap/               # Recap generation prompts
 │   └── ...
 │
@@ -1238,8 +1217,6 @@ llm-story-writer/
 │       ├── outline.json      # Story outline
 │       ├── chapters/         # Generated chapter files
 │       ├── output/           # Final assembled manuscript output
-│       ├── characters/       # Character JSON sheets
-│       ├── settings/         # Setting JSON sheets
 │       ├── savepoints/       # Savepoint files
 │       │   └── pipeline_state.json  # Resume checkpoint
 │       └── wiki/             # Progressive wiki
@@ -1322,7 +1299,7 @@ Wiki pages support three hierarchical summary levels:
 
 ### 11.5 Wiki Update Lifecycle
 
-1. **Initial bootstrap** (Phase 7, before Chapter 1): `_list_wiki_entities()` reads `characters/*.json` and `settings/*.json` as the canonical entity source, adds outline-derived entities only when the saved outline text is non-empty, then `_bootstrap_single_wiki_entity()` writes retrieval-ready L1/L2/L3 detail levels page by page
+1. **Initial bootstrap** (Phase 7, before Chapter 1): `_list_wiki_entities()` reads the saved outline and extracts non-character and non-location entity types not already created during wiki generation, then `_bootstrap_single_wiki_entity()` writes retrieval-ready L1/L2/L3 detail levels page by page
 2. **Post-chapter persistence** (after each accepted chapter): `wiki-maintainer` calls `update_wiki_from_chapter()`, the `wiki/extract_from_chapter` prompt returns structured JSON, and `run_batch()` persists new pages, state changes, aliases, and timeline events under `stories/<name>/wiki/`
 3. **Recap event sync** (after each accepted chapter recap): the orchestrator parses recap `events` and creates or updates wiki `event` pages with verified provenance fields including `timestamp`, `participants`, `importance`, `emotional_state`, `causal_context`, and `chapter_provenance`
 4. **Chapter-level lint** (after each chapter): `wiki-lint` checks consistency against the ConStory-Bench error taxonomy
@@ -1365,7 +1342,7 @@ The orchestrator may dispatch exactly these subagents for creative work:
 | `prose-scrubber` | Sentence/paragraph-level prose cleanup | Phase 7.5 ⏳ |
 | `final-editor` | Post-assembly voice, pacing, and coherence pass | Phase 9 |
 
-**Orchestrator Pipeline Phases:** Init → Story Foundation → Outline → `metadata-outline` → Narrative Arc → Characters & Settings → Wiki Init → Chapter Loop (+ `metadata-chapter-1` after the first approved chapter) → Final Edit → `metadata-final` → Assembly
+**Orchestrator Pipeline Phases:** Init → Story Foundation → Outline → `metadata-outline` → Narrative Arc → Wiki Generation → Wiki Init → Wiki Bootstrap → Chapter Loop (+ `metadata-chapter-1` after the first approved chapter) → Final Edit → `metadata-final` → Assembly
 
 ### 12.2 Tools
 
@@ -1379,13 +1356,14 @@ Tools are Python modules under `src/tools/`. The runtime imports them directly o
 | `story_state.py` | Initialize and update story state JSON (`--operation init/read/write/list`) |
 | `story_assembler.py` | Assemble approved chapters into a single manuscript |
 | `savepoint_manager.py` | Create, inspect, and load savepoints (`list`, `list-full`, `next-phase`, `clear`) |
-| `character_manager.py` | Extract and manage character sheets |
-| `setting_manager.py` | Extract and manage setting sheets |
+| `character_manager.py` | Legacy character-sheet management helpers retained for manual or migration workflows |
+| `setting_manager.py` | Legacy setting-sheet management helpers retained for manual or migration workflows |
 | `recap_manager.py` | Generate and manage chapter recaps |
 | `scene_writer.py` | Generate scene-level content |
 | `critique_runner.py` | Run quality critique on outline or chapter |
 | `critique_parser.py` | Parse critique output into structured scores and feedback |
-| `rag_query.py` | Query ChromaDB for relevant story content chunks |
+| `context_assembly.py` | Assemble wiki and recap context for wiki-aware agents |
+| `wiki_generation.py` | Generate initial wiki character and location pages directly from the approved outline |
 | `outline_generator.py` | Generate and expand story outlines |
 
 #### Wiki Tools
@@ -1487,8 +1465,8 @@ Granular resume inside converted phases works by combining that ledger state wit
 
 ```
 stories/<name>/chapters/chapter_<N>.md
-stories/<name>/characters/_names.json
-stories/<name>/settings/_names.json
+stories/<name>/wiki/characters/<slug>.md
+stories/<name>/wiki/locations/<slug>.md
 stories/<name>/chapters/chapter_<N>_scenes.json
 stories/<name>/chapters/chapter_<N>/scene_<M>.md
 stories/<name>/chapters/chapter_<N>_edited.md
@@ -1708,42 +1686,40 @@ story-writer run --story my-story --batch
 story-writer tui --story my-story
 ```
 
-### 15.7 Working with Character and Setting Sheets
+### 15.7 Working with Wiki Entity Pages
 
-Character and setting sheets are split across pointer JSON plus sibling markdown files. Edit the markdown bodies directly when you want to change sheet content:
+Characters and locations now live directly in the wiki. Edit the page markdown when you want to inspect or correct generated entity state:
 
 ```bash
-# Edit a character sheet body
-vim stories/my-story/characters/yuki-tanaka-oduya/sheet.md
+# Edit a character wiki page
+vim stories/my-story/wiki/characters/yuki-tanaka-oduya.md
 
-# Edit a setting sheet body
-vim stories/my-story/settings/europa-research-base/sheet.md
+# Edit a location wiki page
+vim stories/my-story/wiki/locations/europa-research-base.md
 ```
 
-Each entity still has a companion JSON file, but markdown-bearing fields now store `{"$ref": ...}` pointers to sibling `.md` files:
+Each page is a standalone markdown document with YAML frontmatter plus the L1/L2/L3 detail sections used by retrieval:
 
-```json
-{
-  "name": "Yuki Tanaka-Oduya",
-  "sheet": {"$ref": "characters/yuki-tanaka-oduya/sheet.md"},
-  "chunks": {
-    "backstory": {"$ref": "characters/yuki-tanaka-oduya/chunks/backstory.md"},
-    "personality": {"$ref": "characters/yuki-tanaka-oduya/chunks/personality.md"},
-    "motivation": {"$ref": "characters/yuki-tanaka-oduya/chunks/motivation.md"},
-    "relationships": {"$ref": "characters/yuki-tanaka-oduya/chunks/relationships.md"},
-    "skills": {"$ref": "characters/yuki-tanaka-oduya/chunks/skills.md"},
-    "arc": {"$ref": "characters/yuki-tanaka-oduya/chunks/arc.md"},
-    "current_state": {"$ref": "characters/yuki-tanaka-oduya/chunks/current_state.md"}
-  },
-  "abridged": {"$ref": "characters/yuki-tanaka-oduya/abridged.md"},
-  "summary": {"$ref": "characters/yuki-tanaka-oduya/summary.md"},
-  "updated_at": "2026-04-30T12:00:00Z"
-}
+```md
+---
+type: character
+slug: yuki-tanaka-oduya
+confidence: verified
+---
+
+# Yuki Tanaka-Oduya
+
+## Summary
+One-line or short paragraph summary.
+
+## Abridged
+Prompt-safe dossier content.
+
+## Background
+Full wiki body sections continue here.
 ```
 
-Setting sheets use the same top-level pointer shape but different chunk keys: `physical_description`, `atmosphere_mood`, `function_purpose`, `history_background`, `connections_relationships`, and `rules_constraints`.
-
-After manual edits, the next chapter generation will pick up the updated sheets automatically. Runtime reads now expect pointer objects for markdown-backed fields, and new writes always persist markdown into sibling `.md` files. If an older story still has inline markdown in JSON, run `python3 src/tools/migrate_inline_markdown.py --name <story>` before continuing. Chapter prompts prefer `abridged`, then `summary`, then the first 300 characters of `sheet` when building character and setting context.
+After manual edits, refresh the corresponding ChromaDB wiki collection before relying on semantic retrieval from that page. Runtime chapter prompts read wiki snapshots assembled from `wiki_snapshot.py`; there is no sheet fallback.
 
 ### 15.8 Common Daily Workflows
 

--- a/docs/planning/adr/004-progressive-wiki-memory-system.md
+++ b/docs/planning/adr/004-progressive-wiki-memory-system.md
@@ -6,6 +6,7 @@
 > Correction (2026-05-04): This ADR originally described per-scene wiki updates. The implemented system invokes `WikiMaintainerAgent` once per chapter with the full chapter draft content.
 
 Implementation completed via issue #344 and PR #345. The active Python orchestrator now boots the wiki from sheets plus outline data and pushes recap-derived event pages into the wiki during the chapter loop.
+Wiki source-of-truth consolidation (Tasks 0–11) completed via PRD [`docs/planning/wiki-source-of-truth-consolidation/prd.md`](../wiki-source-of-truth-consolidation/prd.md), fulfilling the unfulfilled Phase 7d/7e work described in the Consequences section.
 
 ## Context
 

--- a/docs/planning/adr/014-wiki-as-entity-source-of-truth.md
+++ b/docs/planning/adr/014-wiki-as-entity-source-of-truth.md
@@ -1,7 +1,7 @@
 # ADR 014: Wiki as Entity Source of Truth + Independent Recap Index
 
 **Date:** 2026-05-05
-**Status:** Proposed
+**Status:** Accepted
 
 ## Context
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,8 +42,7 @@ The orchestrator also now produces intermediate story artefacts directly in the 
 - `stories/<story>/outline/skeleton.md` plus `stories/<story>/outline/details/chapter_{N}.md` during Phase 3 when `generation.expand_outline` is enabled and the runtime stays on the per-chapter expansion path
 - `stories/<story>/outline/chunks/chunk_{start}_{end}.md`, `stories/<story>/outline/continuity/continuity_{start}_{end}.md`, and `stories/<story>/outline/enrichment.md` during Phase 3 when `generation.expand_outline`, `generation.use_chunked_outline_generation`, and `wanted_chapters > outline_chunk_size` select the chunked path
 - `stories/<story>/metadata.json` after each successful metadata checkpoint, with the latest generated title, summary, tags, and `updated_at`
-- `stories/<story>/characters/*.json` from the characters phase
-- `stories/<story>/settings/*.json` from the settings phase
+- `stories/<story>/wiki/characters/*.md` and `stories/<story>/wiki/locations/*.md` from the `wiki-generation` phase
 - `stories/<story>/chapters/chapter_{N}.md` during chapter approval
 - `stories/<story>/chapters/chapter_{N}_recap.json` after each approved chapter when recap generation returns non-empty events
 - `stories/<story>/output/story.md` during final assembly
@@ -87,8 +86,8 @@ The orchestrator also now produces intermediate story artefacts directly in the 
 | `src/tools/wiki_extract.py` | Run initial wiki population and post-chapter extraction, generate detail levels, and apply batch-ready wiki updates |
 | `src/tools/wiki_update.py` | Apply wiki page updates |
 | `src/tools/wiki_lint.py` | Validate wiki pages against formatting and consistency rules |
-| `src/tools/rag_query.py` | Index or query ChromaDB collections for story context; `index` accepts optional `--source-path` so source-backed entries record provenance metadata while synthetic entries use an empty source path |
-| `src/tools/rag_reconcile.py` | Reconcile per-story ChromaDB collections against on-disk markdown sources; supports `--dry-run`, `--all`, `--collection`, and `--json` flags; idempotent |
+| `src/tools/wiki_generation.py` | Generate initial wiki character and location pages directly from the approved outline; exposes `generate_character_pages(story_name, outline_result)` and `generate_location_pages(story_name, outline_result)` used by the `wiki-generation` orchestrator phase |
+| `src/tools/context_assembly.py` | Single entry point for wiki + recap context retrieval; `assemble_context(story_name, *, scope, focus, chapter, scene, pov_character, primary_location, characters, locations, keywords, recap_window, token_budget)` returns `{wiki_snapshot: str, recap_snippets: list[str]}`; used by all wiki/recap-aware agents |
 | `src/tools/migrate_inline_markdown.py` | One-shot migration tool that rewrites legacy inline-markdown story JSON into pointer-backed markdown files, including `outline_result.base_context` and `outline_result.story_elements`; supports `--name`, `--all`, and `--dry-run` |
 
 ### Shared Internal Helpers
@@ -118,17 +117,13 @@ Several runtime artefacts are written by the Python-native orchestrator and then
 | `stories/<story>/outline/enrichment.md` | `src/presentation/agents/outline_planner.py` after the final chunked window | Manual inspection, downstream enrichment review | Final enrichment suggestions from `outline/analyze_enrichment`; mirrored into `OutlineResult.enrichment_suggestions` |
 | `stories/<story>/outline/critic_summary.md` | `src/presentation/agents/outline_critic.py` when `generation.enable_outline_critique` is `true` | Manual inspection, debugging workflows | Concatenated summaries from the six outline-review critics. The separately synthesised arc summary is stored on `PipelineState.critic_summary` |
 | `stories/<story>/metadata.json` | `src/presentation/orchestrator.py` after `metadata-outline`, `metadata-chapter-1`, and `metadata-final` | Manual inspection, release metadata export, debugging workflows | JSON document with `title`, `summary`, `tags`, and `updated_at`. The orchestrator also mirrors `title` and `tags` into `PipelineState.outline_result`, but the summary lives on disk only |
-| `stories/<story>/characters/<slug>.json` | `src/presentation/orchestrator.py` characters phase | `src/presentation/agents/chapter_writer.py`, wiki-bootstrap workflows, character-management workflows | JSON document with `name`, pointer refs for `sheet`, `chunks`, `abridged`, and `summary`, plus `updated_at`. Bodies live under `stories/<story>/characters/<slug>/` as sibling `.md` files such as `sheet.md`, `summary.md`, `abridged.md`, and `chunks/<key>.md` |
-| `stories/<story>/settings/<slug>.json` | `src/presentation/orchestrator.py` settings phase | `src/presentation/agents/chapter_writer.py`, wiki-bootstrap workflows, setting-management workflows | Same pointer-based shape as character sheets, with markdown bodies under `stories/<story>/settings/<slug>/` |
 | `stories/<story>/chapters/chapter_{N}.md` | `src/presentation/orchestrator.py` chapter loop | `src/tools/story_assembler.py`, downstream review flows | Approved chapter manuscript |
 | `stories/<story>/chapters/chapter_{N}_recap.json` | `src/presentation/orchestrator.py` after `src/presentation/agents/recap_writer.py` returns a recap result | later chapter-loop continuity context, manual inspection, debugging workflows | JSON document with `events`, `compact`, and `sanitised` fields; the same object is also stored in `PipelineState.recaps[str(N)]` |
 | `stories/<story>/output/story.md` | `src/presentation/orchestrator.py` assembly phase | Manual export and downstream editing | Concatenated final manuscript |
 
-Characters and settings files are generated from prompt templates in `prompts/characters/` and `prompts/settings/`. The JSON files now keep only structured metadata plus `{"$ref": ...}` pointers for `sheet`, `chunks`, `summary`, and `abridged`; the markdown bodies live in sibling `.md` files under each entity slug directory. Filenames are slugified from the extracted entity names, and writes are atomic so later phases never read a half-written JSON file.
+`ChapterWriterAgent` builds chapter- and scene-specific wiki snapshots via `src/tools/wiki_snapshot.py`. Wiki snapshot absence raises `StoryGenerationError` — there is no sheet fallback. The `wiki-generation` phase ensures all outline characters and locations have wiki pages before the chapter loop begins.
 
-`ChapterWriterAgent` now treats those sheet directories as fallback context only. It first attempts to build a chapter- or scene-specific wiki snapshot via `src/tools/wiki_snapshot.py`; only when no snapshot is available does it read `characters/*.json` and `settings/*.json`. In that fallback path it prefers each sheet's stored `abridged` text, then falls back to `summary`, then falls back to the first 300 characters of the `sheet` body. Missing directories, malformed JSON files, or individual read failures are skipped instead of aborting chapter generation.
-
-`src/tools/wiki_extract.py` now exposes four programmatic entry points used by the runtime. `_list_wiki_entities(story_name, *, model=None)` performs entity extraction plus deduplication only, always reading `characters/*.json` and `settings/*.json` first and adding outline-derived entities only when the saved outline text is non-empty. `_bootstrap_single_wiki_entity(story_name, entity, *, model=None, wiki_dir=None)` generates detail levels and writes one missing wiki page. `bootstrap_wiki_from_story(story_name, *, model=None)` still supports the full one-shot bootstrap for CLI or ad-hoc use by seeding the wiki from the same sheet-first input set, deduplicating extracted entities, skipping already-existing slugs for idempotent upsert behavior, applying the batch through `run_batch()`, and returning `{created, skipped, entity_counts}`. `update_wiki_from_chapter(story_name, chapter_number, chapter_text, *, model=None)` handles the later incremental chapter updates.
+`src/tools/wiki_extract.py` now exposes four programmatic entry points used by the runtime. `_list_wiki_entities(story_name, *, model=None)` performs entity extraction plus deduplication from the outline, extracting non-character/non-location entity types such as factions, items, and plot threads not already covered by the `wiki-generation` phase. `_bootstrap_single_wiki_entity(story_name, entity, *, model=None, wiki_dir=None)` generates detail levels and writes one missing wiki page. `bootstrap_wiki_from_story(story_name, *, model=None)` still supports the full one-shot bootstrap for CLI or ad-hoc use by seeding the wiki from the same outline-derived input set, deduplicating extracted entities, skipping already-existing slugs for idempotent upsert behavior, applying the batch through `run_batch()`, and returning `{created, skipped, entity_counts}`. `update_wiki_from_chapter(story_name, chapter_number, chapter_text, *, model=None)` handles the later incremental chapter updates.
 
 `WikiMaintainerAgent` now uses `src/tools/wiki_extract.py` directly for post-chapter updates. The programmatic `update_wiki_from_chapter(story_name, chapter_number, chapter_text, *, model=None)` entry point runs the `wiki/extract_from_chapter` prompt, matches existing entities from the wiki index, generates detail levels for newly created pages, applies the batch through `run_batch()`, and returns both summary counts and the concrete created or updated slug lists. That keeps wiki persistence inside one Python boundary and gives the orchestrator a typed result instead of free-form model text.
 
@@ -163,12 +158,9 @@ Individual tools still expose argparse-based interfaces for shell use. Example:
 ```bash
 python -m src.tools.story_state --operation list
 python -m src.tools.wiki_search --story test_story --query "chapter summary"
-python -m src.tools.rag_query --operation index --name test_story --doc-id chapter-1 --content-type chapter --source-path stories/test_story/chapters/chapter_1.md
 ```
 
 The exact arguments differ per tool module. Read the module's `cmd_*` function or argparse setup before documenting or scripting against its JSON output.
-
-`src/tools/rag_query.py` currently exposes two operations: `index` and `query`. For `index`, pass either `--content` for synthetic content or `--source-path` for markdown-backed content. When `--source-path` is present, the helper records `source_path`, `source_mtime`, and `source_sha256` in Chroma metadata; when omitted, the upsert is treated as synthetic and stores an empty `source_path`.
 
 ## Adding Or Updating A Tool
 


### PR DESCRIPTION
## Summary

Refreshes all documentation to reflect the new architecture after Tasks 0–11 of the Wiki Source-of-Truth Consolidation are merged. No production code changes.

## Closes
Closes #362

## Changes

- **ADR 004** — adds Phase 7d/7e completion pointer linking to the PRD
- **ADR 014** — flips status from `Proposed` to `Accepted`
- **`docs/manual.md`** — replaces `Characters & Settings` phase with `Wiki Generation`; updates pipeline sequence text, ASCII flow diagram, expected file tree (removes `characters/` and `settings/` story subdirectories), phase descriptions, wiki-bootstrap description (removes sheet-source references), and chapter-loop description (removes sheet fallback; wiki absence now raises `StoryGenerationError`)
- **`docs/tools.md`** — removes `rag_query.py` and `rag_reconcile.py` (deleted in Task 11); adds `wiki_generation.py` and `context_assembly.py`; removes sheet artefact rows and rag CLI examples; updates runtime descriptions
- **`.github/copilot-instructions.md`** — adds ADR 014 architecture bullet; updates ChromaDB collections note to `wiki-{story}` + `recaps-{story}`
- **`.github/notes/audits/2026-05-05-wiki-consolidation-status.md`** — replaces `Recommended Actions` section with Tasks 0–11 resolution table

## Checklist
- [x] All referenced docs updated
- [x] ADR 004 body has the Phase 7e pointer
- [x] ADR 014 status flipped to `Accepted`
- [x] `docs/manual.md` and `docs/tools.md` do not reference sheet generators or the `stories-{story}` collection
- [x] `.github/copilot-instructions.md` does not reference retired tooling
- [x] Linting clean (`ruff check` + `ruff format --check` pass)

## Plan

**Affected Areas:** Documentation only — no Python source changes

**Task Checklist:**
- [x] ADR 004: add Phase 7e completion pointer
- [x] ADR 014: flip status to Accepted
- [x] docs/manual.md: replace Characters & Settings with Wiki Generation phase throughout
- [x] docs/tools.md: remove retired tools, add new tools
- [x] .github/copilot-instructions.md: update Architecture section
- [x] audit file: replace recommendations with resolution table