### PR TITLE
feat(agents): add wiki + recap context to story planner, quality reviewer, and chapter outline expander

### DIFF
--- a/prompts/chapter_review/chapter-character-consistency.md
+++ b/prompts/chapter_review/chapter-character-consistency.md
@@ -6,6 +6,14 @@ Please critique the following chapter, providing both detailed feedback and a nu
 {outline}
 </OUTLINE>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 As a character consistency specialist, evaluate the chapter based on these criteria:
     - Pacing (15 points): Do character reactions, decisions, and emotional shifts unfold at a believable pace within the chapter?
     - Details (15 points): Do dialogue, interiority, and behavioural details reinforce distinct character voice and established traits?

--- a/prompts/chapter_review/chapter-pacing.md
+++ b/prompts/chapter_review/chapter-pacing.md
@@ -6,6 +6,14 @@ Please critique the following chapter, providing both detailed feedback and a nu
 {outline}
 </OUTLINE>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 As a chapter pacing specialist, evaluate the chapter based on these criteria:
     - Pacing (15 points): Does each scene arrive at the right speed? Are buildup, conflict, and release distributed effectively across the chapter?
     - Details (15 points): Do descriptive and reflective passages support pacing rather than stall it? Are slower beats purposeful?

--- a/prompts/chapter_review/character-voice-consistency.md
+++ b/prompts/chapter_review/character-voice-consistency.md
@@ -8,6 +8,14 @@ Please critique the following chapter, providing both detailed feedback and a nu
 {outline}
 </OUTLINE>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 As a character voice consistency specialist, evaluate the chapter based on these criteria:
     - Pacing (15 points): Does each character's dialogue, interiority, and reaction pace feel consistent with how they have spoken and reacted in prior chapters?
     - Details (15 points): Do vocabulary choices, sentence rhythms, and idiosyncratic speech patterns match the established voice samples for each character?

--- a/prompts/chapter_review/commercial-fiction-editor.md
+++ b/prompts/chapter_review/commercial-fiction-editor.md
@@ -6,6 +6,14 @@ Please critique the following chapter, providing both detailed feedback and a nu
 {outline}
 </OUTLINE>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 As a commercial fiction editor, evaluate the chapter based on these criteria:
     - Pacing (15 points): Does the prose-level pacing keep readers turning pages scene by scene? Are hooks, momentum, and reveals timed effectively within the chapter?
     - Details (15 points): Are descriptive details vivid, clear, and commercially appealing without bogging down the prose?

--- a/prompts/outline/arc_assessment_direct.md
+++ b/prompts/outline/arc_assessment_direct.md
@@ -20,6 +20,14 @@ You are a senior story editor assessing the dramatic arc of a completed story ou
 {promise_payoff}
 </PROMISE_PAYOFF>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 ## ASSESSMENT CRITERIA
 Evaluate the outline across these dimensions:
 

--- a/prompts/outline/expand_chapter_detail.md
+++ b/prompts/outline/expand_chapter_detail.md
@@ -10,6 +10,14 @@ You are a literary fiction outline specialist. Your task is to take a single cha
 {base_context}
 </BASE_CONTEXT>
 
+<WIKI_CONTEXT>
+{wiki_context}
+</WIKI_CONTEXT>
+
+<RECAP_CONTEXT>
+{recap_context}
+</RECAP_CONTEXT>
+
 <APPROVED_OUTLINE>
 {previous_chunks}
 </APPROVED_OUTLINE>

--- a/src/presentation/agents/chapter_outline_expander.py
+++ b/src/presentation/agents/chapter_outline_expander.py
@@ -1,0 +1,120 @@
+"""Chapter Outline Expander agent - expands a skeleton chapter into a detailed outline."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, cast
+
+from application.interfaces.model_provider import ModelProvider
+from domain.value_objects.model_config import ModelConfig
+from infrastructure.prompts.prompt_loader import PromptLoader
+from presentation.pipeline_primitives import (
+    TokenStreamBus,
+    WikiContextBus,
+    WikiContextEvent,
+)
+from tools.context_assembly import assemble_context
+
+
+def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
+    models = config.get("models", {})
+    model_name = models.get(role, default)
+    return ModelConfig.from_string(model_name)
+
+
+class ChapterOutlineExpanderAgent:
+    def __init__(
+        self,
+        provider: ModelProvider,
+        config: dict[str, Any],
+        bus: TokenStreamBus,
+        wiki_bus: WikiContextBus,
+    ) -> None:
+        self.provider = provider
+        self.config = config
+        self.bus = bus
+        self.wiki_bus = wiki_bus
+        self._loader = PromptLoader(prompts_dir="prompts")
+
+    async def run(
+        self,
+        story_name: str,
+        chapter_number: int,
+        chapter_outline: str,
+        story_elements: str = "",
+        previous_chunks: str = "",
+        continuity_summary: str = "",
+        total_chapters: int = 0,
+        protagonist: str | None = None,
+    ) -> str:
+        """Expand a skeleton chapter outline into a detailed chapter outline.
+
+        Returns the expanded detail text as a string.
+        """
+        await self.wiki_bus.emit(
+            WikiContextEvent(
+                phase="outline-expansion",
+                event_type="entity_match",
+                content=f"Expanding chapter {chapter_number} outline",
+            )
+        )
+
+        try:
+            ctx = assemble_context(
+                story_name,
+                scope="outline",
+                focus=chapter_outline[:500],
+                chapter=chapter_number,
+                pov_character=protagonist,
+                recap_window=("character", 3),
+            )
+            wiki_context: str = ctx["wiki_snapshot"]
+            recap_context: str = "\n\n".join(ctx["recap_snippets"])
+        except Exception as exc:  # noqa: BLE001
+            await self.wiki_bus.emit(
+                WikiContextEvent(
+                    phase="outline-expansion",
+                    event_type="retrieval_error",
+                    content=f"Context retrieval failed: {exc}",
+                )
+            )
+            wiki_context = ""
+            recap_context = ""
+
+        loader = self._loader
+        system_prompt = loader.load_prompt(
+            "outline/expand_chapter_detail",
+            variables={
+                "story_elements": story_elements,
+                "base_context": "",
+                "previous_chunks": previous_chunks,
+                "continuity_summary": continuity_summary,
+                "chunk_start": str(chapter_number),
+                "total_chapters": str(total_chapters or chapter_number),
+                "wiki_context": wiki_context,
+                "recap_context": recap_context,
+            },
+        )
+
+        model_config = _build_model_config(
+            self.config,
+            "initial_outline_writer",
+            "openai-compat://default",
+        )
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": f"Please expand chapter {chapter_number}.",
+            },
+        ]
+
+        full_text = ""
+        stream = cast(
+            AsyncIterator[str],
+            self.provider.stream_text(messages, model_config),
+        )
+        async for token in stream:
+            await self.bus.emit(token)
+            full_text += token
+
+        return full_text

--- a/src/presentation/agents/quality_reviewer.py
+++ b/src/presentation/agents/quality_reviewer.py
@@ -1,0 +1,128 @@
+"""Quality Reviewer agent - runs multi-perspective chapter critiques."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, cast
+
+from application.interfaces.model_provider import ModelProvider
+from application.pipeline.handoffs import OutlineResult
+from domain.value_objects.model_config import ModelConfig
+from infrastructure.prompts.prompt_loader import PromptLoader
+from presentation.pipeline_primitives import (
+    TokenStreamBus,
+    WikiContextBus,
+    WikiContextEvent,
+)
+from tools.context_assembly import assemble_context
+
+
+_CRITIQUE_PROMPTS: list[tuple[str, str]] = [
+    ("commercial-fiction-editor", "chapter_review/commercial-fiction-editor"),
+    ("chapter-pacing", "chapter_review/chapter-pacing"),
+    (
+        "chapter-character-consistency",
+        "chapter_review/chapter-character-consistency",
+    ),
+    (
+        "character-voice-consistency",
+        "chapter_review/character-voice-consistency",
+    ),
+]
+
+
+def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
+    models = config.get("models", {})
+    model_name = models.get(role, default)
+    return ModelConfig.from_string(model_name)
+
+
+class QualityReviewerAgent:
+    def __init__(
+        self,
+        provider: ModelProvider,
+        config: dict[str, Any],
+        bus: TokenStreamBus,
+        wiki_bus: WikiContextBus,
+    ) -> None:
+        self.provider = provider
+        self.config = config
+        self.bus = bus
+        self.wiki_bus = wiki_bus
+        self._loader = PromptLoader(prompts_dir="prompts")
+
+    async def run(
+        self,
+        story_name: str,
+        chapter_number: int,
+        chapter_content: str,
+        outline_result: OutlineResult | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run multi-perspective quality review for a chapter.
+
+        Returns a list of critique dicts, one per perspective.
+        """
+        _ = outline_result
+
+        await self.wiki_bus.emit(
+            WikiContextEvent(
+                phase="quality-review",
+                event_type="detail_level",
+                content=f"Running quality review for chapter {chapter_number}",
+            )
+        )
+
+        try:
+            ctx = assemble_context(
+                story_name,
+                scope="consistency",
+                focus=chapter_content[:500],
+                chapter=chapter_number,
+                recap_window=("chapter", 3),
+            )
+            wiki_context: str = ctx["wiki_snapshot"]
+            recap_context: str = "\n\n".join(ctx["recap_snippets"])
+        except Exception as exc:  # noqa: BLE001
+            await self.wiki_bus.emit(
+                WikiContextEvent(
+                    phase="quality-review",
+                    event_type="retrieval_error",
+                    content=f"Context retrieval failed: {exc}",
+                )
+            )
+            wiki_context = ""
+            recap_context = ""
+
+        model_config = _build_model_config(
+            self.config,
+            "checker_model",
+            "openai-compat://default",
+        )
+        loader = self._loader
+        results: list[dict[str, Any]] = []
+
+        for critique_type, prompt_key in _CRITIQUE_PROMPTS:
+            system_prompt = loader.load_prompt(
+                prompt_key,
+                variables={
+                    "outline": chapter_content,
+                    "wiki_context": wiki_context,
+                    "recap_context": recap_context,
+                },
+            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": "Please provide your critique."},
+            ]
+
+            full_text = ""
+            stream = cast(
+                AsyncIterator[str],
+                self.provider.stream_text(messages, model_config),
+            )
+            async for token in stream:
+                await self.bus.emit(token)
+                full_text += token
+
+            results.append({"critique_type": critique_type, "text": full_text})
+
+        return results

--- a/src/presentation/agents/story_planner.py
+++ b/src/presentation/agents/story_planner.py
@@ -8,8 +8,6 @@ from typing import Any, AsyncIterator, cast
 
 from application.interfaces.model_provider import ModelProvider
 from application.pipeline.handoffs import ArcAnalysisResult, PipelineState
-from tools._io import STORIES_DIR
-from tools._persist import read_markdown_ref
 from domain.value_objects.generation_settings import GenerationSettings
 from domain.value_objects.model_config import ModelConfig
 from infrastructure.prompts.prompt_loader import PromptLoader
@@ -18,6 +16,9 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from tools._io import STORIES_DIR
+from tools._persist import read_markdown_ref
+from tools.context_assembly import assemble_context
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -89,6 +90,30 @@ class StoryPlannerAgent:
                 outline_result.chapter_outlines, ensure_ascii=False, indent=2
             )
 
+        if state.approved_chapters:
+            try:
+                ctx = assemble_context(
+                    state.story_name,
+                    scope="outline",
+                    focus=outline_text[:800],
+                    recap_window=("chapter", 5),
+                )
+                wiki_context: str = ctx["wiki_snapshot"]
+                recap_context: str = "\n\n".join(ctx["recap_snippets"])
+            except Exception as exc:  # noqa: BLE001
+                await self.wiki_bus.emit(
+                    WikiContextEvent(
+                        phase="narrative-arc",
+                        event_type="retrieval_error",
+                        content=f"Context retrieval failed: {exc}",
+                    )
+                )
+                wiki_context = ""
+                recap_context = ""
+        else:
+            wiki_context = ""
+            recap_context = ""
+
         loader = self._loader
         system_prompt = loader.load_prompt(
             "outline/arc_assessment_direct",
@@ -97,6 +122,8 @@ class StoryPlannerAgent:
                 "critic_summary": state.critic_summary,
                 "arc_distribution": state.arc_distribution,
                 "promise_payoff": state.promise_payoff,
+                "wiki_context": wiki_context,
+                "recap_context": recap_context,
             },
         )
 

--- a/tests/unit/test_chapter_outline_expander.py
+++ b/tests/unit/test_chapter_outline_expander.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from presentation.agents.chapter_outline_expander import ChapterOutlineExpanderAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+async def _stream_tokens(tokens: list[str]):
+    for token in tokens:
+        yield token
+
+
+class _ProviderStub:
+    def __init__(self, tokens: list[str] | None = None) -> None:
+        self.tokens = tokens or ["expanded ", "outline"]
+
+    def stream_text(self, messages, model_config, seed=None):
+        return _stream_tokens(self.tokens)
+
+
+@pytest.mark.asyncio
+async def test_run_calls_assemble_context_with_outline_scope() -> None:
+    chapter_outline = "B" * 900
+    agent = ChapterOutlineExpanderAgent(
+        _ProviderStub(), {}, TokenStreamBus(), WikiContextBus()
+    )
+
+    with (
+        patch(
+            "presentation.agents.chapter_outline_expander.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": ["recap"]},
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="mocked prompt",
+        ),
+    ):
+        await agent.run(
+            "test-story",
+            3,
+            chapter_outline,
+            protagonist="Mira",
+        )
+
+    mock_assemble_context.assert_called_once_with(
+        "test-story",
+        scope="outline",
+        focus=chapter_outline[:500],
+        chapter=3,
+        pov_character="Mira",
+        recap_window=("character", 3),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_passes_wiki_and_recap_to_prompt() -> None:
+    agent = ChapterOutlineExpanderAgent(
+        _ProviderStub(), {}, TokenStreamBus(), WikiContextBus()
+    )
+    captured: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured.update(variables)
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.chapter_outline_expander.assemble_context",
+            return_value={
+                "wiki_snapshot": "wiki snapshot",
+                "recap_snippets": ["recap one", "recap two"],
+            },
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run("test-story", 3, "chapter outline")
+
+    assert captured["wiki_context"] == "wiki snapshot"
+    assert captured["recap_context"] == "recap one\n\nrecap two"
+
+
+@pytest.mark.asyncio
+async def test_run_returns_expanded_text() -> None:
+    agent = ChapterOutlineExpanderAgent(
+        _ProviderStub(["expanded ", "outline"]),
+        {},
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with (
+        patch(
+            "presentation.agents.chapter_outline_expander.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": []},
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="mocked prompt",
+        ),
+    ):
+        result = await agent.run("test-story", 3, "chapter outline")
+
+    assert isinstance(result, str)
+    assert result == "expanded outline"
+
+
+@pytest.mark.asyncio
+async def test_run_degrades_gracefully_when_assemble_context_raises() -> None:
+    agent = ChapterOutlineExpanderAgent(
+        _ProviderStub(["expanded outline"]),
+        {},
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+    captured: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured.update(variables)
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.chapter_outline_expander.assemble_context",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        result = await agent.run("test-story", 3, "chapter outline")
+
+    assert captured["wiki_context"] == ""
+    assert captured["recap_context"] == ""
+    assert isinstance(result, str)
+    assert result == "expanded outline"

--- a/tests/unit/test_quality_reviewer.py
+++ b/tests/unit/test_quality_reviewer.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from presentation.agents.quality_reviewer import QualityReviewerAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+async def _stream_tokens(tokens: list[str]):
+    for token in tokens:
+        yield token
+
+
+class _ProviderStub:
+    def __init__(self, tokens: list[str] | None = None) -> None:
+        self.tokens = tokens or ["critique"]
+
+    def stream_text(self, messages, model_config, seed=None):
+        return _stream_tokens(self.tokens)
+
+
+@pytest.mark.asyncio
+async def test_run_calls_assemble_context_with_consistency_scope() -> None:
+    chapter_content = "A" * 800
+    agent = QualityReviewerAgent(
+        _ProviderStub(), {}, TokenStreamBus(), WikiContextBus()
+    )
+
+    with (
+        patch(
+            "presentation.agents.quality_reviewer.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": ["recap"]},
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="mocked prompt",
+        ),
+    ):
+        await agent.run("test-story", 7, chapter_content)
+
+    mock_assemble_context.assert_called_once_with(
+        "test-story",
+        scope="consistency",
+        focus=chapter_content[:500],
+        chapter=7,
+        recap_window=("chapter", 3),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_passes_wiki_and_recap_to_prompts() -> None:
+    agent = QualityReviewerAgent(
+        _ProviderStub(), {}, TokenStreamBus(), WikiContextBus()
+    )
+    captured_variables: list[dict[str, str]] = []
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured_variables.append(dict(variables))
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.quality_reviewer.assemble_context",
+            return_value={
+                "wiki_snapshot": "wiki snapshot",
+                "recap_snippets": ["recap one", "recap two"],
+            },
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run("test-story", 2, "chapter content")
+
+    assert len(captured_variables) == 4
+    assert all(item["wiki_context"] == "wiki snapshot" for item in captured_variables)
+    assert all(
+        item["recap_context"] == "recap one\n\nrecap two" for item in captured_variables
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_returns_list_of_critiques() -> None:
+    agent = QualityReviewerAgent(
+        _ProviderStub(["review text"]), {}, TokenStreamBus(), WikiContextBus()
+    )
+
+    with (
+        patch(
+            "presentation.agents.quality_reviewer.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": []},
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="mocked prompt",
+        ),
+    ):
+        result = await agent.run("test-story", 2, "chapter content")
+
+    assert len(result) == 4
+    assert all("critique_type" in item for item in result)
+    assert all("text" in item for item in result)
+
+
+@pytest.mark.asyncio
+async def test_run_degrades_gracefully_when_assemble_context_raises() -> None:
+    agent = QualityReviewerAgent(
+        _ProviderStub(["review text"]), {}, TokenStreamBus(), WikiContextBus()
+    )
+    captured_variables: list[dict[str, str]] = []
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured_variables.append(dict(variables))
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.quality_reviewer.assemble_context",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        result = await agent.run("test-story", 2, "chapter content")
+
+    assert len(result) == 4
+    assert all(item["wiki_context"] == "" for item in captured_variables)
+    assert all(item["recap_context"] == "" for item in captured_variables)

--- a/tests/unit/test_story_planner_wiki.py
+++ b/tests/unit/test_story_planner_wiki.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import ChapterDraft, OutlineResult, PipelineState
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.story_planner import StoryPlannerAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+async def _stream_tokens(tokens: list[str]):
+    for token in tokens:
+        yield token
+
+
+class _ProviderStub:
+    def __init__(self, tokens: list[str] | None = None) -> None:
+        self.tokens = tokens or ["arc ", "assessment"]
+
+    def stream_text(self, messages, model_config, seed=None):
+        return _stream_tokens(self.tokens)
+
+
+def _make_state(*, approved_chapters: list[ChapterDraft]) -> PipelineState:
+    return PipelineState(
+        story_name="test-story",
+        current_phase="arc",
+        outline_result=OutlineResult(
+            story_name="test-story",
+            chapter_outlines=[{"chapter_number": 1, "title": "Ch 1", "summary": "..."}],
+            summary="outline text",
+            genre="fiction",
+            themes=[],
+            base_context="",
+            story_elements="",
+        ),
+        approved_chapters=approved_chapters,
+        critic_summary="critic summary",
+        arc_distribution="arc distribution",
+        promise_payoff="promise payoff",
+    )
+
+
+def _approved_chapter() -> ChapterDraft:
+    return ChapterDraft(
+        story_name="test-story",
+        chapter_number=1,
+        title="Chapter 1",
+        content="approved content",
+        word_count=1000,
+    )
+
+
+def _outline_text(state: PipelineState) -> str:
+    outline = state.outline_result
+    assert outline is not None
+    text = outline.summary if isinstance(outline.summary, str) else ""
+    if outline.chapter_outlines:
+        text += "\n\n" + json.dumps(
+            outline.chapter_outlines, ensure_ascii=False, indent=2
+        )
+    return text
+
+
+@pytest.mark.asyncio
+async def test_run_calls_assemble_context_on_continuation_run() -> None:
+    state = _make_state(approved_chapters=[_approved_chapter()])
+    agent = StoryPlannerAgent(_ProviderStub(), {}, TokenStreamBus(), WikiContextBus())
+
+    with (
+        patch(
+            "presentation.agents.story_planner.assemble_context",
+            return_value={"wiki_snapshot": "wiki", "recap_snippets": ["recap"]},
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            return_value="mocked prompt",
+        ),
+    ):
+        await agent.run(state, GenerationSettings())
+
+    mock_assemble_context.assert_called_once_with(
+        state.story_name,
+        scope="outline",
+        focus=_outline_text(state)[:800],
+        recap_window=("chapter", 5),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_skips_assemble_context_on_initial_run() -> None:
+    state = _make_state(approved_chapters=[])
+    agent = StoryPlannerAgent(_ProviderStub(), {}, TokenStreamBus(), WikiContextBus())
+    captured: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured.update(variables)
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.story_planner.assemble_context"
+        ) as mock_assemble_context,
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run(state, GenerationSettings())
+
+    mock_assemble_context.assert_not_called()
+    assert captured["wiki_context"] == ""
+    assert captured["recap_context"] == ""
+
+
+@pytest.mark.asyncio
+async def test_run_passes_wiki_and_recap_to_prompt_on_continuation() -> None:
+    state = _make_state(approved_chapters=[_approved_chapter()])
+    agent = StoryPlannerAgent(_ProviderStub(), {}, TokenStreamBus(), WikiContextBus())
+    captured: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured.update(variables)
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.story_planner.assemble_context",
+            return_value={
+                "wiki_snapshot": "wiki snapshot",
+                "recap_snippets": ["recap one", "recap two"],
+            },
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.run(state, GenerationSettings())
+
+    assert captured["wiki_context"] == "wiki snapshot"
+    assert captured["recap_context"] == "recap one\n\nrecap two"
+
+
+@pytest.mark.asyncio
+async def test_run_degrades_gracefully_when_assemble_context_raises() -> None:
+    state = _make_state(approved_chapters=[_approved_chapter()])
+    agent = StoryPlannerAgent(
+        _ProviderStub(["strong verdict"]), {}, TokenStreamBus(), WikiContextBus()
+    )
+    captured: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        assert variables is not None
+        captured.update(variables)
+        return "mocked prompt"
+
+    with (
+        patch(
+            "presentation.agents.story_planner.assemble_context",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        result = await agent.run(state, GenerationSettings())
+
+    assert captured["wiki_context"] == ""
+    assert captured["recap_context"] == ""
+    assert result.story_name == state.story_name
+    assert result.arc_assessment == "strong verdict"


### PR DESCRIPTION
## Summary

Implements wiki and recap context injection for three pipeline agents identified in the wiki-context-consumers planning documents as not covered by Tasks 8–10.

- **Story Planner**: continuation runs call `assemble_context(scope="outline", recap_window=("chapter", 5))`; initial runs use empty strings. `{wiki_context}` and `{recap_context}` injected into `arc_assessment_direct.md`.
- **Quality Reviewer** (new agent): calls `assemble_context(scope="consistency", recap_window=("chapter", 3))`, loops over 4 chapter-review critique prompts, returns list of critiques.
- **Chapter Outline Expander** (new agent): calls `assemble_context(scope="outline", pov_character=protagonist, recap_window=("character", 3))`, uses `expand_chapter_detail.md`.
- All three degrade gracefully (empty string substitution + wiki bus warning) when ChromaDB index is empty or retrieval fails.

## Closes
Closes #363

## Changes
- [x] `src/presentation/agents/story_planner.py` — add assemble_context, wiki_context, recap_context
- [x] `src/presentation/agents/quality_reviewer.py` — new agent
- [x] `src/presentation/agents/chapter_outline_expander.py` — new agent
- [x] `prompts/outline/arc_assessment_direct.md` — add {wiki_context}, {recap_context}
- [x] `prompts/outline/expand_chapter_detail.md` — add {wiki_context}, {recap_context}
- [x] `prompts/chapter_review/*.md` (4 files) — add {wiki_context}, {recap_context}
- [x] `tests/unit/test_story_planner_wiki.py` — 4 tests
- [x] `tests/unit/test_quality_reviewer.py` — 4 tests
- [x] `tests/unit/test_chapter_outline_expander.py` — 4 tests
- [x] All 12 tests passing
- [x] Linting clean (ruff + mypy)