### PR TITLE
feat(context): prose scrubber character aliases + wiki event recap context

### DIFF
--- a/prompts/final_edit/prose_scrub.md
+++ b/prompts/final_edit/prose_scrub.md
@@ -3,6 +3,9 @@ Analyze Chapter {chapter_number} for sentence-level and paragraph-level prose pr
 Chapter text:
 {chapter_text}
 
+Character names and aliases in this chapter (do not "correct" these back to a different form):
+{character_aliases}
+
 Targets:
 - Adverb overuse, especially common offenders such as quickly, suddenly, softly, quietly, sharply, immediately, slowly, carefully, finally, and heavily.
 - Filter words and phrases such as "he saw that", "she felt that", "she noticed that", "he heard", "she watched", and similar distancing constructions.

--- a/prompts/wiki/extract_events_from_chapter.md
+++ b/prompts/wiki/extract_events_from_chapter.md
@@ -10,6 +10,10 @@ You are extracting events from a completed chapter.
 {chapter_text}
 </CHAPTER_TEXT>
 
+<PRIOR_CHAPTER_CONTEXT>
+{prior_recap_context}
+</PRIOR_CHAPTER_CONTEXT>
+
 ## Task
 
 Return a JSON array of candidate event page objects extracted from the chapter.
@@ -40,6 +44,7 @@ Return a JSON array of candidate event page objects extracted from the chapter.
 - Use `verified` confidence only. This operates on completed chapter text.
 - Do not invent facts not stated in the chapter.
 - Do not create duplicates of entries already listed in `existing_pages_index`.
+- Use `prior_recap_context` to distinguish a "continuation of prior event" from a genuinely new event. If the context is empty, treat all extracted events as potentially new.
 - Keep descriptions concise, factual, and grounded in what the chapter states.
 - Set `frontmatter.event_type` only from explicit chapter evidence. If not explicit, use an empty string.
 - Set `frontmatter.status` only from explicit chapter evidence. If not explicit, use `completed`.

--- a/src/presentation/agents/final_editor.py
+++ b/src/presentation/agents/final_editor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, AsyncIterator, cast
 
 from application.interfaces.model_provider import ModelProvider
@@ -15,6 +16,8 @@ from presentation.pipeline_primitives import (
     WikiContextEvent,
 )
 from tools.context_assembly import assemble_context
+from tools._io import _validate_story_name
+from tools._wiki import get_wiki_dir, match_entities_in_text, read_index
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -85,11 +88,60 @@ class FinalEditorAgent:
         )
 
         if settings.enable_scrubbing:
+            character_aliases = ""
+            try:
+                _story_dir: Path = _validate_story_name(draft.story_name)
+                _wiki_dir = get_wiki_dir(_story_dir)
+                if _wiki_dir.exists():
+                    _index_entries = read_index(_wiki_dir)
+                    _char_entries = [
+                        entry
+                        for entry in _index_entries
+                        if entry.get("type") == "character"
+                    ]
+                    _matches = match_entities_in_text(draft.content, _char_entries)
+                    _matched_slugs = {match.get("slug") for match in _matches}
+                    _alias_lines: list[str] = []
+                    for _entry in _char_entries:
+                        if _entry.get("slug") not in _matched_slugs:
+                            continue
+                        _name = _entry.get("name", "")
+                        _aliases = [
+                            alias
+                            for alias in _entry.get("aliases", [])
+                            if isinstance(alias, str) and alias.strip()
+                        ]
+                        if _aliases:
+                            _alias_lines.append(
+                                f"{_name} (aliases: {', '.join(_aliases)})"
+                            )
+                        elif _name:
+                            _alias_lines.append(_name)
+                    character_aliases = "\n".join(_alias_lines)
+                else:
+                    await self.wiki_bus.emit(
+                        WikiContextEvent(
+                            phase="final-edit",
+                            event_type="warning",
+                            content="character alias lookup skipped: wiki unavailable",
+                        )
+                    )
+            except Exception as _alias_exc:
+                await self.wiki_bus.emit(
+                    WikiContextEvent(
+                        phase="final-edit",
+                        event_type="error",
+                        content=f"character alias lookup failed: {_alias_exc}",
+                    )
+                )
+                character_aliases = ""
+
             prose_prompt = self._loader.load_prompt(
                 "final_edit/prose_scrub",
                 variables={
                     "chapter_text": draft.content,
                     "chapter_number": str(chapter_number),
+                    "character_aliases": character_aliases,
                 },
             )
             messages = [

--- a/src/tools/_wiki_api.py
+++ b/src/tools/_wiki_api.py
@@ -21,6 +21,7 @@ from tools._wiki import (
     slugify,
     write_index,
 )
+from tools.recap_index import query_recap
 from tools.wiki_update import run_batch
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -309,6 +310,7 @@ def _extract_type_candidates(
     *,
     model: str | None = None,
     base_url: str | None = None,
+    prior_recap_context: str = "",
 ) -> list[dict[str, Any]]:
     _ = story_name
     prompt_suffix = _TYPE_TO_PROMPT.get(page_type)
@@ -318,16 +320,19 @@ def _extract_type_candidates(
     filtered_entries = [
         entry for entry in index_entries if entry.get("type") == page_type
     ]
+    prompt_vars: dict[str, Any] = {
+        "chapter_text": chapter_text,
+        "existing_pages_index": json.dumps(
+            filtered_entries,
+            indent=2,
+            ensure_ascii=True,
+        ),
+    }
+    if page_type == "event":
+        prompt_vars["prior_recap_context"] = prior_recap_context
     prompt = _load_prompt(
         f"wiki/extract_{prompt_suffix}_from_chapter",
-        {
-            "chapter_text": chapter_text,
-            "existing_pages_index": json.dumps(
-                filtered_entries,
-                indent=2,
-                ensure_ascii=True,
-            ),
-        },
+        prompt_vars,
     )
     result = _parse_json_response(
         _chat_completion(prompt, model=model, base_url=base_url),
@@ -685,6 +690,27 @@ def update_wiki_full_pass(
     wiki_dir = get_wiki_dir(story_dir)
     index_entries = read_index(wiki_dir) if wiki_dir.exists() else []
 
+    _prior_recap_context = ""
+    try:
+        _recap_results = query_recap(
+            story_name,
+            query_text=chapter_text[:500],
+            n_results=3,
+        )
+        if _recap_results:
+            _snippets = [
+                recap_result["document"]
+                for recap_result in _recap_results
+                if recap_result.get("document")
+            ]
+            _prior_recap_context = "\n\n---\n\n".join(_snippets)
+    except Exception as _recap_exc:
+        logging.warning(
+            "[Wiki] WARNING event recap context unavailable: %s",
+            _recap_exc,
+        )
+        _prior_recap_context = ""
+
     pass_a_types = list(_TYPE_TO_PROMPT.keys())
     type_candidates: dict[str, list[dict[str, Any]]] = {
         page_type: [] for page_type in pass_a_types
@@ -701,6 +727,11 @@ def update_wiki_full_pass(
                     index_entries,
                     model=model,
                     base_url=base_url,
+                    **(
+                        {"prior_recap_context": _prior_recap_context}
+                        if page_type == "event"
+                        else {}
+                    ),
                 ): page_type
                 for page_type in pass_a_types
             }

--- a/tests/unit/test_issue_364.py
+++ b/tests/unit/test_issue_364.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import ChapterDraft
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.final_editor import FinalEditorAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from tools._wiki_api import _extract_type_candidates, update_wiki_full_pass
+
+
+async def _stream_tokens(tokens: list[str]):
+    for token in tokens:
+        yield token
+
+
+def _make_draft(content: str = "Alice walked in.") -> ChapterDraft:
+    return ChapterDraft(
+        story_name="test-story",
+        chapter_number=1,
+        title="Chapter 1",
+        content=content,
+        word_count=len(content.split()),
+    )
+
+
+def _make_provider(responses: list[str]) -> MagicMock:
+    provider = MagicMock()
+    provider.stream_text = MagicMock(
+        side_effect=[_stream_tokens([response]) for response in responses]
+    )
+    return provider
+
+
+def _make_buses() -> tuple[MagicMock, MagicMock]:
+    bus = MagicMock(spec=TokenStreamBus)
+    bus.emit = AsyncMock()
+    wiki_bus = MagicMock(spec=WikiContextBus)
+    wiki_bus.emit = AsyncMock()
+    return bus, wiki_bus
+
+
+@pytest.mark.asyncio
+async def test_prose_scrub_passes_character_aliases_to_prompt(tmp_path: Path) -> None:
+    provider = _make_provider(['{"issues": []}', '{"issues": []}', "Alice walked in."])
+    bus, wiki_bus = _make_buses()
+    agent = FinalEditorAgent(provider=provider, config={}, bus=bus, wiki_bus=wiki_bus)
+    draft = _make_draft()
+    settings = GenerationSettings.from_dict({"enable_scrubbing": True})
+    captured_prose_vars: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        if name == "final_edit/prose_scrub":
+            assert variables is not None
+            captured_prose_vars.update(variables)
+        return "prompt"
+
+    with (
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+        patch(
+            "presentation.agents.final_editor._validate_story_name",
+            return_value=tmp_path,
+        ),
+        patch(
+            "presentation.agents.final_editor.get_wiki_dir",
+            return_value=tmp_path,
+        ),
+        patch(
+            "presentation.agents.final_editor.read_index",
+            return_value=[
+                {
+                    "name": "Alice",
+                    "slug": "alice",
+                    "type": "character",
+                    "aliases": ["Ali", "Ally"],
+                },
+                {
+                    "name": "Bob",
+                    "slug": "bob",
+                    "type": "character",
+                    "aliases": [],
+                },
+            ],
+        ),
+        patch(
+            "presentation.agents.final_editor.match_entities_in_text",
+            return_value=[{"slug": "alice"}],
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.edit_single_chapter(
+            draft,
+            prior_summary="",
+            chapter_number=1,
+            settings=settings,
+        )
+
+    assert captured_prose_vars["character_aliases"] == "Alice (aliases: Ali, Ally)"
+    assert "Bob" not in captured_prose_vars["character_aliases"]
+
+
+@pytest.mark.asyncio
+async def test_prose_scrub_degrades_gracefully_when_wiki_unavailable() -> None:
+    provider = _make_provider(['{"issues": []}', '{"issues": []}', "Alice walked in."])
+    bus, wiki_bus = _make_buses()
+    agent = FinalEditorAgent(provider=provider, config={}, bus=bus, wiki_bus=wiki_bus)
+    draft = _make_draft()
+    settings = GenerationSettings.from_dict({"enable_scrubbing": True})
+    prompt_names: list[str] = []
+    captured_prose_vars: dict[str, str] = {}
+
+    def capture_prompt(name: str, variables: dict | None = None) -> str:
+        prompt_names.append(name)
+        if name == "final_edit/prose_scrub":
+            assert variables is not None
+            captured_prose_vars.update(variables)
+        return "prompt"
+
+    with (
+        patch(
+            "presentation.agents.final_editor.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+        patch(
+            "presentation.agents.final_editor._validate_story_name",
+            side_effect=Exception("no wiki"),
+        ),
+        patch(
+            "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
+            side_effect=capture_prompt,
+        ),
+    ):
+        await agent.edit_single_chapter(
+            draft,
+            prior_summary="",
+            chapter_number=1,
+            settings=settings,
+        )
+
+    assert any(
+        call.args[0].event_type == "error"
+        for call in wiki_bus.emit.await_args_list
+        if call.args
+    )
+    assert "final_edit/prose_scrub" in prompt_names
+    assert captured_prose_vars["character_aliases"] == ""
+
+
+def test_extract_type_candidates_event_passes_prior_recap_context() -> None:
+    captured_prompt_vars: dict[str, object] = {}
+
+    def capture_prompt(prompt_id: str, variables: dict[str, object]) -> str:
+        captured_prompt_vars.clear()
+        captured_prompt_vars.update(variables)
+        return "prompt"
+
+    with (
+        patch("tools._wiki_api._load_prompt", side_effect=capture_prompt),
+        patch("tools._wiki_api._chat_completion", return_value="[]"),
+    ):
+        result = _extract_type_candidates(
+            "story",
+            "event",
+            "chapter text",
+            [],
+            prior_recap_context="Prior recap here",
+        )
+
+    assert result == []
+    assert captured_prompt_vars["prior_recap_context"] == "Prior recap here"
+
+
+def test_extract_type_candidates_non_event_does_not_pass_recap_context() -> None:
+    captured_prompt_vars: dict[str, object] = {}
+
+    def capture_prompt(prompt_id: str, variables: dict[str, object]) -> str:
+        captured_prompt_vars.clear()
+        captured_prompt_vars.update(variables)
+        return "prompt"
+
+    with (
+        patch("tools._wiki_api._load_prompt", side_effect=capture_prompt),
+        patch("tools._wiki_api._chat_completion", return_value="[]"),
+    ):
+        result = _extract_type_candidates(
+            "story",
+            "character",
+            "chapter text",
+            [],
+            prior_recap_context="Some recap",
+        )
+
+    assert result == []
+    assert "prior_recap_context" not in captured_prompt_vars
+
+
+def test_update_wiki_full_pass_fetches_recap_context_for_events(tmp_path: Path) -> None:
+    captured_event_kwargs: list[dict[str, object]] = []
+
+    def capture_extract(*args, **kwargs):
+        if args[1] == "event":
+            captured_event_kwargs.append(kwargs)
+        return []
+
+    with (
+        patch("tools._wiki_api._validate_story_name", return_value=tmp_path),
+        patch("tools._wiki_api.get_wiki_dir", return_value=tmp_path / "missing-wiki"),
+        patch(
+            "tools._wiki_api.query_recap",
+            return_value=[
+                {
+                    "document": "Chapter 1 summary",
+                    "id": "agg/1",
+                    "metadata": {},
+                }
+            ],
+        ) as mock_query_recap,
+        patch("tools._wiki_api._extract_type_candidates", side_effect=capture_extract),
+        patch("tools._wiki_api.match_entities_in_text", return_value=[]),
+    ):
+        result = update_wiki_full_pass("story", chapter=2, chapter_text="test chapter")
+
+    assert result["per_type"]["event"] == {"created": 0, "updated": 0}
+    mock_query_recap.assert_called_once_with(
+        "story",
+        query_text="test chapter",
+        n_results=3,
+    )
+    assert captured_event_kwargs
+    assert captured_event_kwargs[0]["prior_recap_context"] == "Chapter 1 summary"
+
+
+def test_update_wiki_full_pass_degrades_when_recap_unavailable(tmp_path: Path) -> None:
+    captured_event_kwargs: list[dict[str, object]] = []
+
+    def capture_extract(*args, **kwargs):
+        if args[1] == "event":
+            captured_event_kwargs.append(kwargs)
+        return []
+
+    with (
+        patch("tools._wiki_api._validate_story_name", return_value=tmp_path),
+        patch("tools._wiki_api.get_wiki_dir", return_value=tmp_path / "missing-wiki"),
+        patch(
+            "tools._wiki_api.query_recap",
+            side_effect=Exception("chromadb unavailable"),
+        ),
+        patch("tools._wiki_api._extract_type_candidates", side_effect=capture_extract),
+        patch("tools._wiki_api.match_entities_in_text", return_value=[]),
+    ):
+        result = update_wiki_full_pass("story", chapter=1, chapter_text="test")
+
+    assert result["per_type"]["event"] == {"created": 0, "updated": 0}
+    assert captured_event_kwargs
+    assert captured_event_kwargs[0]["prior_recap_context"] == ""


### PR DESCRIPTION
## Summary

Two low-priority context-consumer additions from the Wiki Source-of-Truth Consolidation planning documents.

**Prose Scrubber character aliases:** `FinalEditorAgent.edit_single_chapter()` now reads the wiki index for the story, matches character entities against the chapter text, and builds a compact `{character_aliases}` block (`Name (aliases: a, b)` per line) passed to `prompts/final_edit/prose_scrub.md`. Degrades gracefully — on any wiki lookup failure, emits a `WikiContextEvent(event_type="error")` and continues with an empty alias block.

**Wiki event extraction recap context:** `update_wiki_full_pass` now calls `query_recap(story_name, query_text=chapter_text[:500], n_results=3)` before the parallel extraction sweep and passes the result as `{prior_recap_context}` exclusively to the event extraction prompt. Degrades gracefully — on ChromaDB absence or empty recap index, falls back to empty string.

## Closes
Closes #364

## Changes
- [x] `src/presentation/agents/final_editor.py` — character alias block construction + graceful degradation
- [x] `prompts/final_edit/prose_scrub.md` — `{character_aliases}` template variable
- [x] `src/tools/_wiki_api.py` — recap context retrieval + `prior_recap_context` threading for event extraction
- [x] `prompts/wiki/extract_events_from_chapter.md` — `{prior_recap_context}` template variable + rule
- [x] `tests/unit/test_issue_364.py` — 6 unit tests (all pass)
- [x] Lint clean, mypy success

## Test Results
6 passed, 0 failed (0.07s)