### PR TITLE
fix(wiki-generation): generate entity pages from pre-story state

### DIFF
--- a/prompts/wiki/generate_character_page.md
+++ b/prompts/wiki/generate_character_page.md
@@ -1,8 +1,8 @@
 You are generating a planned wiki page for character `{character_name}` in story `{story_name}`.
 
-<OUTLINE_EXCERPT>
-{outline_excerpt}
-</OUTLINE_EXCERPT>
+<PRE_STORY_CONTEXT>
+{pre_story_context}
+</PRE_STORY_CONTEXT>
 
 ## Task
 
@@ -20,16 +20,18 @@ Required keys:
   "L3_background": "Paragraph.",
   "L3_personality": "Paragraph.",
   "L3_motivations": "Paragraph.",
-  "L3_relationships": "Paragraph.",
+  "L3_relationships": "Paragraph (relationships as they stand at story start).",
   "L3_skills": "Paragraph.",
-  "L3_growth_arc": "Paragraph.",
-  "L3_current_state": "Paragraph."
+  "L3_growth_arc": "Paragraph (potential arc trajectory inferred from initial conditions — not events that will unfold).",
+  "L3_current_state": "Paragraph (character's condition at story opening)."
 }
 ```
 
 ## Rules
 
-- Base every field on the outline excerpt only.
+- Describe this character only as they exist at the **opening** of the story, before any story events occur. Do not describe events that happen during the story.
+- All fields must reflect the character's pre-story state.
+- Base every field on the pre-story context only.
 - Do not invent facts not supported by the outline.
 - `slug` must be snake_case derived from the character name.
 - `page_name` should be the display name used in the outline.

--- a/prompts/wiki/generate_location_page.md
+++ b/prompts/wiki/generate_location_page.md
@@ -1,8 +1,8 @@
 You are generating a planned wiki page for location `{location_name}` in story `{story_name}`.
 
-<OUTLINE_EXCERPT>
-{outline_excerpt}
-</OUTLINE_EXCERPT>
+<PRE_STORY_CONTEXT>
+{pre_story_context}
+</PRE_STORY_CONTEXT>
 
 ## Task
 
@@ -22,13 +22,15 @@ Required keys:
   "L3_atmosphere": "Paragraph.",
   "L3_inhabitants": "Paragraph.",
   "L3_significance": "Paragraph.",
-  "L3_current_state": "Paragraph."
+  "L3_current_state": "Paragraph (condition at story opening)."
 }
 ```
 
 ## Rules
 
-- Base every field on the outline excerpt only.
+- Describe this location only as it exists at the **opening** of the story, before any story events alter it.
+- All fields must reflect the location's pre-story state.
+- Base every field on the pre-story context only.
 - Do not invent facts not supported by the outline.
 - `slug` must be snake_case derived from the location name.
 - `page_name` should be the display name used in the outline.

--- a/src/tools/wiki_generation.py
+++ b/src/tools/wiki_generation.py
@@ -60,6 +60,22 @@ def _build_outline_excerpt(outline_result: OutlineResult, story_root: Path) -> s
     return "\n\n".join(part for part in parts if part)
 
 
+def _build_pre_story_excerpt(outline_result: OutlineResult, story_root: Path) -> str:
+    parts: list[str] = []
+
+    story_elements = _resolve_markdown(
+        outline_result.story_elements, story_root
+    ).strip()
+    if story_elements:
+        parts.append(story_elements)
+
+    base_context = _resolve_markdown(outline_result.base_context, story_root).strip()
+    if base_context:
+        parts.append(base_context)
+
+    return "\n\n".join(parts)
+
+
 def _invoke_provider(
     provider: Any,
     messages: list[dict[str, str]],
@@ -214,6 +230,7 @@ def generate_character_pages(
     story_root = stories_dir / story_name
     wiki_dir = get_wiki_dir(story_root)
     outline_excerpt = _build_outline_excerpt(outline_result, story_root)
+    pre_story_excerpt = _build_pre_story_excerpt(outline_result, story_root)
     model_config = _model_config(config)
     seed = _generation_seed(config)
     entities = _dedupe_entities(
@@ -231,7 +248,7 @@ def generate_character_pages(
             "wiki/generate_character_page",
             {
                 "story_name": story_name,
-                "outline_excerpt": outline_excerpt,
+                "pre_story_context": pre_story_excerpt,
                 "character_name": character_name,
             },
             provider,
@@ -311,6 +328,7 @@ def generate_location_pages(
     story_root = stories_dir / story_name
     wiki_dir = get_wiki_dir(story_root)
     outline_excerpt = _build_outline_excerpt(outline_result, story_root)
+    pre_story_excerpt = _build_pre_story_excerpt(outline_result, story_root)
     model_config = _model_config(config)
     seed = _generation_seed(config)
     entities = _dedupe_entities(
@@ -328,7 +346,7 @@ def generate_location_pages(
             "wiki/generate_location_page",
             {
                 "story_name": story_name,
-                "outline_excerpt": outline_excerpt,
+                "pre_story_context": pre_story_excerpt,
                 "location_name": location_name,
             },
             provider,

--- a/tests/unit/test_wiki_generation.py
+++ b/tests/unit/test_wiki_generation.py
@@ -11,7 +11,11 @@ if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
 from application.pipeline.handoffs import OutlineResult
-from tools.wiki_generation import generate_character_pages, generate_location_pages
+from tools.wiki_generation import (
+    _build_pre_story_excerpt,
+    generate_character_pages,
+    generate_location_pages,
+)
 
 
 def _config() -> dict[str, object]:
@@ -78,6 +82,78 @@ def _location_page_json() -> str:
 
 def _prompt_loader_side_effect(prompt_name: str, variables: dict[str, object]) -> str:
     return f"{prompt_name}:{sorted(variables)}"
+
+
+class TestBuildPreStoryExcerpt:
+    def test_returns_empty_string_when_both_fields_empty(self, tmp_path: Path) -> None:
+        outline_result = OutlineResult(
+            story_name="test-story",
+            chapter_outlines=[],
+            summary="Story summary",
+            genre="fantasy",
+            themes=["identity"],
+            story_elements="",
+            base_context="",
+        )
+
+        result = _build_pre_story_excerpt(outline_result, tmp_path)
+
+        assert result == ""
+
+    def test_returns_story_elements_only_when_base_context_absent(
+        self, tmp_path: Path
+    ) -> None:
+        outline_result = OutlineResult(
+            story_name="test-story",
+            chapter_outlines=[],
+            summary="Story summary",
+            genre="fantasy",
+            themes=["identity"],
+            story_elements="Some elements text",
+            base_context="",
+        )
+
+        result = _build_pre_story_excerpt(outline_result, tmp_path)
+
+        assert result == "Some elements text"
+
+    def test_returns_both_sections_joined_when_populated(self, tmp_path: Path) -> None:
+        outline_result = OutlineResult(
+            story_name="test-story",
+            chapter_outlines=[],
+            summary="Story summary",
+            genre="fantasy",
+            themes=["identity"],
+            story_elements="Elements text",
+            base_context="Base context text",
+        )
+
+        result = _build_pre_story_excerpt(outline_result, tmp_path)
+
+        assert result == "Elements text\n\nBase context text"
+
+    def test_excludes_summary_and_chapter_outlines(self, tmp_path: Path) -> None:
+        outline_result = OutlineResult(
+            story_name="test-story",
+            chapter_outlines=[
+                {
+                    "chapter_number": 1,
+                    "title": "Ch1",
+                    "summary": "Alice dies.",
+                }
+            ],
+            summary="The full story arc summary",
+            genre="fantasy",
+            themes=["identity"],
+            story_elements="Elements",
+            base_context="",
+        )
+
+        result = _build_pre_story_excerpt(outline_result, tmp_path)
+
+        assert "full story arc" not in result
+        assert "Alice dies" not in result
+        assert result == "Elements"
 
 
 class TestWikiGeneration:
@@ -218,6 +294,70 @@ class TestWikiGeneration:
 
         assert result == {"generated": 0, "skipped": 0}
         run_batch_mock.assert_not_called()
+
+    def test_generate_character_pages_uses_pre_story_context_for_page_generation(
+        self, tmp_path: Path
+    ) -> None:
+        story_name = "test-story"
+        (tmp_path / story_name).mkdir(parents=True)
+        provider = MagicMock()
+        provider.generate_text = AsyncMock(
+            side_effect=[
+                json.dumps([{"name": "Alice", "type": "character", "aliases": []}]),
+                _character_page_json(),
+            ]
+        )
+        run_batch_mock = MagicMock(
+            return_value={
+                "created": 1,
+                "updated": 0,
+                "timeline_events": 0,
+                "entity_counts": {},
+            }
+        )
+        prompt_loader_mock = MagicMock(side_effect=_prompt_loader_side_effect)
+        outline_result = OutlineResult(
+            story_name="test-story",
+            chapter_outlines=[
+                {
+                    "chapter_number": 1,
+                    "title": "Chapter 1",
+                    "summary": "Alice arrives in Harbor Town.",
+                }
+            ],
+            summary="Story summary",
+            genre="fantasy",
+            themes=["identity"],
+            story_elements="Story elements",
+            base_context="Base context text",
+        )
+
+        with (
+            patch(
+                "tools.wiki_generation._PROMPT_LOADER.load_prompt",
+                prompt_loader_mock,
+            ),
+            patch("tools.wiki_generation.run_batch", run_batch_mock),
+        ):
+            result = generate_character_pages(
+                story_name,
+                outline_result,
+                provider,
+                _config(),
+                tmp_path,
+            )
+
+        assert result == {"generated": 1, "skipped": 0}
+        page_generation_calls = [
+            call_args
+            for call_args in prompt_loader_mock.call_args_list
+            if call_args.args[0] == "wiki/generate_character_page"
+        ]
+        assert len(page_generation_calls) == 1
+        variables = page_generation_calls[0].args[1]
+        assert "pre_story_context" in variables
+        assert variables["pre_story_context"] == "Story elements\n\nBase context text"
+        assert "outline_excerpt" not in variables
 
     def test_generate_location_pages_happy_path(self, tmp_path: Path) -> None:
         story_name = "test-story"


### PR DESCRIPTION
## Summary

During the `wiki-generation` phase, `generate_character_pages()` and `generate_location_pages()` previously passed the entire story outline — story_elements + full outline summary + all chapter_outlines — as LLM context when generating wiki pages. This caused character and location pages to describe post-story states: `L3_current_state` reflected end-of-arc conditions, `L3_relationships` included relationships formed during the story, and `L3_growth_arc` described arc events rather than initial conditions.

The wiki is a pre-story benchmark that should be built out incrementally as chapters are written. This PR fixes the context split.

## Closes

Closes #383

## Changes

- **`src/tools/wiki_generation.py`** — Added `_build_pre_story_excerpt(outline_result, story_root)` which assembles only `story_elements` + `base_context`. Both `generate_character_pages()` and `generate_location_pages()` now pass `pre_story_excerpt` to `_generate_page()` while keeping the full `outline_excerpt` for `_extract_entities()` (entity discovery still needs the full arc to catch late-appearing entities).
- **`prompts/wiki/generate_character_page.md`** — Renamed `{outline_excerpt}` → `{pre_story_context}`; added explicit pre-story-only framing rules; updated `L3_current_state`, `L3_growth_arc`, `L3_relationships` descriptions to reflect opening-state semantics.
- **`prompts/wiki/generate_location_page.md`** — Same rename + pre-story framing for `L3_current_state`.
- **`tests/unit/test_wiki_generation.py`** — Added `TestBuildPreStoryExcerpt` (4 tests covering empty, single-field, both-fields, and exclusion of summary/chapter_outlines) and one integration call-site test verifying `pre_story_context` is passed (not `outline_excerpt`) to the page generation prompt.

## Verification

- [ ] Implementation complete
- [ ] 10/10 new + existing tests passing
- [ ] ruff: ✅ clean
- [ ] mypy: ✅ no issues found in 66 source files

## Plan

### Task 1 — Add `_build_pre_story_excerpt` + wire into generate_character_pages / generate_location_pages ✅
### Task 2 — Update `generate_character_page.md` for pre-story framing ✅
### Task 3 — Update `generate_location_page.md` for pre-story framing ✅
### Task 4 — Lint, type-check, confirm all unit tests pass ✅