### PR TITLE
[P1] Add scene-level critic + revise loop before scrubbing

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -35,6 +35,7 @@ generation:
   scenes_per_chapter_min: 8
   scenes_per_chapter_max: 16
   enable_outline_critique: true
+  enable_scene_critique: true
   stream: true
   debug: true
   use_improved_recap_sanitizer: true

--- a/prompts/scenes/critique_draft.md
+++ b/prompts/scenes/critique_draft.md
@@ -1,0 +1,63 @@
+# Scene Critique
+
+## Your Task
+You are a scene-level editor for **Scene {scene_num} of Chapter {chapter_num}**. Critically evaluate the draft scene below against the scene definition and chapter outline.
+
+Return your findings as a single JSON object. Return `{}` (empty object) if the scene passes all checks with no issues.
+
+Return ONLY valid JSON. No prose. No markdown fences. Empty object {} if the scene passes all checks.
+
+## Scene Draft
+<SCENE_CONTENT>
+{scene_content}
+</SCENE_CONTENT>
+
+## Scene Definition
+<SCENE_DEFINITION>
+{scene_definition}
+</SCENE_DEFINITION>
+
+## Chapter Outline
+<CHAPTER_OUTLINE>
+{chapter_outline}
+</CHAPTER_OUTLINE>
+
+## Previous Scene
+<PREVIOUS_SCENE>
+{previous_scene}
+</PREVIOUS_SCENE>
+*Note: Empty if this is the first scene in the chapter.*
+
+## Evaluation Criteria
+
+Check each of the following:
+
+### 1. Outline Adherence
+Are all `key_events` from the scene definition present in the draft? List any missing key events.
+
+### 2. POV Consistency
+Is the point-of-view character maintained throughout the scene without drift? Identify any POV violations.
+
+### 3. Continuity
+Does the opening of this scene follow naturally from the previous scene? Note any continuity breaks.
+
+### 4. Style Violations
+Flag any banned constructions, purple prose, or stylistic inconsistencies. Be specific.
+
+## Output Format
+
+Return ONLY a valid JSON object. No prose, no markdown code fences, no explanation:
+
+- `{}` — scene passes all checks
+- `{"outline_adherence": ["missing event: X"], "pov_consistency": ["POV shift at paragraph 3"]}` — include only failing categories
+
+Allowed top-level keys:
+- `outline_adherence`
+- `pov_consistency`
+- `continuity`
+- `style_violations`
+
+Each present key must map to a JSON array of specific finding strings.
+If a category is clean, omit it or use an empty array.
+
+Return ONLY valid JSON now.

--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -24,6 +24,7 @@ class GenerationSettings:
     # Critique settings
     enable_outline_critique: bool = True
     enable_concurrent_critics: bool = False
+    enable_scene_critique: bool = True
 
     # Initial outline generation settings
     use_chunked_outline_generation: bool = (
@@ -102,6 +103,7 @@ class GenerationSettings:
             "scenes_per_chapter_min": self.scenes_per_chapter_min,
             "scenes_per_chapter_max": self.scenes_per_chapter_max,
             "enable_outline_critique": self.enable_outline_critique,
+            "enable_scene_critique": self.enable_scene_critique,
             "enable_concurrent_critics": self.enable_concurrent_critics,
             "stream": self.stream,
             "debug": self.debug,

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -661,6 +661,101 @@ class ChapterWriterAgent:
             if not scene_text:
                 continue
 
+            if settings.enable_scene_critique:
+                await self.status_bus.emit(
+                    StatusEvent(
+                        phase=phase,
+                        message=(
+                            f"Ch {chapter_number}: critiquing scene "
+                            f"{index}/{total_scenes}"
+                        ),
+                        kind="step",
+                    )
+                )
+                await self.bus.emit(
+                    f"\n[Chapter {chapter_number}] Critiquing scene {index}...\n"
+                )
+                critique_prompt = loader.load_prompt(
+                    "scenes/critique_draft",
+                    variables={
+                        "chapter_num": str(chapter_number),
+                        "scene_num": str(index),
+                        "scene_content": scene_text,
+                        "scene_definition": json.dumps(scene, ensure_ascii=False),
+                        "chapter_outline": chapter_summary,
+                        "previous_scene": prev_tail,
+                    },
+                )
+                try:
+                    critique_text = await self._stream_to_bus(
+                        [
+                            {"role": "system", "content": critique_prompt},
+                            {"role": "user", "content": "Critique the scene now."},
+                        ],
+                        scene_model,
+                        settings.seed,
+                    )
+                    critique_text = critique_text.strip()
+                    if critique_text and critique_text != "{}":
+                        # Non-empty findings — run one revision pass
+                        await self.status_bus.emit(
+                            StatusEvent(
+                                phase=phase,
+                                message=(
+                                    f"Ch {chapter_number}: revising scene "
+                                    f"{index}/{total_scenes}"
+                                ),
+                                kind="step",
+                            )
+                        )
+                        await self.bus.emit(
+                            f"\n[Chapter {chapter_number}] Revising scene {index}...\n"
+                        )
+                        revise_prompt = loader.load_prompt(
+                            "scenes/revise_content",
+                            variables={
+                                "chapter_num": str(chapter_number),
+                                "scene_num": str(index),
+                                "scene_content": scene_text,
+                                "feedback": critique_text,
+                                "scene_definition": json.dumps(
+                                    scene, ensure_ascii=False
+                                ),
+                                "chapter_outline": chapter_summary,
+                                "previous_scene": prev_tail,
+                                "next_chapter_synopsis": (
+                                    next_chapter_summary
+                                    if index == total_scenes
+                                    else ""
+                                ),
+                            },
+                        )
+                        try:
+                            revised = await self._stream_to_bus(
+                                [
+                                    {"role": "system", "content": revise_prompt},
+                                    {
+                                        "role": "user",
+                                        "content": "Revise the scene now.",
+                                    },
+                                ],
+                                scene_model,
+                                settings.seed,
+                            )
+                            revised = revised.strip()
+                            if revised:
+                                scene_text = revised
+                        except Exception as exc:
+                            await self.bus.emit(
+                                f"\n[Chapter {chapter_number}] scene {index} revision "
+                                f"failed ({type(exc).__name__}: {exc}); using draft.\n"
+                            )
+                except Exception as exc:
+                    await self.bus.emit(
+                        f"\n[Chapter {chapter_number}] scene {index} critique "
+                        f"failed ({type(exc).__name__}: {exc}); skipping critique.\n"
+                    )
+
             if settings.enable_scrubbing:
                 await self.status_bus.emit(
                     StatusEvent(

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -1047,11 +1047,7 @@ async def _continue_pipeline(
                     # (e.g. wiki-generation). If so, treat bootstrap as a
                     # no-op success rather than blocking forever.
                     existing_pages = (
-                        sum(
-                            1
-                            for _ in wiki_dir.rglob("*.md")
-                            if _.parent != wiki_dir
-                        )
+                        sum(1 for _ in wiki_dir.rglob("*.md") if _.parent != wiki_dir)
                         if wiki_dir.exists()
                         else 0
                     )

--- a/tests/unit/test_chapter_writer_scene_pipeline.py
+++ b/tests/unit/test_chapter_writer_scene_pipeline.py
@@ -118,7 +118,12 @@ async def test_scene_pipeline_runs_three_stages_in_order(tmp_path: Path) -> None
 
     agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
     with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
-        draft = await agent.run("test-story", 1, _outline_result(), _settings())
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
 
     # Four stream_text invocations: synopsis, scenes, scene1, scene2.
     assert len(captured) == 4
@@ -163,7 +168,12 @@ async def test_scene_pipeline_falls_back_when_json_unparseable(tmp_path: Path) -
 
     agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
     with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
-        draft = await agent.run("test-story", 1, _outline_result(), _settings())
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
 
     # Three calls: synopsis, scenes (failed parse), direct draft fallback.
     assert len(captured) == 3
@@ -306,7 +316,11 @@ async def test_scene_pipeline_skips_decomposition_when_ledger_done(
 
     with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
         draft = await agent.run(
-            "test-story", 1, _outline_result(), _settings(), state=state
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+            state=state,
         )
 
     assert draft.content
@@ -350,7 +364,11 @@ async def test_scene_pipeline_skips_completed_scenes_on_resume(tmp_path: Path) -
 
     with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
         draft = await agent.run(
-            "test-story", 1, _outline_result(), _settings(), state=state
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+            state=state,
         )
 
     assert "Scene 1 prose from disk" in draft.content
@@ -401,7 +419,11 @@ async def test_scene_pipeline_marks_work_items_done(tmp_path: Path) -> None:
         ),
     ):
         draft = await agent.run(
-            "test-story", 1, _outline_result(), _settings(), state=state
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+            state=state,
         )
 
     assert draft.content
@@ -468,7 +490,12 @@ async def test_scene_prompt_receives_scene_recap_context(tmp_path: Path) -> None
             side_effect=assemble_side_effect,
         ),
     ):
-        await agent.run("test-story", 1, _outline_result(), _settings())
+        await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
 
     assert any("scene recap A" in prompt for prompt in captured)
 
@@ -525,10 +552,219 @@ async def test_scene_pipeline_calls_assemble_context_per_scene(tmp_path: Path) -
             side_effect=_assemble_side_effect,
         ),
     ):
-        draft = await agent.run("test-story", 1, _outline_result(), _settings())
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
 
     assert call_count == 3
     assert draft.content
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_fires_and_revises_when_findings_returned(
+    tmp_path: Path,
+) -> None:
+    scenes_payload = json.dumps(
+        [
+            {"title": "Opening", "description": "Hero arrives at the gate."},
+            {"title": "Climax", "description": "Hero confronts the guard."},
+        ]
+    )
+    provider, captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            f"```json\n{scenes_payload}\n```",
+            "Scene 1 draft prose.",
+            '{"outline_adherence": ["missing: hero meets villain"]}',
+            "Scene 1 revised prose with hero meets villain.",
+            "Scene 2 draft prose.",
+            "{}",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            },
+            "model_api_base": "http://localhost/v1",
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=True, enable_scrubbing=False),
+        )
+
+    assert len(captured) == 7
+    assert any("Scene Critique" in prompt for prompt in captured)
+    assert any("Scene Revision" in prompt for prompt in captured)
+    assert "Scene 1 revised prose with hero meets villain." in draft.content
+    assert "Scene 1 draft prose." not in draft.content
+    assert "Scene 2 draft prose." in draft.content
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_bypasses_revision_when_findings_empty(
+    tmp_path: Path,
+) -> None:
+    scenes_payload = json.dumps(
+        [{"title": "Opening", "description": "Hero arrives at the gate."}]
+    )
+    provider, captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            f"```json\n{scenes_payload}\n```",
+            "Scene 1 clean draft prose.",
+            "{}",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(
+                scenes_per_chapter_min=1,
+                enable_scene_critique=True,
+                enable_scrubbing=False,
+            ),
+        )
+
+    assert len(captured) == 4
+    assert any("Scene Critique" in prompt for prompt in captured)
+    assert not any("Scene Revision" in prompt for prompt in captured)
+    assert "Scene 1 clean draft prose." in draft.content
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_skipped_when_disabled(tmp_path: Path) -> None:
+    scenes_payload = json.dumps(
+        [
+            {"title": "Opening", "description": "Hero arrives at the gate."},
+            {"title": "Climax", "description": "Hero confronts the guard."},
+        ]
+    )
+    provider, captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            f"```json\n{scenes_payload}\n```",
+            "Scene 1 prose body.",
+            "Scene 2 prose body.",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
+
+    assert len(captured) == 4
+    assert not any("Scene Critique" in prompt for prompt in captured)
+    assert not any("Scene Revision" in prompt for prompt in captured)
+    assert "Scene 1 prose body." in draft.content
+    assert "Scene 2 prose body." in draft.content
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_skipped_on_resume_when_scene_already_saved(
+    tmp_path: Path,
+) -> None:
+    scenes = [
+        {"title": "Opening", "description": "Hero arrives at the gate."},
+        {"title": "Climax", "description": "Hero confronts the guard."},
+    ]
+    provider, captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            json.dumps(scenes),
+            "Scene 2 prose body.",
+            "{}",
+        ]
+    )
+    state = PipelineState(
+        story_name="test-story",
+        current_phase="chapters",
+        completed_work_items={"chapter-1": ["scene:1"]},
+    )
+
+    scene_1_path = tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_1.md"
+    scene_1_path.parent.mkdir(parents=True, exist_ok=True)
+    scene_1_path.write_text("Scene 1 prose from disk", encoding="utf-8")
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(
+                scenes_per_chapter_min=1,
+                enable_scene_critique=True,
+                enable_scrubbing=False,
+            ),
+            state=state,
+        )
+
+    assert len(captured) == 4
+    assert captured[2].startswith("# Scene Critique") is False
+    assert "Scene 1 prose from disk" in draft.content
+    assert "Scene 2 prose body." in draft.content
+    assert any("Climax" in prompt for prompt in captured)
+    assert sum("Scene Critique" in prompt for prompt in captured) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a structured critic → single-revision feedback loop to `_run_scene_pipeline()` in `ChapterWriterAgent`. After each scene is drafted, if `generation.enable_scene_critique` is `true`, the pipeline runs a critique pass; if the critique returns non-empty findings, it runs `scenes/revise_content.md` once before proceeding to scrubbing. Empty findings bypass revision entirely.

## Closes
Closes #385

## Changes

- **`prompts/scenes/critique_draft.md`** — new prompt; checks outline adherence (`key_events` present), POV consistency, continuity with previous scene, and style violations; returns structured JSON findings or `{}` when clean
- **`src/presentation/agents/chapter_writer.py`** — `_run_scene_pipeline()` now runs critique after draft, revision on non-empty findings, before the existing scrub step
- **`src/domain/value_objects/generation_settings.py`** — `enable_scene_critique: bool = True` field + `to_dict()` entry
- **`config.example.yml`** — `enable_scene_critique: true` under `generation:`
- **`tests/unit/test_chapter_writer_scene_pipeline.py`** — 4 new tests; existing call-count tests opt out via `enable_scene_critique=False`

## Plan

### Task Checklist

- [x] `prompts/scenes/critique_draft.md` created with structured JSON output
- [x] `ChapterWriterAgent._run_scene_pipeline()` runs critic after initial draft
- [x] On non-empty findings, runs `scenes/revise_content.md` once; empty findings bypass revision
- [x] `generation.enable_scene_critique` config flag in `GenerationSettings`; default `true`
- [x] Resume-safe: existing checkpoint guard skips the critique block for already-saved scenes
- [x] Unit test: non-empty critic finding triggers one revision call
- [x] Unit test: empty findings bypasses revision and proceeds directly
- [x] Unit test: `enable_scene_critique=False` skips critique entirely
- [x] Unit test: resume path skips critique for already-saved scene

### Verification

- All tests passing (verified)
- Linting clean
