### PR TITLE
[P1] Replace predicted-ending with actual-prose recap in scenes_completed_summary

### DIFF
--- a/prompts/scenes/summarise_for_continuity.md
+++ b/prompts/scenes/summarise_for_continuity.md
@@ -1,0 +1,12 @@
+You are a continuity assistant for a fiction writing pipeline.
+
+Given the closing excerpt of a scene, write **one sentence** (maximum 25 words) summarising what concretely happened at the end of the scene: who acted, what changed, and where it left off.
+
+Rules:
+- Plain prose only — no bullet points, no headers, no scene numbers.
+- Report facts from the text. Do not speculate or add anything not present.
+- Write in past tense, third person.
+
+Scene excerpt:
+
+{prose_excerpt}

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -519,6 +519,7 @@ class ChapterWriterAgent:
         # Stage 3: per-scene drafting.
         scene_prose: list[str] = []
         scenes_completed_meta: list[dict[str, Any]] = []
+        actual_recaps: dict[int, str] = {}
         total_scenes = len(scenes)
         scenes_dir = STORIES_DIR / story_name / "chapters" / f"chapter_{chapter_number}"
         for index, scene in enumerate(scenes, start=1):
@@ -554,6 +555,11 @@ class ChapterWriterAgent:
                 scene_text = scene_file.read_text(encoding="utf-8")
                 scene_prose.append(scene_text)
                 scenes_completed_meta.append(scene)
+                recap_cache_file = scenes_dir / f"scene_{index}_actual_recap.txt"
+                if recap_cache_file.exists():
+                    actual_recaps[index] = recap_cache_file.read_text(
+                        encoding="utf-8"
+                    ).strip()
                 continue
 
             if index == 1:
@@ -576,7 +582,7 @@ class ChapterWriterAgent:
                 completed_lines = []
                 for done_idx, done_scene in enumerate(scenes_completed_meta, start=1):
                     title = done_scene.get("title", "") or f"scene {done_idx}"
-                    desc = (
+                    desc = actual_recaps.get(done_idx) or (
                         done_scene.get("ending") or done_scene.get("description") or ""
                     )
                     completed_lines.append(f"{done_idx}. {title} — {desc}".strip())
@@ -799,6 +805,32 @@ class ChapterWriterAgent:
                         f"\n[Chapter {chapter_number}] scene {index} scrub "
                         f"failed ({type(exc).__name__}: {exc}); using raw draft.\n"
                     )
+
+            # Generate and cache an actual-prose recap for continuity.
+            prose_excerpt = scene_text[-500:].strip()
+            recap_prompt = loader.load_prompt(
+                "scenes/summarise_for_continuity",
+                variables={"prose_excerpt": prose_excerpt},
+            )
+            try:
+                recap_text = await self._stream_to_bus(
+                    [
+                        {"role": "system", "content": recap_prompt},
+                        {"role": "user", "content": "Summarise the scene ending now."},
+                    ],
+                    scene_model,
+                    settings.seed,
+                )
+                recap_text = recap_text.strip()
+                if recap_text:
+                    actual_recaps[index] = recap_text
+                    recap_cache_file = scenes_dir / f"scene_{index}_actual_recap.txt"
+                    _atomic_write(recap_cache_file, recap_text)
+            except Exception as exc:
+                await self.bus.emit(
+                    f"\n[Chapter {chapter_number}] scene {index} recap failed "
+                    f"({type(exc).__name__}: {exc}); continuity will use predicted ending.\n"
+                )
 
             scene_prose.append(scene_text)
             scenes_completed_meta.append(scene)

--- a/tests/unit/test_chapter_writer_scene_pipeline.py
+++ b/tests/unit/test_chapter_writer_scene_pipeline.py
@@ -101,7 +101,9 @@ async def test_scene_pipeline_runs_three_stages_in_order(tmp_path: Path) -> None
             "Detailed synopsis content for chapter 1.",  # synopsis call
             f"```json\n{scenes_payload}\n```",  # scene decomposition call
             "Scene 1 prose body.",  # scene 1 drafting
+            "Scene 1 actual recap.",
             "Scene 2 prose body.",  # scene 2 drafting
+            "Scene 2 actual recap.",
         ]
     )
 
@@ -125,12 +127,15 @@ async def test_scene_pipeline_runs_three_stages_in_order(tmp_path: Path) -> None
             _settings(enable_scene_critique=False, enable_scrubbing=False),
         )
 
-    # Four stream_text invocations: synopsis, scenes, scene1, scene2.
-    assert len(captured) == 4
+    # Six stream_text invocations: synopsis, scenes, scene1, scene1 recap,
+    # scene2, scene2 recap.
+    assert len(captured) == 6
     assert "Create Chapter Synopsis" in captured[0]
     assert "scene" in captured[1].lower()
     assert "Opening" in captured[2]
-    assert "Climax" in captured[3]
+    assert "continuity assistant" in captured[3]
+    assert "Climax" in captured[4]
+    assert "continuity assistant" in captured[5]
 
     # Final chapter content concatenates scene prose under the chapter title.
     assert "Scene 1 prose body." in draft.content
@@ -290,7 +295,14 @@ async def test_scene_pipeline_skips_decomposition_when_ledger_done(
         {"title": "Opening", "description": "Hero arrives at the gate."},
         {"title": "Climax", "description": "Hero confronts the guard."},
     ]
-    provider, captured = _make_provider(["Scene 1 prose body.", "Scene 2 prose body."])
+    provider, captured = _make_provider(
+        [
+            "Scene 1 prose body.",
+            "Scene 1 actual recap.",
+            "Scene 2 prose body.",
+            "Scene 2 actual recap.",
+        ]
+    )
     state = PipelineState(
         story_name="test-story",
         current_phase="chapters",
@@ -324,7 +336,7 @@ async def test_scene_pipeline_skips_decomposition_when_ledger_done(
         )
 
     assert draft.content
-    assert len(captured) == 2
+    assert len(captured) == 4
     assert "Scene 1 prose body." in draft.content
     assert "Scene 2 prose body." in draft.content
 
@@ -335,7 +347,9 @@ async def test_scene_pipeline_skips_completed_scenes_on_resume(tmp_path: Path) -
         {"title": "Opening", "description": "Hero arrives at the gate."},
         {"title": "Climax", "description": "Hero confronts the guard."},
     ]
-    provider, captured = _make_provider(["Scene 2 prose body."])
+    provider, captured = _make_provider(
+        ["Scene 2 prose body.", "Scene 2 actual recap."]
+    )
     state = PipelineState(
         story_name="test-story",
         current_phase="chapters",
@@ -373,7 +387,7 @@ async def test_scene_pipeline_skips_completed_scenes_on_resume(tmp_path: Path) -
 
     assert "Scene 1 prose from disk" in draft.content
     assert "Scene 2 prose body." in draft.content
-    assert len(captured) == 1
+    assert len(captured) == 2
     assert "Climax" in captured[0]
 
 
@@ -390,7 +404,9 @@ async def test_scene_pipeline_marks_work_items_done(tmp_path: Path) -> None:
             "Detailed synopsis content for chapter 1.",
             f"```json\n{scenes_payload}\n```",
             "Scene 1 prose body.",
+            "Scene 1 actual recap.",
             "Scene 2 prose body.",
+            "Scene 2 actual recap.",
         ]
     )
     state = PipelineState(story_name="test-story", current_phase="chapters")
@@ -427,7 +443,7 @@ async def test_scene_pipeline_marks_work_items_done(tmp_path: Path) -> None:
         )
 
     assert draft.content
-    assert len(captured) == 4
+    assert len(captured) == 6
     completed = state.completed_work_items.get("chapter-1", [])
     assert "scenes/decomposition" in completed
     assert "scene:1" in completed
@@ -457,7 +473,9 @@ async def test_scene_prompt_receives_scene_recap_context(tmp_path: Path) -> None
                 ]
             ),
             "Scene 1 prose body.",
+            "Scene 1 actual recap.",
             "Scene 2 prose body.",
+            "Scene 2 actual recap.",
         ]
     )
 
@@ -500,6 +518,173 @@ async def test_scene_prompt_receives_scene_recap_context(tmp_path: Path) -> None
     assert any("scene recap A" in prompt for prompt in captured)
 
 
+@pytest.mark.asyncio
+async def test_actual_recap_file_written_after_scene_draft(tmp_path: Path) -> None:
+    scenes = [
+        {"title": "Opening", "description": "Hero arrives."},
+        {"title": "Climax", "description": "Hero fights."},
+    ]
+    provider, _captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            json.dumps(scenes),
+            "Scene 1 prose.",
+            "Hero arrived at the gate.",
+            "Scene 2 prose.",
+            "Hero defeated the guard.",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
+
+    recap_1 = (
+        tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_1_actual_recap.txt"
+    )
+    recap_2 = (
+        tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_2_actual_recap.txt"
+    )
+    assert recap_1.exists()
+    assert recap_2.exists()
+    assert recap_1.read_text(encoding="utf-8") == "Hero arrived at the gate."
+    assert recap_2.read_text(encoding="utf-8") == "Hero defeated the guard."
+    assert draft.content
+
+
+@pytest.mark.asyncio
+async def test_scenes_completed_summary_uses_actual_recap_not_predicted_ending(
+    tmp_path: Path,
+) -> None:
+    scenes = [
+        {
+            "title": "Opening",
+            "description": "...",
+            "ending": "PREDICTED_ENDING_ONE",
+        },
+        {
+            "title": "Climax",
+            "description": "...",
+            "ending": "PREDICTED_ENDING_TWO",
+        },
+    ]
+    provider, captured = _make_provider(
+        [
+            "Detailed synopsis content for chapter 1.",
+            json.dumps(scenes),
+            "Scene 1 actual prose.",
+            "ACTUAL_RECAP_ONE",
+            "Scene 2 actual prose.",
+            "ACTUAL_RECAP_TWO",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+        )
+
+    assert "ACTUAL_RECAP_ONE" in captured[4]
+    assert "PREDICTED_ENDING_ONE" not in captured[4]
+    assert (
+        tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_1_actual_recap.txt"
+    ).exists()
+    assert (
+        tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_2_actual_recap.txt"
+    ).exists()
+
+
+@pytest.mark.asyncio
+async def test_resume_reads_actual_recap_from_disk_no_extra_llm_call(
+    tmp_path: Path,
+) -> None:
+    scenes = [
+        {"title": "Opening", "ending": "PREDICTED_ENDING"},
+        {"title": "Climax", "ending": "PREDICTED_CLIMAX"},
+    ]
+    provider, captured = _make_provider(
+        ["Scene 2 prose body.", "Scene 2 actual recap."]
+    )
+    state = PipelineState(
+        story_name="test-story",
+        current_phase="chapters",
+        completed_work_items={"chapter-1": ["scenes/decomposition", "scene:1"]},
+    )
+
+    scenes_file = tmp_path / "test-story" / "chapters" / "chapter_1_scenes.json"
+    scenes_file.parent.mkdir(parents=True, exist_ok=True)
+    scenes_file.write_text(json.dumps(scenes), encoding="utf-8")
+
+    scene_1_path = tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_1.md"
+    scene_1_path.parent.mkdir(parents=True, exist_ok=True)
+    scene_1_path.write_text("Scene 1 actual prose from disk.", encoding="utf-8")
+
+    recap_1_path = (
+        tmp_path / "test-story" / "chapters" / "chapter_1" / "scene_1_actual_recap.txt"
+    )
+    recap_1_path.write_text("DISK_RECAP_ONE", encoding="utf-8")
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_scene_critique=False, enable_scrubbing=False),
+            state=state,
+        )
+
+    assert len(captured) == 2
+    assert "DISK_RECAP_ONE" in captured[0]
+    assert "PREDICTED_ENDING" not in captured[0]
+    assert "Scene 2 prose body." in draft.content
+
+
 def test_extract_json_array_filters_non_dict_entries() -> None:
     payload = '[{"title": "A"}, "stray string", 42, {"title": "B"}]'
     assert _extract_json_array(payload) == [{"title": "A"}, {"title": "B"}]
@@ -522,7 +707,9 @@ async def test_scene_pipeline_calls_assemble_context_per_scene(tmp_path: Path) -
             "Synopsis text.",
             f"```json\n{scenes_payload}\n```",
             "Scene A prose.",
+            "Scene A actual recap.",
             "Scene B prose.",
+            "Scene B actual recap.",
         ]
     )
 
@@ -580,8 +767,10 @@ async def test_scene_critique_fires_and_revises_when_findings_returned(
             "Scene 1 draft prose.",
             '{"outline_adherence": ["missing: hero meets villain"]}',
             "Scene 1 revised prose with hero meets villain.",
+            "Scene 1 actual recap.",
             "Scene 2 draft prose.",
             "{}",
+            "Scene 2 actual recap.",
         ]
     )
 
@@ -607,7 +796,7 @@ async def test_scene_critique_fires_and_revises_when_findings_returned(
             _settings(enable_scene_critique=True, enable_scrubbing=False),
         )
 
-    assert len(captured) == 7
+    assert len(captured) == 9
     assert any("Scene Critique" in prompt for prompt in captured)
     assert any("Scene Revision" in prompt for prompt in captured)
     assert "Scene 1 revised prose with hero meets villain." in draft.content
@@ -628,6 +817,7 @@ async def test_scene_critique_bypasses_revision_when_findings_empty(
             f"```json\n{scenes_payload}\n```",
             "Scene 1 clean draft prose.",
             "{}",
+            "Scene 1 actual recap.",
         ]
     )
 
@@ -656,7 +846,7 @@ async def test_scene_critique_bypasses_revision_when_findings_empty(
             ),
         )
 
-    assert len(captured) == 4
+    assert len(captured) == 5
     assert any("Scene Critique" in prompt for prompt in captured)
     assert not any("Scene Revision" in prompt for prompt in captured)
     assert "Scene 1 clean draft prose." in draft.content
@@ -675,7 +865,9 @@ async def test_scene_critique_skipped_when_disabled(tmp_path: Path) -> None:
             "Detailed synopsis content for chapter 1.",
             f"```json\n{scenes_payload}\n```",
             "Scene 1 prose body.",
+            "Scene 1 actual recap.",
             "Scene 2 prose body.",
+            "Scene 2 actual recap.",
         ]
     )
 
@@ -700,7 +892,7 @@ async def test_scene_critique_skipped_when_disabled(tmp_path: Path) -> None:
             _settings(enable_scene_critique=False, enable_scrubbing=False),
         )
 
-    assert len(captured) == 4
+    assert len(captured) == 6
     assert not any("Scene Critique" in prompt for prompt in captured)
     assert not any("Scene Revision" in prompt for prompt in captured)
     assert "Scene 1 prose body." in draft.content
@@ -721,6 +913,7 @@ async def test_scene_critique_skipped_on_resume_when_scene_already_saved(
             json.dumps(scenes),
             "Scene 2 prose body.",
             "{}",
+            "Scene 2 actual recap.",
         ]
     )
     state = PipelineState(
@@ -759,7 +952,7 @@ async def test_scene_critique_skipped_on_resume_when_scene_already_saved(
             state=state,
         )
 
-    assert len(captured) == 4
+    assert len(captured) == 5
     assert captured[2].startswith("# Scene Critique") is False
     assert "Scene 1 prose from disk" in draft.content
     assert "Scene 2 prose body." in draft.content
@@ -784,6 +977,7 @@ async def test_scene_pipeline_falls_back_per_scene_when_scene_context_unavailabl
             "Synopsis text.",
             f"```json\n{scenes_payload}\n```",
             "Scene prose content.",
+            "Scene actual recap.",
         ]
     )
 


### PR DESCRIPTION
## Summary

Replaces the predicted `ending` field from scene decomposition JSON with a factual one-sentence recap of the actual written prose in `scenes_completed_summary`. This fixes a correctness bug where later scenes in a chapter received continuity context based on forecast outcomes rather than what was actually written, causing drift to compound scene-by-scene.

## Closes

Closes #386

## Changes

- `prompts/scenes/summarise_for_continuity.md` — new prompt that takes the last ~500 chars of a scene and returns ≤1 sentence describing what concretely happened
- `src/presentation/agents/chapter_writer.py` — after each scene is drafted and finalized (post-critique/scrub), calls LLM with the summarise prompt and caches result as `scene_{i}_actual_recap.txt`; `scenes_completed_summary` reads from cache when available, falls back to `done_scene["ending"]`; resume path reads cache from disk without a new LLM call
- `tests/unit/test_chapter_writer_scene_pipeline.py` — updated 8 existing tests for new per-scene recap call counts; added 3 new verification tests

## Plan

- [x] New prompt `prompts/scenes/summarise_for_continuity.md` with `{prose_excerpt}` variable
- [x] `_run_scene_pipeline()` writes `scene_{i}_actual_recap.txt` after each scene drafted
- [x] `scenes_completed_summary` reads from `scene_{i}_actual_recap.txt` when available
- [x] On resume, recap file read from disk — no new LLM call
- [x] Unit tests: recap file written, actual recap used in scene 2 prompt, resume uses cached recap

## Verification

21 tests passed, 0 failed
Lint: ✅ (ruff check, ruff format, mypy)