### PR TITLE
[P2] Run a decomposition critic before scene drafting begins

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -36,6 +36,7 @@ generation:
   scenes_per_chapter_max: 16
   enable_outline_critique: true
   enable_scene_critique: true
+  enable_decomposition_critique: true
   stream: true
   debug: true
   use_improved_recap_sanitizer: true

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,7 @@ generation:
   scenes_per_chapter_min: 8
   scenes_per_chapter_max: 16
   enable_outline_critique: false
+  enable_decomposition_critique: true
   stream: true
   debug: true
   use_improved_recap_sanitizer: true

--- a/prompts/chapters/critique_scene_decomposition.md
+++ b/prompts/chapters/critique_scene_decomposition.md
@@ -1,0 +1,123 @@
+Review the proposed chapter scene decomposition for clear structural problems only.
+
+## Inputs
+
+You will receive:
+- `{scene_array_json}`: JSON array of scene objects for one chapter
+- `{chapter_synopsis}`: synopsis the scenes are supposed to cover
+- `{known_character_slugs}`: comma-separated wiki character slugs, may be empty
+- `{known_location_slugs}`: comma-separated wiki location slugs, may be empty
+
+## Goal
+
+Find only concrete decomposition problems that would make scene drafting weaker or inconsistent.
+
+Be conservative:
+- Flag only clear structural violations
+- Do not flag stylistic preferences
+- Do not ask for richer prose, more atmosphere, or different wording
+- Do not invent missing facts unless the synopsis clearly requires them
+- If evidence is ambiguous, do not flag it
+
+## Checks
+
+Review the scene array against the synopsis for these issue types:
+
+### Overlap Pairs
+
+Flag pairs of scenes that cover the same beat, same confrontation, same reveal, same transition, or the same chunk of chapter timeline.
+
+Use this when two scenes materially overlap instead of advancing to a new part of the chapter.
+
+Output format:
+
+```json
+"overlap_pairs": [[0, 1, "both cover the opening confrontation"]]
+```
+
+### Missing POV
+
+Flag a scene when the synopsis clearly requires a viewpoint anchor or focal character, but the decomposition omits that character or makes the scene's viewpoint unclear.
+
+Use zero-based scene indexes.
+
+Output format:
+
+```json
+"missing_pov": [{"scene_index": 2, "character": "Elena"}]
+```
+
+### Duplicate Setting
+
+Flag adjacent or near-adjacent scenes that appear to duplicate the same setting without a meaningful progression in chapter time, purpose, or situation.
+
+Do not flag repeated settings when the synopsis clearly calls for multiple distinct beats in the same place.
+
+Output format:
+
+```json
+"duplicate_setting": [[1, 2, "Throne Room"]]
+```
+
+### Continuity Break
+
+Flag a scene when its opening state clearly contradicts where the prior scene leaves the chapter, or when the sequence breaks synopsis continuity.
+
+Output format:
+
+```json
+"continuity_break": [{"scene_index": 3, "reason": "Scene 3 opens with Amy at the cafe but scene 2 ends with her leaving for the airport"}]
+```
+
+## Wiki Hints
+
+Known character slugs: {known_character_slugs}
+
+Known location slugs: {known_location_slugs}
+
+Use these only as weak continuity hints. Do not require exact slug usage in the scene JSON. Their purpose is to help detect obvious missing or duplicated references when the synopsis clearly points to known characters or locations.
+
+## Chapter Synopsis
+
+{chapter_synopsis}
+
+## Scene Array JSON
+
+```json
+{scene_array_json}
+```
+
+## Output Rules
+
+Return a single JSON object only.
+
+Allowed keys:
+- `overlap_pairs`
+- `missing_pov`
+- `duplicate_setting`
+- `continuity_break`
+- `summary`
+
+Rules:
+- Omit any key with no findings
+- If there are no clear issues, return exactly `{}`
+- `summary` should be one short line describing overall severity only when at least one issue exists
+- Do not return markdown fences
+- Do not return prose before or after the JSON object
+
+## Example
+
+```json
+{
+  "overlap_pairs": [[0, 1, "both cover the opening confrontation"]],
+  "missing_pov": [{"scene_index": 2, "character": "Elena"}],
+  "duplicate_setting": [[1, 2, "Throne Room"]],
+  "continuity_break": [
+    {
+      "scene_index": 3,
+      "reason": "Scene 3 opens with Amy at the cafe but scene 2 ends with her leaving for the airport"
+    }
+  ],
+  "summary": "Several clear structural overlaps and continuity problems found."
+}
+```

--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -25,6 +25,7 @@ class GenerationSettings:
     enable_outline_critique: bool = True
     enable_concurrent_critics: bool = False
     enable_scene_critique: bool = True
+    enable_decomposition_critique: bool = True
 
     # Initial outline generation settings
     use_chunked_outline_generation: bool = (
@@ -104,6 +105,7 @@ class GenerationSettings:
             "scenes_per_chapter_max": self.scenes_per_chapter_max,
             "enable_outline_critique": self.enable_outline_critique,
             "enable_scene_critique": self.enable_scene_critique,
+            "enable_decomposition_critique": self.enable_decomposition_critique,
             "enable_concurrent_critics": self.enable_concurrent_critics,
             "stream": self.stream,
             "debug": self.debug,

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -92,6 +92,30 @@ def _extract_json_array(text: str) -> list[dict[str, Any]]:
     return [scene for scene in parsed if isinstance(scene, dict)]
 
 
+def _extract_json_object(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+
+    fence = re.search(r"```(?:json)?\s*(.*?)```", stripped, re.DOTALL)
+    if fence:
+        stripped = fence.group(1).strip()
+
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            parsed = json.loads(stripped[start : end + 1])
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return parsed
+
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 class ChapterWriterAgent:
     def __init__(
         self,
@@ -515,6 +539,126 @@ class ChapterWriterAgent:
                     f"\n[Chapter {chapter_number}] could not persist scene "
                     f"definitions ({type(exc).__name__}: {exc}); continuing.\n"
                 )
+
+            if settings.enable_decomposition_critique:
+                try:
+                    known_character_slugs: list[str] = []
+                    known_location_slugs: list[str] = []
+                    wiki_index_path = STORIES_DIR / story_name / "wiki" / "index.md"
+                    if wiki_index_path.exists():
+                        try:
+                            for raw_line in wiki_index_path.read_text(
+                                encoding="utf-8"
+                            ).splitlines():
+                                line = raw_line.strip()
+                                if not line:
+                                    continue
+                                parts = [part.strip() for part in line.split("|")]
+                                if len(parts) != 5:
+                                    raise ValueError(
+                                        f"Malformed wiki index line: {raw_line}"
+                                    )
+                                slug, entry_type, _name, _aliases, entry_path = parts
+                                if entry_type == "character":
+                                    known_character_slugs.append(slug)
+                                if entry_path.startswith("locations/"):
+                                    known_location_slugs.append(slug)
+                        except (OSError, ValueError) as exc:
+                            known_character_slugs = []
+                            known_location_slugs = []
+                            await self.bus.emit(
+                                f"\n[Chapter {chapter_number}] Decomposition critic "
+                                f"wiki index unavailable ({type(exc).__name__}: {exc}); "
+                                "using empty slug hints.\n"
+                            )
+
+                    critic_prompt = loader.load_prompt(
+                        "chapters/critique_scene_decomposition",
+                        variables={
+                            "scene_array_json": json.dumps(
+                                scenes, indent=2, ensure_ascii=False
+                            ),
+                            "chapter_synopsis": synopsis_text,
+                            "known_character_slugs": ", ".join(known_character_slugs),
+                            "known_location_slugs": ", ".join(known_location_slugs),
+                        },
+                    )
+                    critic_raw = await self._stream_to_bus(
+                        [
+                            {"role": "system", "content": critic_prompt},
+                            {
+                                "role": "user",
+                                "content": "Return the JSON findings object.",
+                            },
+                        ],
+                        synopsis_model,
+                        settings.seed,
+                    )
+                    findings = _extract_json_object(critic_raw)
+                    has_findings = any(key != "summary" for key in findings)
+
+                    if has_findings:
+                        await self.bus.emit(
+                            f"\n[Chapter {chapter_number}] Decomposition critic found issues; regenerating scenes.\n"
+                        )
+                        await self.status_bus.emit(
+                            StatusEvent(
+                                phase=phase,
+                                message=(
+                                    f"Ch {chapter_number}: regenerating scenes "
+                                    "(critic feedback)"
+                                ),
+                                kind="step",
+                            )
+                        )
+                        feedback_msg = (
+                            "The previous scene decomposition had the following "
+                            "structural issues:\n\n"
+                            + json.dumps(findings, indent=2, ensure_ascii=False)
+                            + "\n\nPlease regenerate the scene array, fixing all "
+                            "listed issues. Return ONLY the JSON array of scenes."
+                        )
+                        retry_raw = await self._stream_to_bus(
+                            [
+                                {"role": "system", "content": scenes_prompt},
+                                {"role": "user", "content": feedback_msg},
+                            ],
+                            synopsis_model,
+                            settings.seed,
+                        )
+                        retry_scenes = _extract_json_array(retry_raw)
+                        if (
+                            retry_scenes
+                            and scenes_min <= len(retry_scenes) <= scenes_max
+                        ):
+                            scenes = retry_scenes
+                            try:
+                                _atomic_write(
+                                    scenes_json_path,
+                                    json.dumps(scenes, indent=2, ensure_ascii=False),
+                                )
+                            except OSError as exc:
+                                await self.bus.emit(
+                                    f"\n[Chapter {chapter_number}] could not persist "
+                                    "critic-regenerated scenes "
+                                    f"({type(exc).__name__}: {exc}); continuing.\n"
+                                )
+                        else:
+                            retry_count = len(retry_scenes) if retry_scenes else 0
+                            await self.bus.emit(
+                                f"\n[Chapter {chapter_number}] Decomposition critic "
+                                "retry produced invalid scene output "
+                                f"({retry_count} scenes); proceeding with original decomposition.\n"
+                            )
+                    else:
+                        await self.bus.emit(
+                            f"\n[Chapter {chapter_number}] Decomposition critic: no issues found.\n"
+                        )
+                except Exception as exc:
+                    await self.bus.emit(
+                        f"\n[Chapter {chapter_number}] Decomposition critic failed "
+                        f"({type(exc).__name__}: {exc}); proceeding.\n"
+                    )
 
         # Stage 3: per-scene drafting.
         scene_prose: list[str] = []

--- a/tests/unit/test_chapter_writer_scene_pipeline.py
+++ b/tests/unit/test_chapter_writer_scene_pipeline.py
@@ -87,6 +87,27 @@ def _make_provider(responses: list[str]):
     return provider, captured_systems
 
 
+def _two_scenes() -> list[dict[str, object]]:
+    return [
+        {
+            "title": "Scene A",
+            "description": "First scene.",
+            "characters": ["Alice"],
+            "setting": "Forest",
+            "key_events": ["Alice arrives"],
+            "ending": "Alice rests",
+        },
+        {
+            "title": "Scene B",
+            "description": "Second scene.",
+            "characters": ["Alice"],
+            "setting": "Cave",
+            "key_events": ["Alice explores"],
+            "ending": "Alice escapes",
+        },
+    ]
+
+
 @pytest.mark.asyncio
 async def test_scene_pipeline_runs_three_stages_in_order(tmp_path: Path) -> None:
     """Synopsis → scene-array → per-scene calls happen in order with correct prompts."""
@@ -802,6 +823,165 @@ async def test_scene_critique_fires_and_revises_when_findings_returned(
     assert "Scene 1 revised prose with hero meets villain." in draft.content
     assert "Scene 1 draft prose." not in draft.content
     assert "Scene 2 draft prose." in draft.content
+
+
+@pytest.mark.asyncio
+async def test_decomposition_critic_clean_decomposition_no_retry(
+    tmp_path: Path,
+) -> None:
+    scenes_json_valid = json.dumps(_two_scenes())
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            scenes_json_valid,
+            "{}",
+            "Scene 1 prose body.",
+            "Scene 1 actual recap.",
+            "Scene 2 prose body.",
+            "Scene 2 actual recap.",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(
+                enable_decomposition_critique=True,
+                enable_scene_critique=False,
+                enable_scrubbing=False,
+            ),
+        )
+
+    assert len(captured) == 7
+    assert "decomposition" in captured[2].lower()
+    assert "Scene 1 prose body." in draft.content
+    assert "Scene 2 prose body." in draft.content
+
+
+@pytest.mark.asyncio
+async def test_decomposition_critic_findings_triggers_one_retry(
+    tmp_path: Path,
+) -> None:
+    scenes_json_valid = json.dumps(_two_scenes())
+    retry_scenes = [
+        {
+            "title": "Retry Scene A",
+            "description": "Reworked first scene.",
+            "characters": ["Alice"],
+            "setting": "Forest",
+            "key_events": ["Alice arrives carefully"],
+            "ending": "Alice regroups",
+        },
+        {
+            "title": "Retry Scene B",
+            "description": "Reworked second scene.",
+            "characters": ["Alice"],
+            "setting": "Cave",
+            "key_events": ["Alice explores deeper"],
+            "ending": "Alice escapes faster",
+        },
+    ]
+    scenes_json_retry = json.dumps(retry_scenes)
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            scenes_json_valid,
+            '{"overlap_pairs": [[0, 1, "both describe arrival"]], "summary": "overlap found"}',
+            scenes_json_retry,
+            "Retry scene 1 prose body.",
+            "Scene 1 actual recap.",
+            "Retry scene 2 prose body.",
+            "Scene 2 actual recap.",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(
+                enable_decomposition_critique=True,
+                enable_scene_critique=False,
+                enable_scrubbing=False,
+            ),
+        )
+
+    assert len(captured) == 8
+    assert "Retry scene 1 prose body." in draft.content
+    assert "Retry scene 2 prose body." in draft.content
+
+
+@pytest.mark.asyncio
+async def test_decomposition_critic_disabled_skips_critic(tmp_path: Path) -> None:
+    scenes_json_valid = json.dumps(_two_scenes())
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            scenes_json_valid,
+            "Scene 1 prose body.",
+            "Scene 1 actual recap.",
+            "Scene 2 prose body.",
+            "Scene 2 actual recap.",
+        ]
+    )
+
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+
+    with patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path):
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(
+                enable_decomposition_critique=False,
+                enable_scene_critique=False,
+                enable_scrubbing=False,
+            ),
+        )
+
+    assert len(captured) == 6
+    assert "Scene 1 prose body." in draft.content
+    assert "Scene 2 prose body." in draft.content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a structural quality gate between scene decomposition and per-scene drafting. After the scene count is validated and persisted, a new LLM critic evaluates the decomposition for overlap pairs, missing POV characters, duplicate settings, and continuity breaks. If findings exist, the decomposition is regenerated once with the findings as feedback. The pipeline never blocks — all errors are caught and logged, and the original decomposition is kept as fallback.

## Closes

Closes #387

## Changes

- **`prompts/chapters/critique_scene_decomposition.md`** — New critic prompt. Receives `scene_array_json`, `chapter_synopsis`, `known_character_slugs`, `known_location_slugs`. Returns structured JSON findings object or `{}` if clean.
- **`src/presentation/agents/chapter_writer.py`** — Added `_extract_json_object()` helper and decomposition critic block inside `_run_scene_pipeline()` (inside `else` branch, after savepoint write, before Stage 3).
- **`src/domain/value_objects/generation_settings.py`** — Added `enable_decomposition_critique: bool = True` field + `to_dict()` entry.
- **`config.example.yml`** / **`config.yml`** — Added `enable_decomposition_critique: true`.
- **`tests/unit/test_chapter_writer_scene_pipeline.py`** — 3 new tests: clean path (no retry), findings trigger one retry, toggle disabled skips critic.

## Acceptance Criteria

- [x] `prompts/chapters/critique_scene_decomposition.md` created with structured JSON output.
- [x] `_run_scene_pipeline()` runs decomposition critic after count validation.
- [x] On findings, reruns decomposition once with findings as feedback; result re-validated for count.
- [x] POV character names cross-referenced against wiki `index.md` slugs (best-effort; warn, don't fail).
- [x] Toggle: `generation.enable_decomposition_critique` (default `true`).
- [x] Unit test: critic finding triggers one decomposition retry.
- [x] Unit test: clean decomposition proceeds without retry.

## Verification

```
3 passed in 0.07s
ruff: All checks passed
mypy: Success: no issues found in 66 source files
```