### PR TITLE
[P2] Extract stable style-guide block separate from story_elements

### DIFF
--- a/prompts/multistep/scene/create_content_final.md
+++ b/prompts/multistep/scene/create_content_final.md
@@ -9,6 +9,11 @@ Use the context provided below as your sole source of truth for setting, charact
 {story_elements}
 </STORY_ELEMENTS>
 
+## Style Guide
+<STYLE_GUIDE>
+{style_guide}
+</STYLE_GUIDE>
+
 ## Base Context (Wiki Snapshot — Characters, Settings, Lore)
 <BASE_CONTEXT>
 {base_context}

--- a/prompts/multistep/scene/create_content_first.md
+++ b/prompts/multistep/scene/create_content_first.md
@@ -9,6 +9,11 @@ Use the context provided below as your sole source of truth for setting, charact
 {story_elements}
 </STORY_ELEMENTS>
 
+## Style Guide
+<STYLE_GUIDE>
+{style_guide}
+</STYLE_GUIDE>
+
 ## Base Context (Wiki Snapshot — Characters, Settings, Lore)
 <BASE_CONTEXT>
 {base_context}

--- a/prompts/multistep/scene/create_content_middle.md
+++ b/prompts/multistep/scene/create_content_middle.md
@@ -9,6 +9,11 @@ Use the context provided below as your sole source of truth for setting, charact
 {story_elements}
 </STORY_ELEMENTS>
 
+## Style Guide
+<STYLE_GUIDE>
+{style_guide}
+</STYLE_GUIDE>
+
 ## Base Context (Wiki Snapshot — Characters, Settings, Lore)
 <BASE_CONTEXT>
 {base_context}

--- a/prompts/story/extract_style_guide.md
+++ b/prompts/story/extract_style_guide.md
@@ -1,0 +1,46 @@
+# Extract Style Guide
+
+You are a story-writing assistant. Read the story prompt below and extract a compact, reusable style guide.
+
+<PROMPT>
+{prompt}
+</PROMPT>
+
+Extract ONLY prose-style rules — not plot, not character backgrounds, not setting descriptions.
+
+Focus on:
+- **Banned words and phrases**: Any words, constructions, or cliches explicitly prohibited
+- **POV rules**: Point of view (first/third person, limited/omniscient, whose perspective)
+- **Voice and register**: Tone, tense, sentence rhythm, formality level
+- **Non-negotiable world rules**: Hard facts about the world that must appear consistently (e.g. "magic is always painful", "no technology above medieval level")
+- **Formatting rules**: Chapter length targets, scene break conventions, dialogue formatting
+
+If a category has no rules, omit it entirely.
+
+Format your response as a compact markdown document, ≤300 words total. Use short bullet points. No prose padding.
+
+<EXAMPLE>
+## Banned Phrases
+- "like a knife through butter"
+- "her heart skipped a beat"
+- Ellipsis for dramatic pause (use em-dash instead)
+
+## POV
+- Deep third-person limited, Emma's perspective only
+- No head-hopping within a scene
+
+## Voice
+- Present tense throughout
+- Short declarative sentences; fragments allowed for effect
+- Sardonic register; avoid sentimentality
+
+## World Rules
+- Magic requires blood sacrifice; always painful
+- No character knows the true name of the antagonist
+
+## Formatting
+- Scenes: 500–800 words
+- Chapter endings: always on an unresolved beat
+</EXAMPLE>
+
+Return only the style guide document. No preamble, no explanation.

--- a/src/application/pipeline/handoffs.py
+++ b/src/application/pipeline/handoffs.py
@@ -45,6 +45,7 @@ class OutlineResult:
     title: str = ""
     tags: list[str] = field(default_factory=list)
     savepoint_id: str | None = None
+    style_guide: str = ""
 
 
 @dataclass
@@ -152,6 +153,7 @@ class PipelineState:
     evolved_sheets: dict[str, Any] = field(default_factory=dict)
     completed_work_items: dict[str, list[str]] = field(default_factory=dict)
     status: str = "running"
+    style_guide: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict for savepoint persistence.
@@ -187,6 +189,14 @@ class PipelineState:
                     content,
                 )
 
+        style_guide_val = d.get("style_guide", "")
+        if isinstance(style_guide_val, str) and style_guide_val:
+            d["style_guide"] = persist_markdown(
+                story_root,
+                "style_guide.md",
+                style_guide_val,
+            )
+
         return d
 
     @classmethod
@@ -218,6 +228,7 @@ class PipelineState:
                 base_context=outline_data.get("base_context", ""),
                 story_start_date=outline_data.get("story_start_date", ""),
                 story_elements=outline_data.get("story_elements", ""),
+                style_guide=outline_data.get("style_guide", ""),
                 chapter_skeletons=outline_data.get("chapter_skeletons", []),
                 chapter_details=outline_data.get("chapter_details", []),
                 enrichment_suggestions=outline_data.get("enrichment_suggestions", ""),
@@ -264,6 +275,7 @@ class PipelineState:
             evolved_sheets=data.get("evolved_sheets", {}),
             status=data.get("status", "running"),
             completed_work_items=data.get("completed_work_items", {}),
+            style_guide=_resolve(data.get("style_guide", "")),
         )
 
     def to_json(self) -> str:

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -383,6 +383,10 @@ class ChapterWriterAgent:
         critical step fails so the caller can fall back to single-shot
         drafting.
         """
+        style_guide: str = state.style_guide if state is not None else ""
+        if isinstance(style_guide, dict):
+            style_guide = ""
+
         loader = self._loader
         synopsis_model = _build_model_config(
             self.config, "chapter_outline_writer", "openai-compat://default"
@@ -789,6 +793,7 @@ class ChapterWriterAgent:
                     "previous_scene_tail": prev_tail,
                     "scenes_completed_summary": scenes_completed_summary,
                     "scene_recap_context": scene_recap_context,
+                    "style_guide": style_guide,
                 },
             )
             try:

--- a/src/presentation/agents/story_foundation.py
+++ b/src/presentation/agents/story_foundation.py
@@ -99,6 +99,12 @@ class StoryFoundationAgent:
             model_config,
             settings,
         )
+        style_guide = await self._generate_section(
+            "story/extract_style_guide",
+            story_prompt,
+            model_config,
+            settings,
+        )
 
         return OutlineResult(
             story_name=story_name,
@@ -109,4 +115,5 @@ class StoryFoundationAgent:
             base_context=base_context,
             story_start_date=story_start_date,
             story_elements=story_elements,
+            style_guide=style_guide,
         )

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -722,6 +722,16 @@ async def _continue_pipeline(
                 )
             elif isinstance(foundation_result.story_elements, dict):
                 state.outline_result.story_elements = foundation_result.story_elements
+            if (
+                isinstance(foundation_result.style_guide, str)
+                and foundation_result.style_guide
+            ):
+                persist_markdown(
+                    story_dir,
+                    "style_guide.md",
+                    foundation_result.style_guide,
+                )
+                state.style_guide = foundation_result.style_guide
             await _mark_phase_complete(
                 state,
                 "story-foundation",

--- a/tests/unit/test_style_guide_injection.py
+++ b/tests/unit/test_style_guide_injection.py
@@ -1,0 +1,227 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import OutlineResult, PipelineState
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.chapter_writer import ChapterWriterAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+def _settings(**overrides: object) -> GenerationSettings:
+    base = {
+        "wanted_chapters": 1,
+        "seed": 42,
+        "scene_generation_pipeline": True,
+        "scenes_per_chapter_min": 1,
+        "scenes_per_chapter_max": 1,
+        "enable_scene_critique": False,
+        "enable_decomposition_critique": False,
+        "enable_scrubbing": False,
+    }
+    base.update(overrides)
+    return GenerationSettings(**base)
+
+
+def _outline_result() -> OutlineResult:
+    return OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[
+            {
+                "chapter_number": 1,
+                "title": "Chapter 1",
+                "summary": "Chapter 1 summary",
+            }
+        ],
+        summary="Story summary",
+        genre="fantasy",
+        themes=["courage"],
+    )
+
+
+def _make_provider(responses: list[str]) -> MagicMock:
+    provider = MagicMock()
+    response_iter = iter(responses)
+
+    async def fake_stream(messages, model_config, seed=None):
+        try:
+            text = next(response_iter)
+        except StopIteration:
+            text = ""
+        yield text
+
+    provider.stream_text = fake_stream
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_pipeline_state_style_guide_round_trip(tmp_path: Path) -> None:
+    style_guide = "## Voice\n- First person only\n\n## Banned\n- Ellipsis"
+    state = PipelineState(
+        story_name="test-style-guide",
+        current_phase="init",
+        style_guide=style_guide,
+    )
+
+    with patch("tools._io.STORIES_DIR", tmp_path):
+        payload = state.to_dict()
+        round_tripped = PipelineState.from_dict(payload)
+
+    assert payload["style_guide"] == {"$ref": "style_guide.md"}
+    assert round_tripped.style_guide.startswith("## Voice")
+    assert round_tripped.style_guide == style_guide
+
+
+def test_pipeline_state_style_guide_defaults_to_empty() -> None:
+    state = PipelineState.from_dict({"story_name": "test", "current_phase": "init"})
+
+    assert state.style_guide == ""
+
+
+def test_pipeline_state_style_guide_loads_from_dict() -> None:
+    style_guide = "## Voice\n- First person only"
+    state = PipelineState.from_dict(
+        {
+            "story_name": "test",
+            "current_phase": "init",
+            "style_guide": style_guide,
+        }
+    )
+
+    assert state.style_guide == style_guide
+
+
+@pytest.mark.asyncio
+async def test_chapter_writer_injects_style_guide_into_scene_variables(
+    tmp_path: Path,
+) -> None:
+    captured_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_load_prompt(prompt_key: str, variables: dict[str, object]) -> str:
+        captured_calls.append((prompt_key, dict(variables)))
+        return f"PROMPT::{prompt_key}"
+
+    provider = _make_provider(
+        [
+            "Expanded synopsis.",
+            json.dumps([{"title": "Scene 1", "description": "Opening beat"}]),
+            "Scene 1 prose.",
+            "Actual scene recap.",
+        ]
+    )
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+    agent._loader.load_prompt = fake_load_prompt
+    state = PipelineState(
+        story_name="test-story",
+        current_phase="chapters",
+        style_guide="## Voice\n- First person",
+    )
+
+    with (
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+        patch(
+            "presentation.agents.chapter_writer.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
+        chapter_text = await agent._run_scene_pipeline(
+            story_name="test-story",
+            chapter_number=1,
+            chapter_title="Chapter 1",
+            chapter_summary="Chapter 1 summary",
+            story_elements="Story elements",
+            base_context="Base context",
+            next_chapter_summary="",
+            settings=_settings(),
+            state=state,
+        )
+
+    scene_prompt_calls = [
+        variables
+        for prompt_key, variables in captured_calls
+        if prompt_key.startswith("multistep/scene/create_content")
+    ]
+    assert chapter_text
+    assert scene_prompt_calls
+    assert any(
+        variables.get("style_guide") == "## Voice\n- First person"
+        for variables in scene_prompt_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_chapter_writer_style_guide_empty_when_state_none(
+    tmp_path: Path,
+) -> None:
+    captured_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_load_prompt(prompt_key: str, variables: dict[str, object]) -> str:
+        captured_calls.append((prompt_key, dict(variables)))
+        return f"PROMPT::{prompt_key}"
+
+    provider = _make_provider(
+        [
+            "Expanded synopsis.",
+            json.dumps([{"title": "Scene 1", "description": "Opening beat"}]),
+            "Scene 1 prose.",
+            "Actual scene recap.",
+        ]
+    )
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+    agent._loader.load_prompt = fake_load_prompt
+
+    with (
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+        patch(
+            "presentation.agents.chapter_writer.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
+        chapter_text = await agent._run_scene_pipeline(
+            story_name="test-story",
+            chapter_number=1,
+            chapter_title="Chapter 1",
+            chapter_summary="Chapter 1 summary",
+            story_elements="Story elements",
+            base_context="Base context",
+            next_chapter_summary="",
+            settings=_settings(),
+            state=None,
+        )
+
+    scene_prompt_calls = [
+        variables
+        for prompt_key, variables in captured_calls
+        if prompt_key.startswith("multistep/scene/create_content")
+    ]
+    assert chapter_text
+    assert scene_prompt_calls
+    assert any(variables.get("style_guide") == "" for variables in scene_prompt_calls)


### PR DESCRIPTION
## Summary

Adds a compact, static style guide artifact generated during the story-foundation phase. The guide (≤300 words) extracts prose-style rules from the story prompt — banned phrases, POV rules, voice register, world rules, formatting rules — and injects them as a dedicated `{style_guide}` block into every scene prompt, separate from the large `{story_elements}` narrative-context document.

## Closes
Closes #388

## Changes
- [x] `prompts/story/extract_style_guide.md` — new extraction prompt
- [x] `OutlineResult.style_guide` field — staging field for return from `StoryFoundationAgent`
- [x] `PipelineState.style_guide` field — persisted as `$ref` markdown file, resolved on load
- [x] `StoryFoundationAgent` generates style guide as 4th foundation section
- [x] Orchestrator persists `style_guide.md` and sets `state.style_guide`
- [x] `ChapterWriterAgent._run_scene_pipeline()` reads `state.style_guide`, injects as `"style_guide"` variable
- [x] All three scene prompts (`create_content_first/middle/final.md`) gain `<STYLE_GUIDE>{style_guide}</STYLE_GUIDE>` block
- [x] `{style_guide}` defaults to empty string when not yet generated (graceful)
- [x] 5 unit tests: round-trip persistence, defaults, injection present/absent

## Plan

### Infrastructure
None — no ChromaDB schema changes required.

### Implementation
1. `prompts/story/extract_style_guide.md` — extraction prompt with `{prompt}` variable
2. `src/application/pipeline/handoffs.py` — `style_guide` field on `OutlineResult` and `PipelineState`; `to_dict()` persists as `$ref`; `from_dict()` resolves via `_resolve()`
3. `src/presentation/agents/story_foundation.py` — 4th `_generate_section` call; returned on `OutlineResult.style_guide`
4. `src/presentation/orchestrator.py` — persists `style_guide.md`, sets `state.style_guide`
5. `src/presentation/agents/chapter_writer.py` — reads from `state`, injects into scene variables dict
6. Three scene prompts — `<STYLE_GUIDE>` block after `</STORY_ELEMENTS>`

### Verification
- `tests/unit/test_style_guide_injection.py` — 5 tests, all passing
- ruff ✅ mypy ✅