### PR TITLE
feat(scene): surface literary_devices as explicit prompt instruction

### DIFF
--- a/prompts/multistep/scene/create_content_final.md
+++ b/prompts/multistep/scene/create_content_final.md
@@ -54,6 +54,12 @@ Your scene must begin in continuity with this — same characters, same time-flo
 {current_scene_summary}
 </SCENE_OUTLINE>
 
+## Literary Devices to Apply
+<LITERARY_DEVICES>
+{literary_devices}
+</LITERARY_DEVICES>
+Incorporate these devices naturally in your prose for this scene.
+
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)
 - **Output**: Only the scene content — no commentary, metadata, or summaries

--- a/prompts/multistep/scene/create_content_first.md
+++ b/prompts/multistep/scene/create_content_first.md
@@ -37,6 +37,12 @@ This is scene {scene_index} of {scene_total} — the **opening scene**. No prior
 {current_scene_summary}
 </SCENE_OUTLINE>
 
+## Literary Devices to Apply
+<LITERARY_DEVICES>
+{literary_devices}
+</LITERARY_DEVICES>
+Incorporate these devices naturally in your prose for this scene.
+
 ## Next Scene (for transition only — do not write into it)
 <NEXT_SCENE_OUTLINE>
 {next_scene_summary}

--- a/prompts/multistep/scene/create_content_middle.md
+++ b/prompts/multistep/scene/create_content_middle.md
@@ -49,6 +49,12 @@ Your scene must begin in continuity with this — same characters, same time-flo
 {current_scene_summary}
 </SCENE_OUTLINE>
 
+## Literary Devices to Apply
+<LITERARY_DEVICES>
+{literary_devices}
+</LITERARY_DEVICES>
+Incorporate these devices naturally in your prose for this scene.
+
 ## Next Scene (for transition only — do not write into it)
 <NEXT_SCENE_OUTLINE>
 {next_scene_summary}

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -786,10 +786,28 @@ class ChapterWriterAgent:
                 scene_word_target, settings.scene_word_target_ceiling
             )
 
+            _raw_devices = (
+                scene.get("literary_devices", []) if isinstance(scene, dict) else []
+            )
+            if isinstance(_raw_devices, list):
+                literary_devices_str = "\n".join(f"- {d}" for d in _raw_devices)
+            elif isinstance(_raw_devices, str) and _raw_devices:
+                literary_devices_str = f"- {_raw_devices}"
+            else:
+                literary_devices_str = ""
+
+            scene_for_summary = (
+                {k: v for k, v in scene.items() if k != "literary_devices"}
+                if isinstance(scene, dict)
+                else scene
+            )
+
             scene_prompt = loader.load_prompt(
                 scene_prompt_key,
                 variables={
-                    "current_scene_summary": json.dumps(scene, ensure_ascii=False),
+                    "current_scene_summary": json.dumps(
+                        scene_for_summary, ensure_ascii=False
+                    ),
                     "next_scene_summary": next_scene_summary,
                     "base_context": scene_base_context,
                     "story_elements": story_elements,
@@ -805,6 +823,7 @@ class ChapterWriterAgent:
                     "scene_recap_context": scene_recap_context,
                     "scene_word_target": str(scene_word_target),
                     "style_guide": style_guide,
+                    "literary_devices": literary_devices_str,
                 },
             )
             try:

--- a/tests/unit/test_literary_devices_injection.py
+++ b/tests/unit/test_literary_devices_injection.py
@@ -1,0 +1,208 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import OutlineResult, PipelineState
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.chapter_writer import ChapterWriterAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+def _settings(**overrides: object) -> GenerationSettings:
+    base = {
+        "wanted_chapters": 1,
+        "seed": 42,
+        "scene_generation_pipeline": True,
+        "scenes_per_chapter_min": 1,
+        "scenes_per_chapter_max": 1,
+        "enable_scene_critique": False,
+        "enable_decomposition_critique": False,
+        "enable_scrubbing": False,
+    }
+    base.update(overrides)
+    return GenerationSettings(**base)
+
+
+def _outline_result() -> OutlineResult:
+    return OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[
+            {
+                "chapter_number": 1,
+                "title": "Chapter 1",
+                "summary": "Chapter 1 summary",
+            }
+        ],
+        summary="Story summary",
+        genre="fantasy",
+        themes=["courage"],
+    )
+
+
+def _make_provider(responses: list[str]) -> MagicMock:
+    provider = MagicMock()
+    response_iter = iter(responses)
+
+    async def fake_stream(messages, model_config, seed=None):
+        try:
+            text = next(response_iter)
+        except StopIteration:
+            text = ""
+        yield text
+
+    provider.stream_text = fake_stream
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_literary_devices_list_formats_as_bullets(tmp_path: Path) -> None:
+    captured_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_load_prompt(prompt_key: str, variables: dict[str, object]) -> str:
+        captured_calls.append((prompt_key, dict(variables)))
+        return f"PROMPT::{prompt_key}"
+
+    provider = _make_provider(
+        [
+            "Expanded synopsis.",
+            json.dumps(
+                [
+                    {
+                        "title": "Scene 1",
+                        "description": "Opening beat",
+                        "literary_devices": [
+                            "dramatic irony",
+                            "anaphora",
+                            "unreliable narrator signal",
+                        ],
+                    }
+                ]
+            ),
+            "Scene 1 prose.",
+            "Actual scene recap.",
+        ]
+    )
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+    agent._loader.load_prompt = fake_load_prompt
+    state = PipelineState(
+        story_name="test-story",
+        current_phase="chapters",
+    )
+
+    with (
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+        patch(
+            "presentation.agents.chapter_writer.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
+        chapter_text = await agent._run_scene_pipeline(
+            story_name="test-story",
+            chapter_number=1,
+            chapter_title="Chapter 1",
+            chapter_summary="Chapter 1 summary",
+            story_elements="Story elements",
+            base_context="Base context",
+            next_chapter_summary="",
+            settings=_settings(),
+            state=state,
+        )
+
+    scene_prompt_calls = [
+        variables
+        for prompt_key, variables in captured_calls
+        if prompt_key.startswith("multistep/scene/create_content")
+    ]
+
+    assert chapter_text
+    assert scene_prompt_calls
+    assert all(
+        variables["literary_devices"]
+        == "- dramatic irony\n- anaphora\n- unreliable narrator signal"
+        for variables in scene_prompt_calls
+    )
+    assert all(
+        "literary_devices" not in json.loads(str(variables["current_scene_summary"]))
+        for variables in scene_prompt_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_literary_devices_absent_produces_empty_string(tmp_path: Path) -> None:
+    captured_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_load_prompt(prompt_key: str, variables: dict[str, object]) -> str:
+        captured_calls.append((prompt_key, dict(variables)))
+        return f"PROMPT::{prompt_key}"
+
+    provider = _make_provider(
+        [
+            "Expanded synopsis.",
+            json.dumps([{"title": "Scene 1", "description": "Opening beat"}]),
+            "Scene 1 prose.",
+            "Actual scene recap.",
+        ]
+    )
+    agent = ChapterWriterAgent(
+        provider,
+        {
+            "models": {
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        },
+        TokenStreamBus(),
+        WikiContextBus(),
+    )
+    agent._loader.load_prompt = fake_load_prompt
+    state = PipelineState(
+        story_name="test-story",
+        current_phase="chapters",
+    )
+
+    with (
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+        patch(
+            "presentation.agents.chapter_writer.assemble_context",
+            return_value={"wiki_snapshot": "", "recap_snippets": []},
+        ),
+    ):
+        chapter_text = await agent._run_scene_pipeline(
+            story_name="test-story",
+            chapter_number=1,
+            chapter_title="Chapter 1",
+            chapter_summary="Chapter 1 summary",
+            story_elements="Story elements",
+            base_context="Base context",
+            next_chapter_summary="",
+            settings=_settings(),
+            state=state,
+        )
+
+    scene_prompt_calls = [
+        variables
+        for prompt_key, variables in captured_calls
+        if prompt_key.startswith("multistep/scene/create_content")
+    ]
+
+    assert chapter_text
+    assert scene_prompt_calls
+    assert all(variables["literary_devices"] == "" for variables in scene_prompt_calls)


### PR DESCRIPTION
## Summary

Extracts `literary_devices` from the scene JSON in `ChapterWriterAgent._run_scene_pipeline()` and surfaces it as a dedicated `{literary_devices}` variable in all three scene draft prompts. Previously, the field was buried inside the `{current_scene_summary}` JSON blob and rarely acted upon by the model.

## Closes
Closes #391

## Changes
- **`src/presentation/agents/chapter_writer.py`**: Extracts `literary_devices` from scene dict before building prompt variables. Normalises list → bullet lines (`"- device\n- device"`), string → single bullet, absent/empty → empty string. Excludes `literary_devices` from the JSON serialised into `current_scene_summary` to avoid duplication.
- **`prompts/multistep/scene/create_content_first.md`**: Adds `## Literary Devices to Apply` block with `<LITERARY_DEVICES>{literary_devices}</LITERARY_DEVICES>` and directive after `</SCENE_OUTLINE>`.
- **`prompts/multistep/scene/create_content_middle.md`**: Same addition.
- **`prompts/multistep/scene/create_content_final.md`**: Same addition.
- **`tests/unit/test_literary_devices_injection.py`**: Two unit tests — list of 3 devices produces 3-bullet string; absent key produces empty string without error.

## Verification
- [ ] Implementation complete
- [x] All new tests passing (2/2)
- [x] Linting clean (`ruff`, `mypy`)

## Plan
**Affected Areas:** Python domain logic, Prompt templates. No ChromaDB schema change.

**Task Checklist:**
- [x] Extract `literary_devices` in `_run_scene_pipeline()`, normalise list/string/absent → bullet string
- [x] Build `scene_for_summary` excluding `literary_devices` key
- [x] Add `"literary_devices"` to prompt variables dict
- [x] Update `create_content_first.md` with `<LITERARY_DEVICES>` block
- [x] Update `create_content_middle.md` with `<LITERARY_DEVICES>` block
- [x] Update `create_content_final.md` with `<LITERARY_DEVICES>` block
- [x] Write `test_literary_devices_list_formats_as_bullets`
- [x] Write `test_literary_devices_absent_produces_empty_string`
