### PR TITLE
feat(scene-pipeline): beat-sheet planning stage + living scene plan (#392)

### DIFF
--- a/prompts/multistep/scene/create_beat_sheet.md
+++ b/prompts/multistep/scene/create_beat_sheet.md
@@ -1,0 +1,72 @@
+# Create an Internal Beat-Sheet for a Scene
+
+You are preparing an internal structural scaffold for a fiction scene.
+
+This output is for the prose writer only. It is **not** reader-facing prose. Do **not** write the scene itself. Do **not** write polished narration. Produce a compact working plan the prose writer can follow.
+
+## Chapter Context
+- Chapter {chapter_number}: "{chapter_title}"
+- Scene {scene_index} of {scene_total}
+
+## Chapter Outline
+<CHAPTER_OUTLINE>
+{chapter_summary}
+</CHAPTER_OUTLINE>
+
+## Current Scene
+<CURRENT_SCENE>
+{current_scene_summary}
+</CURRENT_SCENE>
+
+## Next Scene
+<NEXT_SCENE>
+{next_scene_summary}
+</NEXT_SCENE>
+
+## Previous Scene Tail
+<PREVIOUS_SCENE_TAIL>
+{previous_scene_tail}
+</PREVIOUS_SCENE_TAIL>
+
+## Scenes Already Completed
+<SCENES_COMPLETED>
+{scenes_completed_summary}
+</SCENES_COMPLETED>
+
+## Recent Story Recap
+<SCENE_RECAP_CONTEXT>
+{scene_recap_context}
+</SCENE_RECAP_CONTEXT>
+
+## Literary Devices
+<LITERARY_DEVICES>
+{literary_devices}
+</LITERARY_DEVICES>
+
+## Task
+Build an internal beat-sheet for this scene that gives the prose writer a strong structural plan.
+
+Include:
+- 5 to 10 sequential beats
+- pacing notes for where to compress or linger
+- placement of the key emotional or plot turn
+- POV anchors: what the viewpoint character notices, misreads, wants, or avoids
+- a suggested opening line or opening image
+
+## Output Format
+Return a compact structured plan using clear headings and bullet points.
+
+Required sections:
+- Opening Anchor
+- Beat List
+- Pacing Notes
+- Key Moment Placement
+- POV Anchors
+- Device Reminders
+
+## Constraints
+- This is a scaffold, not prose
+- Keep it compact, concrete, and practical
+- Do not include meta-commentary about your process
+- Do not restate the entire chapter outline
+- Do not write full scene paragraphs

--- a/prompts/multistep/scene/create_content_final.md
+++ b/prompts/multistep/scene/create_content_final.md
@@ -60,6 +60,8 @@ Your scene must begin in continuity with this — same characters, same time-flo
 </LITERARY_DEVICES>
 Incorporate these devices naturally in your prose for this scene.
 
+{beat_sheet_section}
+
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)
 - **Output**: Only the scene content — no commentary, metadata, or summaries

--- a/prompts/multistep/scene/create_content_first.md
+++ b/prompts/multistep/scene/create_content_first.md
@@ -48,6 +48,8 @@ Incorporate these devices naturally in your prose for this scene.
 {next_scene_summary}
 </NEXT_SCENE_OUTLINE>
 
+{beat_sheet_section}
+
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)
 - **Output**: Only the scene content — no commentary, metadata, or summaries

--- a/prompts/multistep/scene/create_content_middle.md
+++ b/prompts/multistep/scene/create_content_middle.md
@@ -60,6 +60,8 @@ Incorporate these devices naturally in your prose for this scene.
 {next_scene_summary}
 </NEXT_SCENE_OUTLINE>
 
+{beat_sheet_section}
+
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)
 - **Output**: Only the scene content — no commentary, metadata, or summaries

--- a/prompts/multistep/scene/update_remaining_scenes.md
+++ b/prompts/multistep/scene/update_remaining_scenes.md
@@ -1,0 +1,43 @@
+# Update Remaining Scene Plans After Drafting
+
+You are revising the remaining scene plan for a chapter after one scene has now been drafted.
+
+Adjust the remaining scene entries to account for what actually happened in the completed scene.
+
+## Completed Scene Title
+<COMPLETED_SCENE_TITLE>
+{completed_scene_title}
+</COMPLETED_SCENE_TITLE>
+
+## Completed Scene Recap
+<COMPLETED_SCENE_RECAP>
+{completed_scene_recap}
+</COMPLETED_SCENE_RECAP>
+
+## Chapter Outline
+<CHAPTER_OUTLINE>
+{chapter_summary}
+</CHAPTER_OUTLINE>
+
+## Remaining Scenes JSON
+<REMAINING_SCENES_JSON>
+{remaining_scenes_json}
+</REMAINING_SCENES_JSON>
+
+## Task
+Revise each remaining scene so it stays aligned with the chapter outline while reflecting what actually happened in the completed scene.
+
+For each remaining scene, update only the fields that need adjustment based on the new reality:
+- `summary`
+- `key_events`
+- `ending`
+
+Preserve the existing array order and keep the same overall structure as the input.
+
+## Output Rules
+- Return ONLY a valid JSON array
+- No markdown fences
+- No commentary
+- No prose before or after the JSON
+- The array length must remain exactly the same as the input
+- Each item must remain an object with the same structure as the corresponding input item

--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -28,6 +28,8 @@ class GenerationSettings:
     enable_concurrent_critics: bool = False
     enable_scene_critique: bool = True
     enable_decomposition_critique: bool = True
+    enable_beat_sheet: bool = False
+    enable_living_scene_plan: bool = False
 
     # Initial outline generation settings
     use_chunked_outline_generation: bool = (
@@ -123,6 +125,8 @@ class GenerationSettings:
             "enable_outline_critique": self.enable_outline_critique,
             "enable_scene_critique": self.enable_scene_critique,
             "enable_decomposition_critique": self.enable_decomposition_critique,
+            "enable_beat_sheet": self.enable_beat_sheet,
+            "enable_living_scene_plan": self.enable_living_scene_plan,
             "enable_concurrent_critics": self.enable_concurrent_critics,
             "stream": self.stream,
             "debug": self.debug,

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -802,6 +802,67 @@ class ChapterWriterAgent:
                 else scene
             )
 
+            beat_sheet_section = ""
+            if settings.enable_beat_sheet:
+                await self.status_bus.emit(
+                    StatusEvent(
+                        phase=phase,
+                        message=(
+                            f"Ch {chapter_number}: planning beat-sheet for scene "
+                            f"{index}/{total_scenes}"
+                        ),
+                        kind="step",
+                    )
+                )
+                await self.bus.emit(
+                    f"\n[Chapter {chapter_number}] Planning beat-sheet for scene {index}...\n"
+                )
+                beat_sheet_prompt = loader.load_prompt(
+                    "multistep/scene/create_beat_sheet",
+                    variables={
+                        "chapter_number": str(chapter_number),
+                        "chapter_title": chapter_title,
+                        "chapter_summary": chapter_summary,
+                        "scene_index": str(index),
+                        "scene_total": str(total_scenes),
+                        "current_scene_summary": json.dumps(
+                            scene_for_summary, ensure_ascii=False
+                        ),
+                        "next_scene_summary": next_scene_summary,
+                        "previous_scene_tail": prev_tail,
+                        "scenes_completed_summary": scenes_completed_summary,
+                        "scene_recap_context": scene_recap_context,
+                        "literary_devices": literary_devices_str,
+                    },
+                )
+                try:
+                    beat_sheet_raw = await self._stream_to_bus(
+                        [
+                            {"role": "system", "content": beat_sheet_prompt},
+                            {
+                                "role": "user",
+                                "content": "Produce the beat-sheet now.",
+                            },
+                        ],
+                        scene_model,
+                        settings.seed,
+                    )
+                    beat_sheet_raw = beat_sheet_raw.strip()
+                    if beat_sheet_raw:
+                        beat_sheet_section = (
+                            "\n\n## Scene Beat-Sheet (Internal Planning Notes — Do Not Copy Verbatim)\n"
+                            "<BEAT_SHEET>\n"
+                            f"{beat_sheet_raw}\n"
+                            "</BEAT_SHEET>\n"
+                            "Use these beats as your structural scaffold. The prose you write must "
+                            "flow naturally — do not copy beat labels into the text."
+                        )
+                except Exception as exc:
+                    await self.bus.emit(
+                        f"\n[Chapter {chapter_number}] scene {index} beat-sheet failed "
+                        f"({type(exc).__name__}: {exc}); continuing without beat-sheet.\n"
+                    )
+
             scene_prompt = loader.load_prompt(
                 scene_prompt_key,
                 variables={
@@ -824,6 +885,7 @@ class ChapterWriterAgent:
                     "scene_word_target": str(scene_word_target),
                     "style_guide": style_guide,
                     "literary_devices": literary_devices_str,
+                    "beat_sheet_section": beat_sheet_section,
                 },
             )
             try:
@@ -1017,6 +1079,67 @@ class ChapterWriterAgent:
                 scene_file.parent.mkdir(parents=True, exist_ok=True)
                 _atomic_write(scene_file, scene_text)
                 await _mark_work_item_done(state, phase, scene_item_id)
+
+            if settings.enable_living_scene_plan and index < total_scenes:
+                await self.status_bus.emit(
+                    StatusEvent(
+                        phase=phase,
+                        message=(
+                            f"Ch {chapter_number}: updating remaining scene plans "
+                            f"after scene {index}/{total_scenes}"
+                        ),
+                        kind="step",
+                    )
+                )
+                await self.bus.emit(
+                    f"\n[Chapter {chapter_number}] Updating remaining scene plans after scene {index}...\n"
+                )
+                remaining_scenes = scenes[index:]
+                completed_recap = actual_recaps.get(index, scene_text[-300:].strip())
+                update_prompt = loader.load_prompt(
+                    "multistep/scene/update_remaining_scenes",
+                    variables={
+                        "completed_scene_title": scene.get("title", f"Scene {index}"),
+                        "completed_scene_recap": completed_recap,
+                        "chapter_summary": chapter_summary,
+                        "remaining_scenes_json": json.dumps(
+                            remaining_scenes, ensure_ascii=False, indent=2
+                        ),
+                    },
+                )
+                try:
+                    updated_json_text = await self._stream_to_bus(
+                        [
+                            {"role": "system", "content": update_prompt},
+                            {
+                                "role": "user",
+                                "content": "Return the updated scenes JSON array now.",
+                            },
+                        ],
+                        scene_model,
+                        settings.seed,
+                    )
+                    updated_json_text = updated_json_text.strip()
+                    if updated_json_text.startswith("```"):
+                        lines = updated_json_text.splitlines()
+                        updated_json_text = "\n".join(
+                            line for line in lines if not line.startswith("```")
+                        ).strip()
+                    updated_remaining = json.loads(updated_json_text)
+                    if isinstance(updated_remaining, list) and len(
+                        updated_remaining
+                    ) == len(remaining_scenes):
+                        scenes[index:] = updated_remaining
+                        scenes_json_path.parent.mkdir(parents=True, exist_ok=True)
+                        _atomic_write(
+                            scenes_json_path,
+                            json.dumps(scenes, ensure_ascii=False, indent=2),
+                        )
+                except Exception as exc:
+                    await self.bus.emit(
+                        f"\n[Chapter {chapter_number}] living scene plan update after scene {index} "
+                        f"failed ({type(exc).__name__}: {exc}); continuing with original plans.\n"
+                    )
 
         if not scene_prose:
             return ""

--- a/tests/unit/test_living_scene_plan.py
+++ b/tests/unit/test_living_scene_plan.py
@@ -1,0 +1,327 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import OutlineResult
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.chapter_writer import ChapterWriterAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+def _make_provider(responses: list[str]) -> tuple[object, list[str]]:
+    captured: list[str] = []
+
+    class _Prov:
+        async def stream_text(self, messages, model_config, seed=None):
+            captured.append(messages[0]["content"])
+            yield responses.pop(0)
+
+    return _Prov(), captured
+
+
+def _settings(**kwargs: object) -> GenerationSettings:
+    base = {
+        "wanted_chapters": 1,
+        "seed": 1,
+        "scene_generation_pipeline": True,
+        "scenes_per_chapter_min": 3,
+        "scenes_per_chapter_max": 3,
+        "enable_outline_critique": False,
+        "enable_scene_critique": False,
+        "enable_decomposition_critique": False,
+        "enable_scrubbing": False,
+    }
+    base.update(kwargs)
+    return GenerationSettings(**base)
+
+
+def _outline_result() -> OutlineResult:
+    return OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[
+            {
+                "chapter_number": 1,
+                "title": "Ch1",
+                "summary": "summary",
+            }
+        ],
+        summary="Story summary",
+        genre="fantasy",
+        themes=["courage"],
+    )
+
+
+def _render_prompt(prompt_key: str, *, variables: dict[str, object]) -> str:
+    return json.dumps(
+        {"prompt_key": prompt_key, "variables": variables},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _three_scenes() -> list[dict[str, object]]:
+    return [
+        {
+            "title": "S1",
+            "description": "d1",
+            "summary": "summary1",
+            "key_events": ["e1"],
+            "ending": "end1",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc1",
+        },
+        {
+            "title": "S2",
+            "description": "d2",
+            "summary": "summary2",
+            "key_events": ["e2"],
+            "ending": "end2",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc2",
+        },
+        {
+            "title": "S3",
+            "description": "d3",
+            "summary": "summary3",
+            "key_events": ["e3"],
+            "ending": "end3",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc3",
+        },
+    ]
+
+
+def _two_scenes() -> list[dict[str, object]]:
+    return _three_scenes()[:2]
+
+
+@pytest.fixture(autouse=True)
+def _stub_wiki(monkeypatch):
+    monkeypatch.setattr(
+        "presentation.agents.chapter_writer.assemble_context",
+        lambda *a, **kw: {
+            "wiki_snapshot": "## Stub Wiki Context",
+            "recap_snippets": [],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_living_plan_disabled_default(tmp_path: Path) -> None:
+    original_scenes = _three_scenes()
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            json.dumps(original_scenes),
+            "scene one prose",
+            "Scene 1 recap.",
+            "scene two prose",
+            "Scene 2 recap.",
+            "scene three prose",
+            "Scene 3 recap.",
+        ]
+    )
+    scenes_json_path = tmp_path / "test-story" / "chapters" / "chapter_1_scenes.json"
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(
+            provider,
+            {
+                "models": {
+                    "chapter_outline_writer": "openai-compat://test",
+                    "scene_writer": "openai-compat://test",
+                }
+            },
+            TokenStreamBus(),
+            WikiContextBus(),
+        )
+        draft = await agent.run("test-story", 1, _outline_result(), _settings())
+
+    parsed_prompts = [json.loads(prompt) for prompt in captured]
+    persisted_scenes = json.loads(scenes_json_path.read_text(encoding="utf-8"))
+
+    assert "scene one prose" in draft.content
+    assert "scene two prose" in draft.content
+    assert "scene three prose" in draft.content
+    assert len(captured) == 8
+    assert all(
+        prompt["prompt_key"] != "multistep/scene/update_remaining_scenes"
+        for prompt in parsed_prompts
+    )
+    assert persisted_scenes == original_scenes
+
+
+@pytest.mark.asyncio
+async def test_living_plan_enabled_updates_remaining(tmp_path: Path) -> None:
+    original_scenes = _three_scenes()
+    updated_after_scene_1 = [
+        {
+            "title": "S2",
+            "description": "d2 revised after scene 1",
+            "summary": "summary2 revised after scene 1",
+            "key_events": ["e2 revised"],
+            "ending": "end2 revised after scene 1",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc2",
+        },
+        {
+            "title": "S3",
+            "description": "d3 revised after scene 1",
+            "summary": "summary3 revised after scene 1",
+            "key_events": ["e3 revised after scene 1"],
+            "ending": "end3 revised after scene 1",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc3",
+        },
+    ]
+    updated_after_scene_2 = [
+        {
+            "title": "S3",
+            "description": "d3 revised after scene 2",
+            "summary": "summary3 revised after scene 2",
+            "key_events": ["e3 revised after scene 2"],
+            "ending": "end3 revised after scene 2",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc3",
+        }
+    ]
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            json.dumps(original_scenes),
+            "scene one prose",
+            "Scene 1 recap.",
+            json.dumps(updated_after_scene_1),
+            "scene two prose",
+            "Scene 2 recap.",
+            json.dumps(updated_after_scene_2),
+            "scene three prose",
+            "Scene 3 recap.",
+        ]
+    )
+    scenes_json_path = tmp_path / "test-story" / "chapters" / "chapter_1_scenes.json"
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(
+            provider,
+            {
+                "models": {
+                    "chapter_outline_writer": "openai-compat://test",
+                    "scene_writer": "openai-compat://test",
+                }
+            },
+            TokenStreamBus(),
+            WikiContextBus(),
+        )
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_living_scene_plan=True),
+        )
+
+    parsed_prompts = [json.loads(prompt) for prompt in captured]
+    prompt_keys = [prompt["prompt_key"] for prompt in parsed_prompts]
+    persisted_scenes = json.loads(scenes_json_path.read_text(encoding="utf-8"))
+
+    assert "scene one prose" in draft.content
+    assert "scene two prose" in draft.content
+    assert "scene three prose" in draft.content
+    assert len(captured) == 10
+    assert prompt_keys == [
+        "chapters/create_synopsis",
+        "chapters/expand_to_scenes",
+        "multistep/scene/create_content_first",
+        "scenes/summarise_for_continuity",
+        "multistep/scene/update_remaining_scenes",
+        "multistep/scene/create_content_middle",
+        "scenes/summarise_for_continuity",
+        "multistep/scene/update_remaining_scenes",
+        "multistep/scene/create_content_final",
+        "scenes/summarise_for_continuity",
+    ]
+    assert persisted_scenes[0] == original_scenes[0]
+    assert persisted_scenes[1] == updated_after_scene_1[0]
+    assert persisted_scenes[2] == updated_after_scene_2[0]
+
+
+@pytest.mark.asyncio
+async def test_living_plan_bad_json_does_not_abort(tmp_path: Path) -> None:
+    original_scenes = _two_scenes()
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            json.dumps(original_scenes),
+            "scene one prose",
+            "Scene 1 recap.",
+            "not json at all",
+            "scene two prose",
+            "Scene 2 recap.",
+        ]
+    )
+    scenes_json_path = tmp_path / "test-story" / "chapters" / "chapter_1_scenes.json"
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(
+            provider,
+            {
+                "models": {
+                    "chapter_outline_writer": "openai-compat://test",
+                    "scene_writer": "openai-compat://test",
+                }
+            },
+            TokenStreamBus(),
+            WikiContextBus(),
+        )
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(
+                enable_living_scene_plan=True,
+                scenes_per_chapter_min=2,
+                scenes_per_chapter_max=2,
+            ),
+        )
+
+    parsed_prompts = [json.loads(prompt) for prompt in captured]
+    persisted_scenes = json.loads(scenes_json_path.read_text(encoding="utf-8"))
+
+    assert "scene one prose" in draft.content
+    assert "scene two prose" in draft.content
+    assert len(captured) == 7
+    assert (
+        sum(
+            1
+            for prompt in parsed_prompts
+            if prompt["prompt_key"] == "multistep/scene/update_remaining_scenes"
+        )
+        == 1
+    )
+    assert persisted_scenes == original_scenes

--- a/tests/unit/test_scene_beat_sheet.py
+++ b/tests/unit/test_scene_beat_sheet.py
@@ -1,0 +1,281 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import OutlineResult
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.chapter_writer import ChapterWriterAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+def _make_provider(responses: list[str]) -> tuple[object, list[str]]:
+    captured: list[str] = []
+
+    class _Prov:
+        async def stream_text(self, messages, model_config, seed=None):
+            captured.append(messages[0]["content"])
+            yield responses.pop(0)
+
+    return _Prov(), captured
+
+
+def _settings(**kwargs: object) -> GenerationSettings:
+    base = {
+        "wanted_chapters": 1,
+        "seed": 1,
+        "scene_generation_pipeline": True,
+        "scenes_per_chapter_min": 2,
+        "scenes_per_chapter_max": 2,
+        "enable_outline_critique": False,
+        "enable_scene_critique": False,
+        "enable_decomposition_critique": False,
+        "enable_scrubbing": False,
+    }
+    base.update(kwargs)
+    return GenerationSettings(**base)
+
+
+def _outline_result() -> OutlineResult:
+    return OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[
+            {
+                "chapter_number": 1,
+                "title": "Ch1",
+                "summary": "summary",
+            }
+        ],
+        summary="Story summary",
+        genre="fantasy",
+        themes=["courage"],
+    )
+
+
+def _render_prompt(prompt_key: str, *, variables: dict[str, object]) -> str:
+    return json.dumps(
+        {"prompt_key": prompt_key, "variables": variables},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _two_scenes() -> list[dict[str, object]]:
+    return [
+        {
+            "title": "S1",
+            "description": "d1",
+            "key_events": ["e1"],
+            "ending": "end1",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc",
+        },
+        {
+            "title": "S2",
+            "description": "d2",
+            "key_events": ["e2"],
+            "ending": "end2",
+            "literary_devices": [],
+            "characters": [],
+            "setting": "loc",
+        },
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _stub_wiki(monkeypatch):
+    monkeypatch.setattr(
+        "presentation.agents.chapter_writer.assemble_context",
+        lambda *a, **kw: {
+            "wiki_snapshot": "## Stub Wiki Context",
+            "recap_snippets": [],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_beat_sheet_disabled_default(tmp_path: Path) -> None:
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            json.dumps(_two_scenes()),
+            "scene one prose",
+            "Scene 1 recap.",
+            "scene two prose",
+            "Scene 2 recap.",
+        ]
+    )
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(
+            provider,
+            {
+                "models": {
+                    "chapter_outline_writer": "openai-compat://test",
+                    "scene_writer": "openai-compat://test",
+                }
+            },
+            TokenStreamBus(),
+            WikiContextBus(),
+        )
+        draft = await agent.run("test-story", 1, _outline_result(), _settings())
+
+    parsed_prompts = [json.loads(prompt) for prompt in captured]
+    prose_prompts = [
+        prompt
+        for prompt in parsed_prompts
+        if prompt["prompt_key"].startswith("multistep/scene/create_content")
+    ]
+
+    assert "scene one prose" in draft.content
+    assert "scene two prose" in draft.content
+    assert len(captured) == 6
+    assert all(
+        prompt["prompt_key"] != "multistep/scene/create_beat_sheet"
+        for prompt in parsed_prompts
+    )
+    assert prose_prompts
+    assert all(
+        prompt["variables"]["beat_sheet_section"] == "" for prompt in prose_prompts
+    )
+
+
+@pytest.mark.asyncio
+async def test_beat_sheet_enabled_makes_extra_calls(tmp_path: Path) -> None:
+    provider, captured = _make_provider(
+        [
+            "synopsis text",
+            json.dumps(_two_scenes()),
+            "beat sheet one",
+            "scene one prose",
+            "Scene 1 recap.",
+            "beat sheet two",
+            "scene two prose",
+            "Scene 2 recap.",
+        ]
+    )
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(
+            provider,
+            {
+                "models": {
+                    "chapter_outline_writer": "openai-compat://test",
+                    "scene_writer": "openai-compat://test",
+                }
+            },
+            TokenStreamBus(),
+            WikiContextBus(),
+        )
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_beat_sheet=True),
+        )
+
+    parsed_prompts = [json.loads(prompt) for prompt in captured]
+    prompt_keys = [prompt["prompt_key"] for prompt in parsed_prompts]
+    prose_prompts = [
+        prompt
+        for prompt in parsed_prompts
+        if prompt["prompt_key"].startswith("multistep/scene/create_content")
+    ]
+
+    assert "scene one prose" in draft.content
+    assert "scene two prose" in draft.content
+    assert len(captured) == 8
+    assert prompt_keys == [
+        "chapters/create_synopsis",
+        "chapters/expand_to_scenes",
+        "multistep/scene/create_beat_sheet",
+        "multistep/scene/create_content_first",
+        "scenes/summarise_for_continuity",
+        "multistep/scene/create_beat_sheet",
+        "multistep/scene/create_content_final",
+        "scenes/summarise_for_continuity",
+    ]
+    assert (
+        prose_prompts[0]["variables"]["beat_sheet_section"].count("<BEAT_SHEET>") == 1
+    )
+    assert "beat sheet one" in prose_prompts[0]["variables"]["beat_sheet_section"]
+    assert (
+        prose_prompts[1]["variables"]["beat_sheet_section"].count("<BEAT_SHEET>") == 1
+    )
+    assert "beat sheet two" in prose_prompts[1]["variables"]["beat_sheet_section"]
+
+
+@pytest.mark.asyncio
+async def test_beat_sheet_error_does_not_abort_scene(tmp_path: Path) -> None:
+    captured: list[str] = []
+    responses = [
+        "synopsis text",
+        json.dumps(_two_scenes()),
+        "scene one prose",
+        "Scene 1 recap.",
+        "scene two prose",
+        "Scene 2 recap.",
+    ]
+
+    class _Prov:
+        def __init__(self) -> None:
+            self._call_count = 0
+
+        async def stream_text(self, messages, model_config, seed=None):
+            self._call_count += 1
+            captured.append(messages[0]["content"])
+            if self._call_count in {3, 6}:
+                raise RuntimeError("beat sheet failed")
+            yield responses.pop(0)
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader_cls.return_value.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(
+            _Prov(),
+            {
+                "models": {
+                    "chapter_outline_writer": "openai-compat://test",
+                    "scene_writer": "openai-compat://test",
+                }
+            },
+            TokenStreamBus(),
+            WikiContextBus(),
+        )
+        draft = await agent.run(
+            "test-story",
+            1,
+            _outline_result(),
+            _settings(enable_beat_sheet=True),
+        )
+
+    parsed_prompts = [json.loads(prompt) for prompt in captured]
+    prose_prompts = [
+        prompt
+        for prompt in parsed_prompts
+        if prompt["prompt_key"].startswith("multistep/scene/create_content")
+    ]
+
+    assert "scene one prose" in draft.content
+    assert "scene two prose" in draft.content
+    assert len(captured) == 8
+    assert all(
+        prompt["variables"]["beat_sheet_section"] == "" for prompt in prose_prompts
+    )


### PR DESCRIPTION
## Summary

Two new opt-in architectural improvements to the scene-building workflow. Both features default to `False` — zero behaviour change for existing pipelines unless explicitly enabled.

## Closes
Closes #392

## Changes

### Idea A — Two-stage plan-then-draft (beat-sheet)
- New flag: `GenerationSettings.enable_beat_sheet: bool = False`
- When enabled: each scene runs a pre-draft LLM call using `prompts/multistep/scene/create_beat_sheet.md`, producing a compact internal plan (beats, pacing notes, key-moment placement, POV anchors, suggested opening line)
- Beat-sheet text is injected into the prose prompt via `{beat_sheet_section}` in all three `create_content_*.md` templates
- Failure is non-fatal: if the beat-sheet call errors, scene drafting continues without it

### Idea B — Living scene plan
- New flag: `GenerationSettings.enable_living_scene_plan: bool = False`
- When enabled: after each scene is drafted (and persisted), an update LLM call using `prompts/multistep/scene/update_remaining_scenes.md` revises the `summary`, `key_events`, and `ending` fields of all remaining scene plans based on what actually happened
- Updated scenes are persisted back to `chapter_N_scenes.json` atomically
- Only fires when remaining scenes exist (`index < total_scenes`)
- Failure is non-fatal: bad JSON or exception leaves original plans intact

## Files Changed
- `src/domain/value_objects/generation_settings.py` — 2 new flags + to_dict
- `src/presentation/agents/chapter_writer.py` — beat-sheet stage + living plan update in `_run_scene_pipeline()`
- `prompts/multistep/scene/create_beat_sheet.md` — new beat-sheet prompt
- `prompts/multistep/scene/update_remaining_scenes.md` — new living plan update prompt
- `prompts/multistep/scene/create_content_{first,middle,final}.md` — `{beat_sheet_section}` injection point added
- `tests/unit/test_scene_beat_sheet.py` — 3 tests (disabled/enabled/error)
- `tests/unit/test_living_scene_plan.py` — 3 tests (disabled/enabled/error)

## Verification
- [ ] Implementation complete
- [x] All 6 new tests passing
- [x] Linting clean (ruff check + format)
- [x] mypy src/ — no issues