### PR TITLE
feat(config): enable beat-sheet and living scene plan by default (#401)

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -37,6 +37,8 @@ generation:
   enable_outline_critique: true
   enable_scene_critique: true
   enable_decomposition_critique: true
+  enable_beat_sheet: true
+  enable_living_scene_plan: true
   stream: true
   debug: true
   use_improved_recap_sanitizer: true

--- a/config.yml
+++ b/config.yml
@@ -36,6 +36,8 @@ generation:
   scenes_per_chapter_max: 16
   enable_outline_critique: false
   enable_decomposition_critique: true
+  enable_beat_sheet: true
+  enable_living_scene_plan: true
   stream: true
   debug: true
   use_improved_recap_sanitizer: true


### PR DESCRIPTION
## Summary

Completes the two scene-pipeline improvements from #392 (PR #400) by exposing and enabling both new flags in the config files.

## Closes
Closes #401

## Changes
- `config.yml`: add `enable_beat_sheet: true` and `enable_living_scene_plan: true`
- `config.example.yml`: same

Both flags were implemented in PR #400 but defaulted to `False` with no config entry, making them inaccessible without code changes.

## Verification
- [x] Linting clean
- [x] mypy src/ — no issues