### PR TITLE
feat(persona): persona document schema and generation prompt template

### DIFF
--- a/prompts/persona/_schema.md
+++ b/prompts/persona/_schema.md
@@ -1,0 +1,79 @@
+# Author Persona Schema
+
+This document defines the Markdown output contract for the `persona/generate` prompt.
+
+## Frontmatter
+
+The document must begin with a YAML frontmatter block.
+
+| Field | Type | Constraints | Notes |
+| --- | --- | --- | --- |
+| `genre` | string | Required, non-empty | Broad shelf/category label |
+| `subgenre` | string | Required, non-empty | More specific narrative mode or market positioning |
+| `pov` | string | Required, non-empty | Narrative point of view, such as `First person` or `Third person limited` |
+| `tense` | string | Required, non-empty | Dominant narrative tense |
+| `created_at` | string | Required, ISO 8601 timestamp | Generation timestamp |
+
+## Section Order
+
+The body must appear in this order:
+
+| Order | Section | Target length | Coverage |
+| --- | --- | --- | --- |
+| 1 | `## Identity` | 50-100 words | Concise overall author stance in second person |
+| 2 | `## Prose Texture` | 30-60 words | Sentence length, vocabulary register, sensory emphasis, metaphor habit |
+| 3 | `## Dialogue Style` | 30-60 words | Register, subtext level, attribution style, idiom |
+| 4 | `## Pacing Philosophy` | 30-60 words | Scene-to-summary ratio, action density, introspection density |
+| 5 | `## Thematic Sensibility` | 30-60 words | Preoccupations, moral framework, what the author never does |
+| 6 | `## Narrative Philosophy` | 30-60 words | POV stance, interiority depth, conflict approach, resolution style |
+| 7 | `## Anti-Patterns` | 5-10 bullets | Specific things the author avoids |
+
+## Section Rules
+
+- All prose sections must use second person.
+- `## Identity` must be one paragraph.
+- Each trait section should be one compact paragraph.
+- Trait sections describe stable craft habits, not plot events or character facts.
+- Total target length is driven by the prompt variable `{{word_budget}}`, with default 225 and valid range 100-500.
+
+## Anti-Patterns Format
+
+`## Anti-Patterns` must use Markdown bullet points.
+
+- Use 5-10 bullets.
+- Keep each bullet short and directive.
+- Phrase each bullet as a negative rule or avoidance pattern.
+- Focus on stylistic or narrative behaviors the author specifically avoids.
+
+## Example Skeleton
+
+```md
+---
+genre: Mystery
+subgenre: Psychological mystery
+pov: First person
+tense: Present
+created_at: 2026-05-08T12:00:00Z
+---
+
+## Identity
+You write...
+
+## Prose Texture
+You favour...
+
+## Dialogue Style
+You write...
+
+## Pacing Philosophy
+You prefer...
+
+## Thematic Sensibility
+You return to...
+
+## Narrative Philosophy
+You keep...
+
+## Anti-Patterns
+- Do not...
+```

--- a/prompts/persona/generate.md
+++ b/prompts/persona/generate.md
@@ -1,0 +1,106 @@
+<!--
+SCHEMA
+
+Required output: one Markdown document only. No preamble. No commentary. No code fences.
+
+Frontmatter keys:
+- genre: string
+- subgenre: string
+- pov: string
+- tense: string
+- created_at: ISO 8601 timestamp
+
+Required section order:
+1. ## Identity
+2. ## Prose Texture
+3. ## Dialogue Style
+4. ## Pacing Philosophy
+5. ## Thematic Sensibility
+6. ## Narrative Philosophy
+7. ## Anti-Patterns
+
+Section constraints:
+- Identity: 50-100 words, second person
+- Each trait section: 30-60 words, second person
+- Anti-Patterns: 5-10 short bullet rules
+- Total target length: {{word_budget}} words (default 225; valid range 100-500)
+-->
+
+You are converting story analysis into a compact Author Persona document. Synthesize recurring craft choices. Infer stable author habits, not one-off plot facts. Write as if describing the author's enduring creative stance.
+
+Use second-person prose throughout the body text: "You write...", "You favour...", "You avoid...".
+
+Return only the final Markdown document. Do not add commentary. Do not wrap the document in code fences.
+
+Length target: approximately {{word_budget}} words total. Stay within the spirit of that budget while preserving all required sections. `{{word_budget}}` defaults to 225 when not otherwise specified, and valid values fall within 100 to 500.
+
+Process requirements:
+- Read all four analysis chunks before writing.
+- Reconcile overlaps into one coherent author stance.
+- Prefer concrete craft language over vague praise.
+- Do not mention the source chunks, analysis process, or story title unless needed for genre/subgenre accuracy.
+- Do not invent biography, publishing history, audience claims, or external influences.
+- Keep the document reusable as a style guide for future drafting.
+
+Required output contract:
+- Start with YAML frontmatter containing exactly these keys: genre, subgenre, pov, tense, created_at.
+- After frontmatter, write one `## Identity` paragraph of 50-100 words in second person.
+- Then write the five required trait sections, each 30-60 words.
+- End with `## Anti-Patterns` containing 5-10 short bullet rules describing what this author specifically avoids.
+- `created_at` must be an ISO 8601 timestamp.
+- All body sections must be written in clear second-person prose.
+
+Required section guidance:
+- `## Prose Texture`: sentence length tendencies, vocabulary register, sensory emphasis, metaphor habit.
+- `## Dialogue Style`: spoken register, subtext level, attribution style, idiom.
+- `## Pacing Philosophy`: scene-to-summary ratio, action density, introspection density.
+- `## Thematic Sensibility`: recurring preoccupations, moral framework, what this author never does.
+- `## Narrative Philosophy`: POV stance, interiority depth, conflict approach, resolution style.
+
+Example output:
+---
+genre: Fantasy
+subgenre: Gothic coming-of-age fantasy
+pov: Third person limited
+tense: Past
+created_at: 2026-05-08T12:00:00Z
+---
+
+## Identity
+You write haunted coming-of-age stories that treat wonder as inseparable from cost. You favour intimate emotional framing, symbolic detail, and moral pressure that arrives through ordinary choices rather than speeches. You keep the narrative close to a character's private fear, then widen outward until personal longing exposes the shape of a larger social wound.
+
+## Prose Texture
+You favour supple sentences that alternate crisp observation with lyrical lift. Your vocabulary stays accessible but slightly elevated, and sensory detail leans tactile and atmospheric. When you use metaphor, it clarifies emotional temperature rather than calling attention to itself.
+
+## Dialogue Style
+You write dialogue with restraint and implication. Characters rarely say the full truth outright, so subtext carries emotional force. Attribution stays light and functional, with occasional gesture beats. Idiom feels local and character-bound rather than flashy or contemporary for its own sake.
+
+## Pacing Philosophy
+You prefer fully dramatized scenes over summary, but you compress transitions once emotional stakes are clear. Action arrives in sharp bursts instead of extended spectacle. Introspection is frequent and purposeful, usually embedded inside choice, aftermath, or mounting dread.
+
+## Thematic Sensibility
+You return to inheritance, duty, secrecy, and the price of mercy. Your moral framework resists easy innocence; choices matter, but context matters too. You do not mock sincere feeling, and you never reduce grief, love, or faith to cynical punchlines.
+
+## Narrative Philosophy
+You keep perspective intimate and ethically attentive. Interiority is deep enough to reveal contradiction without dissolving momentum. Conflict grows from incompatible needs more often than pure villainy. Resolutions tend toward earned ambiguity: enough closure to satisfy, enough residue to haunt.
+
+## Anti-Patterns
+- Do not use ironic detachment to undercut sincere emotion.
+- Do not rely on exposition blocks when a scene can carry the information.
+- Do not make metaphors so ornate that they obscure action.
+- Do not let dialogue sound interchangeable across characters.
+- Do not resolve moral tension with a neat sermon.
+
+Source analysis chunks:
+
+### Core Story Foundation
+{{core_story_foundation}}
+
+### Tone and Style
+{{tone_style}}
+
+### Theme and Message
+{{theme_message}}
+
+### Story Elements
+{{story_elements}}

--- a/tests/unit/test_persona_generate_prompt.py
+++ b/tests/unit/test_persona_generate_prompt.py
@@ -1,0 +1,85 @@
+"""Verification tests for issue #403 persona generation prompt template."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+PROMPTS_DIR = PROJECT_ROOT / "prompts"
+PERSONA_PROMPT = PROMPTS_DIR / "persona" / "generate.md"
+PERSONA_SCHEMA = PROMPTS_DIR / "persona" / "_schema.md"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from infrastructure.prompts.prompt_loader import PromptLoader
+
+
+def _loader() -> PromptLoader:
+    return PromptLoader(prompts_dir=str(PROMPTS_DIR))
+
+
+class TestPersonaGeneratePrompt:
+    def test_prompt_file_exists(self) -> None:
+        assert PERSONA_PROMPT.is_file()
+
+    def test_schema_file_exists(self) -> None:
+        assert PERSONA_SCHEMA.is_file()
+
+    def test_prompt_loads_without_error(self) -> None:
+        content = _loader().load_prompt("persona/generate")
+
+        assert content
+
+    def test_prompt_renders_all_variables(self) -> None:
+        content = _loader().load_prompt(
+            "persona/generate",
+            {
+                "core_story_foundation": "CF",
+                "tone_style": "TS",
+                "theme_message": "TM",
+                "story_elements": "SE",
+                "word_budget": 225,
+            },
+        )
+
+        assert "CF" in content
+        assert "TS" in content
+        assert "TM" in content
+        assert "SE" in content
+        assert "225" in content
+        assert "{{core_story_foundation}}" not in content
+
+    def test_prompt_contains_required_sections(self) -> None:
+        content = PERSONA_PROMPT.read_text(encoding="utf-8")
+
+        assert "## Identity" in content
+        assert "## Prose Texture" in content
+        assert "## Dialogue Style" in content
+        assert "## Pacing Philosophy" in content
+        assert "## Thematic Sensibility" in content
+        assert "## Narrative Philosophy" in content
+        assert "## Anti-Patterns" in content
+
+    def test_prompt_contains_word_budget_variable(self) -> None:
+        content = PERSONA_PROMPT.read_text(encoding="utf-8")
+
+        assert "{{word_budget}}" in content
+
+    def test_schema_documents_all_sections(self) -> None:
+        content = PERSONA_SCHEMA.read_text(encoding="utf-8")
+
+        assert "genre" in content
+        assert "subgenre" in content
+        assert "pov" in content
+        assert "tense" in content
+        assert "created_at" in content
+        assert "Identity" in content
+        assert "Prose Texture" in content
+        assert "Dialogue Style" in content
+        assert "Pacing Philosophy" in content
+        assert "Thematic Sensibility" in content
+        assert "Narrative Philosophy" in content
+        assert "Anti-Patterns" in content


### PR DESCRIPTION
## Summary

Implements the Author Persona generation prompt template and schema documentation — the foundational artefact required before the `persona-builder` tool can be built (Task 2 of the author persona system).

## Closes
Closes #403

## Changes
- [ ] `prompts/persona/generate.md` — LLM generation prompt with YAML frontmatter schema, all five template variables, Identity + five trait sections + Anti-Patterns output contract, `{{word_budget}}` length control, schema comment block, and a fictional example output to anchor the LLM
- [ ] `prompts/persona/_schema.md` — schema reference documenting frontmatter fields, section order/word targets, and Anti-Patterns bullet format
- [ ] `tests/unit/test_persona_generate_prompt.py` — 7 unit tests covering file existence, variable rendering, required sections, and schema documentation
- [ ] All tests passing (7/7 verified)
- [ ] Linting and formatting clean

## Plan

### Task 2 — Acceptance Criteria

- [x] `prompts/persona/generate.md` exists with all five template variables
- [x] Template instructs the LLM to produce YAML frontmatter + five trait sections + anti-patterns
- [x] `{{word_budget}}` substitution is present and drives the length instruction in the prompt body
- [x] Schema is documented in a header comment block in the template
- [x] Schema example output is included to anchor the LLM
