### PR TITLE
feat(persona): persona-builder tool — generate, get-view, regenerate

### DIFF
--- a/src/tools/persona_builder.py
+++ b/src/tools/persona_builder.py
@@ -1,0 +1,331 @@
+"""CLI tool for persona generation and view extraction."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+
+if TYPE_CHECKING:
+    from infrastructure.storage.savepoint_repository import (
+        FilesystemSavepointRepository,
+    )
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+_src_path = str(PROJECT_ROOT / "src")
+_root_path = str(PROJECT_ROOT)
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+if _root_path not in sys.path:
+    sys.path.insert(0, _root_path)
+
+from tools._io import STORIES_DIR, _validate_story_name  # noqa: E402
+
+REQUIRED_SECTIONS = [
+    "## Identity",
+    "## Prose Texture",
+    "## Dialogue Style",
+    "## Pacing Philosophy",
+    "## Thematic Sensibility",
+    "## Narrative Philosophy",
+    "## Anti-Patterns",
+]
+VALID_VIEWS = {"outline", "chapter", "scrubber", "editor"}
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n?", re.DOTALL)
+_SECTION_RE = re.compile(r"^(## [^\n]+)\n(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _make_repo(name: str) -> FilesystemSavepointRepository:
+    """Create a FilesystemSavepointRepository for the given story."""
+    from infrastructure.storage.savepoint_repository import (
+        FilesystemSavepointRepository,
+    )
+
+    story_dir = _validate_story_name(name, base_dir=STORIES_DIR)
+    repo = FilesystemSavepointRepository(base_path=story_dir)
+    repo.set_story_directory("savepoints")
+    return repo
+
+
+def _load_savepoint(repo: FilesystemSavepointRepository, step: str) -> Any:
+    """Load a savepoint, returning its data."""
+    return asyncio.run(repo.load_savepoint(step))
+
+
+def _save_savepoint(repo: FilesystemSavepointRepository, step: str, data: Any) -> None:
+    """Save data to a savepoint."""
+    asyncio.run(repo.save_savepoint(step, data))
+
+
+def _has_savepoint(repo: FilesystemSavepointRepository, step: str) -> bool:
+    """Check if a savepoint exists."""
+    return asyncio.run(repo.has_savepoint(step))
+
+
+def _load_prompt(prompt_id: str, variables: dict[str, Any] | None = None) -> str:
+    """Load and render a prompt template."""
+    from infrastructure.prompts.prompt_loader import PromptLoader
+
+    loader = PromptLoader(prompts_dir=str(PROJECT_ROOT / "prompts"))
+    return loader.load_prompt(prompt_id, variables)
+
+
+def _call_llm(prompt: str, *, model: str | None = None) -> str:
+    """Call LLM with a single prompt and return text response."""
+    from tools._llm import generate_text
+
+    return generate_text(prompt, model=model)
+
+
+def _success(operation: str, data: Any) -> None:
+    """Print success response and exit."""
+    print(
+        json.dumps(
+            {"status": "success", "operation": operation, "data": data},
+            indent=2,
+            default=str,
+        )
+    )
+
+
+def _error(message: str, data: Any | None = None, exit_code: int = 1) -> NoReturn:
+    """Print error to stderr and exit."""
+    if data is None:
+        print(f"Error: {message}", file=sys.stderr)
+    else:
+        print(
+            json.dumps(
+                {"status": "error", "operation": message, "data": data},
+                indent=2,
+                default=str,
+            ),
+            file=sys.stderr,
+        )
+    sys.exit(exit_code)
+
+
+def _validate_persona_doc(text: str) -> list[str]:
+    """Return persona document validation errors."""
+    errors: list[str] = []
+    if not text.startswith("---"):
+        errors.append("Missing YAML frontmatter at document start")
+    for heading in REQUIRED_SECTIONS:
+        if heading not in text:
+            errors.append(f"Missing required section: {heading}")
+    return errors
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Strip YAML frontmatter from the top of a document."""
+    return _FRONTMATTER_RE.sub("", text, count=1).strip()
+
+
+def _extract_sections(body: str) -> dict[str, str]:
+    """Extract level-two sections from a markdown body."""
+    sections: dict[str, str] = {}
+    for heading, content in _SECTION_RE.findall(body):
+        sections[heading] = content.strip()
+    return sections
+
+
+def _get_persona_dir(name: str) -> Path:
+    """Return the persona directory for a story."""
+    story_dir = _validate_story_name(name, base_dir=STORIES_DIR)
+    persona_dir = story_dir / "persona"
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    return persona_dir
+
+
+def cmd_generate(
+    name: str, *, model: str | None = None, word_budget: int = 225
+) -> None:
+    """Generate a persona document from outline analysis savepoints."""
+    from datetime import datetime, timezone
+
+    word_budget = max(100, min(500, word_budget))
+    repo = _make_repo(name)
+
+    savepoint_data: dict[str, str] = {}
+    for step_name in (
+        "core_story_foundation",
+        "tone_style",
+        "theme_message",
+        "story_elements",
+    ):
+        data = _load_savepoint(repo, step_name)
+        if data is None or data == "":
+            _error(
+                f"Missing required savepoint: {step_name}. Run outline analysis first."
+            )
+        if isinstance(data, str):
+            savepoint_data[step_name] = data
+        else:
+            savepoint_data[step_name] = json.dumps(data, default=str)
+
+    prompt = _load_prompt(
+        "persona/generate",
+        {
+            "word_budget": word_budget,
+            "core_story_foundation": savepoint_data["core_story_foundation"],
+            "tone_style": savepoint_data["tone_style"],
+            "theme_message": savepoint_data["theme_message"],
+            "story_elements": savepoint_data["story_elements"],
+        },
+    )
+    response = _call_llm(prompt, model=model)
+    errors = _validate_persona_doc(response)
+
+    if errors:
+        persona_dir = _get_persona_dir(name)
+        failed_path = persona_dir / ".last-failed.md"
+        failed_path.write_text(response, encoding="utf-8")
+        _error(
+            "persona/validate",
+            data={"errors": errors, "last_failed_path": str(failed_path)},
+        )
+
+    persona_dir = _get_persona_dir(name)
+    persona_path = persona_dir / "persona.md"
+    persona_path.write_text(response, encoding="utf-8")
+    ts = datetime.now(timezone.utc).isoformat()
+    _save_savepoint(
+        repo,
+        "persona",
+        {
+            "persona_path": str(persona_path),
+            "generation_timestamp": ts,
+        },
+    )
+    word_count = len(response.split())
+    _success(
+        "generate",
+        {
+            "persona_path": str(persona_path),
+            "savepoint_step": "persona",
+            "word_count": word_count,
+        },
+    )
+
+
+def cmd_get_view(name: str, view: str) -> None:
+    """Print a persona view for downstream tools."""
+    if view not in VALID_VIEWS:
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "operation": "get-view",
+                    "data": {
+                        "message": f"Invalid view: {view!r}. Valid views: {sorted(VALID_VIEWS)}"
+                    },
+                },
+                indent=2,
+            )
+        )
+        sys.exit(1)
+
+    story_dir = _validate_story_name(name, base_dir=STORIES_DIR)
+    persona_path = story_dir / "persona" / "persona.md"
+    if not persona_path.exists():
+        sys.exit(0)
+
+    text = persona_path.read_text(encoding="utf-8")
+    body = _strip_frontmatter(text)
+    sections = _extract_sections(body)
+
+    if view == "chapter":
+        output = body
+    elif view == "outline":
+        parts = []
+        for heading in [
+            "## Identity",
+            "## Narrative Philosophy",
+            "## Thematic Sensibility",
+            "## Pacing Philosophy",
+            "## Anti-Patterns",
+        ]:
+            if heading in sections:
+                parts.append(f"{heading}\n{sections[heading]}")
+        output = "\n\n".join(parts)
+    elif view == "scrubber":
+        identity_content = sections.get("## Identity", "")
+        sentences = _SENTENCE_SPLIT_RE.split(identity_content.strip(), maxsplit=1)
+        first_sentence = (
+            sentences[0].strip() if sentences and sentences[0].strip() else ""
+        )
+        if first_sentence and not first_sentence.endswith("."):
+            first_sentence += "."
+        parts = [f"## Identity\n{first_sentence}"]
+        for heading in ["## Prose Texture", "## Dialogue Style", "## Anti-Patterns"]:
+            if heading in sections:
+                parts.append(f"{heading}\n{sections[heading]}")
+        output = "\n\n".join(parts)
+    else:
+        parts = []
+        for heading in [
+            "## Identity",
+            "## Prose Texture",
+            "## Dialogue Style",
+            "## Narrative Philosophy",
+            "## Anti-Patterns",
+        ]:
+            if heading in sections:
+                parts.append(f"{heading}\n{sections[heading]}")
+        output = "\n\n".join(parts)
+
+    print(output)
+
+
+def cmd_regenerate(
+    name: str, *, model: str | None = None, word_budget: int = 225
+) -> None:
+    """Archive the current persona and generate a fresh one."""
+    from datetime import datetime, timezone
+
+    story_dir = _validate_story_name(name, base_dir=STORIES_DIR)
+    persona_path = story_dir / "persona" / "persona.md"
+    if persona_path.exists():
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        history_dir = persona_path.parent / "history"
+        history_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = history_dir / f"persona-{ts}.md"
+        archive_path.write_text(
+            persona_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    cmd_generate(name, model=model, word_budget=word_budget)
+
+
+def main() -> None:
+    """Run the persona builder CLI."""
+    parser = argparse.ArgumentParser(
+        description="Persona builder: generate, get-view, regenerate"
+    )
+    parser.add_argument(
+        "--operation", required=True, choices=["generate", "get-view", "regenerate"]
+    )
+    parser.add_argument("--name", required=True, help="Story name")
+    parser.add_argument("--model", default=None, help="LLM model override")
+    parser.add_argument("--word-budget", type=int, default=225, dest="word_budget")
+    parser.add_argument("--view", default=None, help="View type for get-view")
+    args = parser.parse_args()
+
+    op = args.operation
+    if op == "generate":
+        cmd_generate(args.name, model=args.model, word_budget=args.word_budget)
+    elif op == "get-view":
+        view = args.view or ""
+        cmd_get_view(args.name, view)
+    elif op == "regenerate":
+        cmd_regenerate(args.name, model=args.model, word_budget=args.word_budget)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_persona_builder.py
+++ b/tests/unit/test_persona_builder.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import tools._io as tool_io
+import tools.persona_builder as persona_builder
+from infrastructure.storage.savepoint_repository import FilesystemSavepointRepository
+
+STORY_NAME = "test-story"
+VALID_PERSONA = """---
+genre: Fantasy
+subgenre: Gothic
+pov: Third person limited
+tense: Past
+created_at: 2026-05-08T12:00:00Z
+---
+
+## Identity
+You write haunted stories. You favour intimate framing.
+
+## Prose Texture
+You use supple sentences.
+
+## Dialogue Style
+You write with restraint.
+
+## Pacing Philosophy
+You prefer dramatized scenes.
+
+## Thematic Sensibility
+You explore moral pressure.
+
+## Narrative Philosophy
+You stay close to character fear.
+
+## Anti-Patterns
+- Avoid purple prose.
+- Avoid exposition dumps.
+"""
+SAMPLE_PERSONA = VALID_PERSONA
+
+
+def _patch_stories_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(persona_builder, "STORIES_DIR", tmp_path)
+    monkeypatch.setattr(tool_io, "STORIES_DIR", tmp_path)
+
+
+def _create_story_dir(tmp_path: Path, story_name: str = STORY_NAME) -> Path:
+    story_dir = tmp_path / story_name
+    story_dir.mkdir(parents=True, exist_ok=True)
+    return story_dir
+
+
+def _make_repo(story_dir: Path) -> FilesystemSavepointRepository:
+    repo = FilesystemSavepointRepository(base_path=story_dir)
+    repo.set_story_directory("savepoints")
+    return repo
+
+
+def _write_required_savepoints(story_dir: Path) -> FilesystemSavepointRepository:
+    repo = _make_repo(story_dir)
+    asyncio.run(repo.save_savepoint("core_story_foundation", "Foundation text"))
+    asyncio.run(repo.save_savepoint("tone_style", "Tone text"))
+    asyncio.run(repo.save_savepoint("theme_message", "Theme text"))
+    asyncio.run(repo.save_savepoint("story_elements", "Elements text"))
+    return repo
+
+
+def _patch_generate_dependencies(
+    monkeypatch: pytest.MonkeyPatch, response: str = VALID_PERSONA
+) -> None:
+    monkeypatch.setattr(
+        persona_builder, "_load_prompt", lambda *_args, **_kwargs: "prompt"
+    )
+    monkeypatch.setattr(
+        persona_builder,
+        "_call_llm",
+        lambda prompt, **kw: response,
+    )
+
+
+class TestValidatePersonaDoc:
+    def test_valid_document_returns_no_errors(self) -> None:
+        errors = persona_builder._validate_persona_doc(VALID_PERSONA)
+
+        assert errors == []
+
+    def test_missing_frontmatter_returns_error(self) -> None:
+        document = VALID_PERSONA.removeprefix("---\n").split("---\n", maxsplit=1)[1]
+
+        errors = persona_builder._validate_persona_doc(document)
+
+        assert "Missing YAML frontmatter at document start" in errors
+
+    def test_missing_section_returns_error(self) -> None:
+        document = VALID_PERSONA.replace(
+            "## Anti-Patterns\n- Avoid purple prose.\n- Avoid exposition dumps.\n", ""
+        )
+
+        errors = persona_builder._validate_persona_doc(document)
+
+        assert "Missing required section: ## Anti-Patterns" in errors
+
+
+class TestStripFrontmatter:
+    def test_strips_frontmatter_block(self) -> None:
+        document = "---\nkey: val\n---\nbody text"
+
+        result = persona_builder._strip_frontmatter(document)
+
+        assert result == "body text"
+
+    def test_no_frontmatter_returns_original(self) -> None:
+        document = "# Heading\n\nPlain markdown"
+
+        result = persona_builder._strip_frontmatter(document)
+
+        assert result == document
+
+
+class TestExtractSections:
+    def test_extracts_multiple_sections(self) -> None:
+        body = "## Identity\ncontent1\n## Prose Texture\ncontent2"
+
+        sections = persona_builder._extract_sections(body)
+
+        assert sections["## Identity"] == "content1"
+        assert sections["## Prose Texture"] == "content2"
+
+    def test_section_content_stripped(self) -> None:
+        body = "## Identity\n\n  content with space  \n\n## Prose Texture\nnext"
+
+        sections = persona_builder._extract_sections(body)
+
+        assert sections["## Identity"] == "content with space"
+
+
+class TestGetPersonaDir:
+    def test_creates_persona_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        _create_story_dir(tmp_path)
+
+        persona_dir = persona_builder._get_persona_dir(STORY_NAME)
+
+        assert persona_dir == tmp_path / STORY_NAME / "persona"
+        assert persona_dir.is_dir()
+
+
+class TestCmdGenerate:
+    def test_generate_writes_persona_md(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch)
+
+        persona_builder.cmd_generate(STORY_NAME)
+
+        persona_path = story_dir / "persona" / "persona.md"
+        assert persona_path.exists()
+        assert persona_path.read_text(encoding="utf-8") == VALID_PERSONA
+
+    def test_generate_writes_savepoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        repo = _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch)
+
+        persona_builder.cmd_generate(STORY_NAME)
+
+        savepoint = asyncio.run(repo.load_savepoint("persona"))
+        assert isinstance(savepoint, dict)
+        assert savepoint["persona_path"] == str(story_dir / "persona" / "persona.md")
+        assert isinstance(savepoint["generation_timestamp"], str)
+        assert "T" in savepoint["generation_timestamp"]
+
+    def test_generate_outputs_success_json(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch)
+
+        persona_builder.cmd_generate(STORY_NAME)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["status"] == "success"
+        assert output["operation"] == "generate"
+        assert output["data"]["word_count"] > 0
+
+    def test_generate_word_budget_clamped_low(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, int] = {}
+
+        def fake_load_prompt(
+            prompt_id: str, variables: dict[str, object] | None = None
+        ) -> str:
+            assert prompt_id == "persona/generate"
+            assert variables is not None
+            captured["word_budget"] = int(variables["word_budget"])
+            return "prompt"
+
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        monkeypatch.setattr(persona_builder, "_load_prompt", fake_load_prompt)
+        monkeypatch.setattr(
+            persona_builder, "_call_llm", lambda prompt, **kw: VALID_PERSONA
+        )
+
+        persona_builder.cmd_generate(STORY_NAME, word_budget=50)
+
+        assert captured["word_budget"] == 100
+
+    def test_generate_word_budget_clamped_high(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, int] = {}
+
+        def fake_load_prompt(
+            prompt_id: str, variables: dict[str, object] | None = None
+        ) -> str:
+            assert prompt_id == "persona/generate"
+            assert variables is not None
+            captured["word_budget"] = int(variables["word_budget"])
+            return "prompt"
+
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        monkeypatch.setattr(persona_builder, "_load_prompt", fake_load_prompt)
+        monkeypatch.setattr(
+            persona_builder, "_call_llm", lambda prompt, **kw: VALID_PERSONA
+        )
+
+        persona_builder.cmd_generate(STORY_NAME, word_budget=600)
+
+        assert captured["word_budget"] == 500
+
+    def test_generate_missing_savepoint_exits_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        _create_story_dir(tmp_path)
+        _patch_generate_dependencies(monkeypatch)
+
+        with pytest.raises(SystemExit) as exc_info:
+            persona_builder.cmd_generate(STORY_NAME)
+
+        assert exc_info.value.code == 1
+
+    def test_generate_validation_failure_writes_last_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        invalid_response = "## Identity\nNo frontmatter here."
+
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch, response=invalid_response)
+
+        with pytest.raises(SystemExit) as exc_info:
+            persona_builder.cmd_generate(STORY_NAME)
+
+        failed_path = story_dir / "persona" / ".last-failed.md"
+        assert exc_info.value.code == 1
+        assert failed_path.exists()
+        assert failed_path.read_text(encoding="utf-8") == invalid_response
+
+
+class TestCmdGetView:
+    @pytest.fixture()
+    def persona_story_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> Path:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        persona_dir = story_dir / "persona"
+        persona_dir.mkdir(parents=True, exist_ok=True)
+        (persona_dir / "persona.md").write_text(SAMPLE_PERSONA, encoding="utf-8")
+        return story_dir
+
+    def test_get_view_outline(
+        self, persona_story_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        persona_builder.cmd_get_view(STORY_NAME, "outline")
+
+        output = capsys.readouterr().out
+        assert "## Identity" in output
+        assert "## Narrative Philosophy" in output
+        assert "## Thematic Sensibility" in output
+        assert "## Pacing Philosophy" in output
+        assert "## Anti-Patterns" in output
+        assert "## Prose Texture" not in output
+
+    def test_get_view_chapter(
+        self, persona_story_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        persona_builder.cmd_get_view(STORY_NAME, "chapter")
+
+        output = capsys.readouterr().out
+        assert "---" not in output
+        assert "## Identity" in output
+        assert "## Prose Texture" in output
+
+    def test_get_view_scrubber(
+        self, persona_story_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        persona_builder.cmd_get_view(STORY_NAME, "scrubber")
+
+        output = capsys.readouterr().out
+        assert "## Identity\nYou write haunted stories." in output
+        assert "You favour intimate framing." not in output
+        assert "## Prose Texture" in output
+        assert "## Dialogue Style" in output
+        assert "## Anti-Patterns" in output
+
+    def test_get_view_editor(
+        self, persona_story_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        persona_builder.cmd_get_view(STORY_NAME, "editor")
+
+        output = capsys.readouterr().out
+        assert "## Identity" in output
+        assert "## Prose Texture" in output
+        assert "## Dialogue Style" in output
+        assert "## Narrative Philosophy" in output
+        assert "## Anti-Patterns" in output
+        assert "## Pacing Philosophy" not in output
+
+    def test_get_view_missing_persona_exits_0(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        _create_story_dir(tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            persona_builder.cmd_get_view(STORY_NAME, "outline")
+
+        assert exc_info.value.code == 0
+
+    def test_get_view_invalid_view_exits_1(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            persona_builder.cmd_get_view(STORY_NAME, "invalid_view")
+
+        assert exc_info.value.code == 1
+
+    def test_get_view_invalid_view_outputs_json(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            persona_builder.cmd_get_view(STORY_NAME, "invalid_view")
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["status"] == "error"
+
+
+class TestCmdRegenerate:
+    def test_regenerate_archives_existing_persona(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch)
+        persona_dir = story_dir / "persona"
+        persona_dir.mkdir(parents=True, exist_ok=True)
+        original_persona = "original persona"
+        (persona_dir / "persona.md").write_text(original_persona, encoding="utf-8")
+
+        persona_builder.cmd_regenerate(STORY_NAME)
+
+        history_dir = persona_dir / "history"
+        archived_files = list(history_dir.glob("persona-*.md"))
+        assert history_dir.is_dir()
+        assert len(archived_files) == 1
+        assert archived_files[0].read_text(encoding="utf-8") == original_persona
+
+    def test_regenerate_no_existing_persona_behaves_like_generate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch)
+
+        persona_builder.cmd_regenerate(STORY_NAME)
+
+        assert (story_dir / "persona" / "persona.md").exists()
+
+    def test_regenerate_archive_filename_format(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_stories_dir(monkeypatch, tmp_path)
+        story_dir = _create_story_dir(tmp_path)
+        _write_required_savepoints(story_dir)
+        _patch_generate_dependencies(monkeypatch)
+        persona_dir = story_dir / "persona"
+        persona_dir.mkdir(parents=True, exist_ok=True)
+        (persona_dir / "persona.md").write_text("existing persona", encoding="utf-8")
+
+        persona_builder.cmd_regenerate(STORY_NAME)
+
+        archived_files = list((persona_dir / "history").glob("persona-*.md"))
+        assert len(archived_files) == 1
+        assert re.fullmatch(r"persona-\d{8}-\d{6}\.md", archived_files[0].name)


### PR DESCRIPTION
## Summary

Implements the `persona-builder` CLI tool (`src/tools/persona_builder.py`) with all three operations: `generate`, `get-view`, and `regenerate`. The tool creates and serves the author persona document used for system-message injection into generative agents.

## Closes
Closes #404

## Changes
- [x] `src/tools/persona_builder.py` — new CLI tool following `outline_generator.py`/`scene_writer.py` pattern
  - `generate`: reads 4 savepoints, renders `prompts/persona/generate.md`, calls LLM, validates frontmatter + 7 section headings, writes `stories/<name>/persona/persona.md`, saves `persona` savepoint
  - `get-view`: derives one of 4 projections (`outline`, `chapter`, `scrubber`, `editor`) at read time as plain text; graceful degradation on missing persona (exit 0, empty stdout)
  - `regenerate`: archives existing persona to `history/persona-YYYYMMDD-HHMMSS.md` before re-generating
- [x] `tests/unit/test_persona_builder.py` — 25 unit tests covering all three operations, all 4 view types, missing-persona degradation, word-budget clamping, validation failures
- [x] All 25 tests passing
- [x] Linting clean (`ruff check`, `ruff format`, `mypy`)

## Plan

### Task Checklist
- **Implementation**: `src/tools/persona_builder.py`
  - `_validate_persona_doc` — validates YAML frontmatter + 7 required section headings
  - `_strip_frontmatter` / `_extract_sections` — parse persona doc
  - `cmd_generate` — savepoint reads, LLM call, write output, save savepoint
  - `cmd_get_view` — read-time view derivation with graceful degradation
  - `cmd_regenerate` — archive + generate
- **Verification tests**: `tests/unit/test_persona_builder.py` — 25 tests, all pass
