### PR TITLE
feat(persona): plumb system_message and emphasis-delta through outline-generator and scene-writer

### DIFF
--- a/src/tools/outline_generator.py
+++ b/src/tools/outline_generator.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -75,20 +76,50 @@ def _load_prompt(prompt_id: str, variables: dict[str, Any] | None = None) -> str
     return loader.load_prompt(prompt_id, variables)
 
 
-def _call_llm(prompt: str, *, model: str | None = None) -> str:
+def _call_llm(
+    prompt: str,
+    *,
+    model: str | None = None,
+    system_message: str | None = None,
+) -> str:
     """Call LLM with a single prompt and return text response."""
     from tools._llm import generate_text
 
-    return generate_text(prompt, model=model)
+    return generate_text(prompt, model=model, system_message=system_message)
 
 
 def _call_llm_messages(
-    messages: list[dict[str, str]], *, model: str | None = None
+    messages: list[dict[str, str]],
+    *,
+    model: str | None = None,
+    system_message: str | None = None,
 ) -> str:
     """Call LLM with full conversation history and return text response."""
     from tools._llm import generate_text_messages
 
+    if system_message:
+        messages = [{"role": "system", "content": system_message}, *messages]
     return generate_text_messages(messages, model=model)
+
+
+def _fetch_persona_view(name: str, view: str) -> str | None:
+    """Invoke persona-builder get-view; return text or None on empty stdout."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parent / "persona_builder.py"),
+            "--operation",
+            "get-view",
+            "--name",
+            name,
+            "--view",
+            view,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    text = result.stdout.strip()
+    return text if text else None
 
 
 def _success(operation: str, data: Any) -> None:
@@ -396,6 +427,8 @@ def cmd_expand_chapter(
     continuity_summary: str = "",
     model: str | None = None,
     phase: str = "chunk",
+    persona_view: str | None = None,
+    emphasis_delta: str | None = None,
     **_kwargs: Any,
 ) -> None:
     """Generate an outline chunk for a range of chapters, then analyze continuity.
@@ -417,6 +450,8 @@ def cmd_expand_chapter(
             f"at a time. If you are invoking this tool directly, loop externally; "
             f"otherwise dispatch the chapter-outline-expander subagent instead."
         )
+
+    system_message = _fetch_persona_view(name, persona_view) if persona_view else None
 
     if not _has_savepoint(repo, "story_elements"):
         _error("story_elements savepoint not found — run generate-elements first")
@@ -491,7 +526,13 @@ def cmd_expand_chapter(
                     "continuity_summary": continuity_summary,
                 },
             )
-            chunk_text = _call_llm(chunk_prompt, model=model)
+            if emphasis_delta and emphasis_delta.strip():
+                chunk_prompt += f"\n\n## Chapter Emphasis\n\n{emphasis_delta}"
+            chunk_text = _call_llm(
+                chunk_prompt,
+                model=model,
+                system_message=system_message,
+            )
             _save_savepoint(repo, chunk_step, chunk_text)
         except Exception as exc:
             _error(f"chunk expansion failed: {exc}")
@@ -538,7 +579,13 @@ def cmd_expand_chapter(
                     "last_chapter_in_previous": last_prev,
                 },
             )
-            continuity_analysis = _call_llm(continuity_prompt, model=model)
+            if emphasis_delta and emphasis_delta.strip():
+                continuity_prompt += f"\n\n## Chapter Emphasis\n\n{emphasis_delta}"
+            continuity_analysis = _call_llm(
+                continuity_prompt,
+                model=model,
+                system_message=system_message,
+            )
             _save_savepoint(repo, continuity_step, continuity_analysis)
         except Exception as exc:
             print(
@@ -735,6 +782,8 @@ def cmd_refine(
     feedback: str,
     *,
     model: str | None = None,
+    persona_view: str | None = None,
+    emphasis_delta: str | None = None,
     **_kwargs: Any,
 ) -> None:
     """Refine the outline based on feedback/critique."""
@@ -776,6 +825,7 @@ def cmd_refine(
 
     # TODO: load wanted_chapters from story config when available
     wanted_chapters = ""
+    system_message = _fetch_persona_view(name, persona_view) if persona_view else None
 
     try:
         refinement_prompt = _load_prompt(
@@ -795,7 +845,13 @@ def cmd_refine(
             "Apply the following feedback when refining the outline:\n\n"
             f"{feedback}"
         )
-        refined_text = _call_llm(refinement_prompt, model=model)
+        if emphasis_delta and emphasis_delta.strip():
+            refinement_prompt += f"\n\n## Chapter Emphasis\n\n{emphasis_delta}"
+        refined_text = _call_llm(
+            refinement_prompt,
+            model=model,
+            system_message=system_message,
+        )
         _save_savepoint(repo, "refined_outline", refined_text)
         _success("refine", {"refined_outline": refined_text})
     except Exception as exc:
@@ -868,6 +924,16 @@ def main() -> None:
         "--feedback",
         default=None,
         help="Critique/feedback text (refine)",
+    )
+    parser.add_argument(
+        "--persona-view",
+        default=None,
+        help="Optional persona-builder view name for persona system message",
+    )
+    parser.add_argument(
+        "--emphasis-delta",
+        default=None,
+        help="Optional chapter emphasis text appended to prompt for supported operations",
     )
     parser.add_argument(
         "--chapter-num",
@@ -963,6 +1029,8 @@ def main() -> None:
             continuity_summary=args.continuity_summary,
             model=args.model,
             phase=args.phase,
+            persona_view=args.persona_view,
+            emphasis_delta=args.emphasis_delta,
         )
 
     elif args.operation == "expand-to-scenes":
@@ -990,7 +1058,13 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(2)
-        cmd_refine(args.name, args.feedback, model=args.model)
+        cmd_refine(
+            args.name,
+            args.feedback,
+            model=args.model,
+            persona_view=args.persona_view,
+            emphasis_delta=args.emphasis_delta,
+        )
 
 
 if __name__ == "__main__":

--- a/src/tools/scene_writer.py
+++ b/src/tools/scene_writer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -62,11 +63,36 @@ def _load_prompt(prompt_id: str, variables: dict[str, Any] | None = None) -> str
     return loader.load_prompt(prompt_id, variables)
 
 
-def _call_llm(prompt: str, *, model: str | None = None) -> str:
+def _call_llm(
+    prompt: str,
+    *,
+    model: str | None = None,
+    system_message: str | None = None,
+) -> str:
     """Call LLM with a single prompt and return text response."""
     from tools._llm import generate_text
 
-    return generate_text(prompt, model=model)
+    return generate_text(prompt, model=model, system_message=system_message)
+
+
+def _fetch_persona_view(name: str, view: str) -> str | None:
+    """Invoke persona-builder get-view; return text or None on empty stdout."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parent / "persona_builder.py"),
+            "--operation",
+            "get-view",
+            "--name",
+            name,
+            "--view",
+            view,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    text = result.stdout.strip()
+    return text if text else None
 
 
 def _load_story_state(name: str) -> dict[str, Any]:
@@ -201,6 +227,8 @@ def cmd_generate(
     next_scene_definition: str | None = None,
     next_chapter_synopsis: str | None = None,
     model: str | None = None,
+    persona_view: str | None = None,
+    emphasis_delta: str | None = None,
     include_content: bool = False,
 ) -> None:
     """Generate content for a single scene."""
@@ -227,6 +255,8 @@ def cmd_generate(
             if isinstance(prev_loaded, str):
                 previous_scene = prev_loaded
 
+    system_message = _fetch_persona_view(name, persona_view) if persona_view else None
+
     prompt_text = _load_prompt(
         "scenes/create_content",
         {
@@ -244,9 +274,15 @@ def cmd_generate(
             "next_chapter_synopsis": next_chapter_synopsis or "",
         },
     )
+    if emphasis_delta and emphasis_delta.strip():
+        prompt_text += f"\n\n## Chapter Emphasis\n\n{emphasis_delta}"
 
     try:
-        content = _call_llm(prompt_text, model=model)
+        content = _call_llm(
+            prompt_text,
+            model=model,
+            system_message=system_message,
+        )
     except RuntimeError as exc:
         _error(f"scene generation failed: {exc}")
 
@@ -273,6 +309,8 @@ def cmd_revise(
     previous_scene: str | None = None,
     next_chapter_synopsis: str | None = None,
     model: str | None = None,
+    persona_view: str | None = None,
+    emphasis_delta: str | None = None,
     include_content: bool = False,
 ) -> None:
     """Revise scene content based on feedback."""
@@ -292,6 +330,8 @@ def cmd_revise(
         else:
             _error(f"--scene-content is required: no savepoint found at {step!r}")
 
+    system_message = _fetch_persona_view(name, persona_view) if persona_view else None
+
     prompt_text = _load_prompt(
         "scenes/revise_content",
         {
@@ -305,9 +345,15 @@ def cmd_revise(
             "chapter_num": str(chapter_num),
         },
     )
+    if emphasis_delta and emphasis_delta.strip():
+        prompt_text += f"\n\n## Chapter Emphasis\n\n{emphasis_delta}"
 
     try:
-        revised = _call_llm(prompt_text, model=model)
+        revised = _call_llm(
+            prompt_text,
+            model=model,
+            system_message=system_message,
+        )
     except RuntimeError as exc:
         _error(f"scene revision failed: {exc}")
 
@@ -638,6 +684,16 @@ def main() -> None:
     )
     parser.add_argument("--model", default=None, help="Override LLM model identifier")
     parser.add_argument(
+        "--persona-view",
+        default=None,
+        help="Optional persona-builder view name for persona system message",
+    )
+    parser.add_argument(
+        "--emphasis-delta",
+        default=None,
+        help="Optional chapter emphasis text appended to prompt for supported operations",
+    )
+    parser.add_argument(
         "--chapter-text", default=None, help="Chapter text for scrub/voice analysis"
     )
     parser.add_argument(
@@ -702,6 +758,8 @@ def main() -> None:
             next_scene_definition=args.next_scene_definition,
             next_chapter_synopsis=args.next_chapter_synopsis,
             model=args.model,
+            persona_view=args.persona_view,
+            emphasis_delta=args.emphasis_delta,
             include_content=args.include_content,
         )
 
@@ -727,6 +785,8 @@ def main() -> None:
             previous_scene=getattr(args, "previous_scene", None),
             next_chapter_synopsis=getattr(args, "next_chapter_synopsis", None),
             model=args.model,
+            persona_view=args.persona_view,
+            emphasis_delta=args.emphasis_delta,
             include_content=args.include_content,
         )
 

--- a/tests/unit/test_outline_generator_tool.py
+++ b/tests/unit/test_outline_generator_tool.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+import tools._llm as tool_llm
 import tools._io as tool_io
 import tools.outline_generator as og
 
@@ -353,6 +354,109 @@ def patched_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, 
     return stories_dir, story_name
 
 
+def test_call_llm_forwards_system_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_call_llm should forward system_message to the LLM helper."""
+    received: dict[str, object] = {}
+
+    def fake_generate_text(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        received["prompt"] = prompt
+        received["model"] = model
+        received["system_message"] = system_message
+        return "ok"
+
+    monkeypatch.setattr(tool_llm, "generate_text", fake_generate_text)
+
+    assert og._call_llm("prompt", system_message="sys") == "ok"
+    assert received == {
+        "prompt": "prompt",
+        "model": None,
+        "system_message": "sys",
+    }
+
+
+def test_call_llm_messages_prepends_system_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """System message should be prepended as the first chat message."""
+    received: dict[str, object] = {}
+
+    def fake_generate_text_messages(
+        messages: list[dict[str, str]], *, model: str | None = None
+    ) -> str:
+        received["messages"] = messages
+        received["model"] = model
+        return "ok"
+
+    monkeypatch.setattr(tool_llm, "generate_text_messages", fake_generate_text_messages)
+
+    original_messages = [{"role": "user", "content": "hi"}]
+
+    assert og._call_llm_messages(original_messages, system_message="sys") == "ok"
+    assert received["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
+    assert original_messages == [{"role": "user", "content": "hi"}]
+
+
+def test_call_llm_no_system_message_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a system message, the original message list should pass through unchanged."""
+    received: dict[str, object] = {}
+
+    def fake_generate_text_messages(
+        messages: list[dict[str, str]], *, model: str | None = None
+    ) -> str:
+        received["messages"] = messages
+        received["model"] = model
+        return "ok"
+
+    monkeypatch.setattr(tool_llm, "generate_text_messages", fake_generate_text_messages)
+
+    original_messages = [{"role": "user", "content": "hi"}]
+
+    assert og._call_llm_messages(original_messages, system_message=None) == "ok"
+    assert received["messages"] == original_messages
+
+
+def test_fetch_persona_view_returns_none_on_empty_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty persona-builder stdout should map to None."""
+    monkeypatch.setattr(
+        og.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        ),
+    )
+
+    assert og._fetch_persona_view("story", "outline") is None
+
+
+def test_fetch_persona_view_returns_text_on_non_empty_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-empty persona-builder stdout should be stripped and returned."""
+    monkeypatch.setattr(
+        og.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="You are a writer.\n"
+        ),
+    )
+
+    assert og._fetch_persona_view("story", "outline") == "You are a writer."
+
+
 # ---------------------------------------------------------------------------
 # Test: analyze-prompt happy path (monkeypatched)
 # ---------------------------------------------------------------------------
@@ -487,9 +591,15 @@ def test_expand_chapter_happy_path(
 
     call_count = 0
 
-    def fake_call_llm(prompt: str, *, model: str | None = None) -> str:
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
         nonlocal call_count
         call_count += 1
+        assert system_message is None
         if call_count == 1:
             return "Expanded chapters 1-3 outline"
         return "Continuity analysis for chapters 1-3"
@@ -508,6 +618,100 @@ def test_expand_chapter_happy_path(
     assert out["operation"] == "expand-chapter"
     assert "chunk_outline" in out["data"]
     assert "continuity_analysis" in out["data"]
+
+
+def test_expand_chapter_persona_and_delta_forwarded(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """expand-chapter should forward persona text and append emphasis delta."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+
+    calls: list[dict[str, object]] = []
+
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        calls.append(
+            {
+                "prompt": prompt,
+                "model": model,
+                "system_message": system_message,
+            }
+        )
+        return "chunk response" if len(calls) == 1 else "continuity response"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+    monkeypatch.setattr(og, "_fetch_persona_view", lambda *_a, **_kw: "persona sys")
+
+    og.cmd_expand_chapter(
+        name,
+        1,
+        3,
+        10,
+        model="test-model",
+        persona_view="outline",
+        emphasis_delta="Focus on dread.",
+    )
+
+    json.loads(capsys.readouterr().out)
+    assert len(calls) == 2
+    assert all(call["system_message"] == "persona sys" for call in calls)
+    assert all("## Chapter Emphasis" in str(call["prompt"]) for call in calls)
+    assert all("Focus on dread." in str(call["prompt"]) for call in calls)
+
+
+def test_expand_chapter_no_persona_no_delta(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """expand-chapter should omit both persona system message and emphasis section when absent."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+
+    calls: list[dict[str, object]] = []
+
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        calls.append(
+            {
+                "prompt": prompt,
+                "model": model,
+                "system_message": system_message,
+            }
+        )
+        return "chunk response" if len(calls) == 1 else "continuity response"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+
+    og.cmd_expand_chapter(
+        name,
+        1,
+        3,
+        10,
+        model="test-model",
+        persona_view=None,
+        emphasis_delta=None,
+    )
+
+    json.loads(capsys.readouterr().out)
+    assert len(calls) == 2
+    assert all(call["system_message"] is None for call in calls)
+    assert all("## Chapter Emphasis" not in str(call["prompt"]) for call in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -561,8 +765,14 @@ def test_refine_happy_path(
 
     received_prompts: list[str] = []
 
-    def fake_call_llm(prompt: str, *, model: str | None = None) -> str:
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
         received_prompts.append(prompt)
+        assert system_message is None
         return "Refined outline with stronger ending"
 
     monkeypatch.setattr(og, "_call_llm", fake_call_llm)
@@ -581,6 +791,48 @@ def test_refine_happy_path(
     assert out["status"] == "success"
     assert out["operation"] == "refine"
     assert "Refined outline with stronger ending" in out["data"]["refined_outline"]
+
+
+def test_refine_persona_and_delta_forwarded(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """refine should forward persona text and append emphasis delta."""
+    stories_dir, name = patched_env
+
+    _write_savepoint(stories_dir, name, "initial_outline", "Original outline")
+    _write_savepoint(stories_dir, name, "story_elements", "Elements content")
+    _write_savepoint(stories_dir, name, "base_context", "Base context content")
+
+    received: dict[str, object] = {}
+
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        received["prompt"] = prompt
+        received["model"] = model
+        received["system_message"] = system_message
+        return "Refined outline"
+
+    monkeypatch.setattr(og, "_call_llm", fake_call_llm)
+    monkeypatch.setattr(og, "_fetch_persona_view", lambda *_a, **_kw: "persona sys")
+
+    og.cmd_refine(
+        name,
+        "Sharpen climax",
+        model="test-model",
+        persona_view="outline",
+        emphasis_delta="Keep pressure high.",
+    )
+
+    json.loads(capsys.readouterr().out)
+    assert received["system_message"] == "persona sys"
+    assert "## Chapter Emphasis" in str(received["prompt"])
+    assert "Keep pressure high." in str(received["prompt"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scene_writer.py
+++ b/tests/unit/test_scene_writer.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import pytest
 
+import tools._llm as tool_llm
 import tools.scene_writer as sw
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -42,6 +43,63 @@ def patched_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, 
     monkeypatch.setattr(sw, "_load_prompt", lambda *_a, **_kw: "mock prompt text")
 
     return stories_dir, story_name
+
+
+def test_call_llm_forwards_system_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_call_llm should forward system_message to the LLM helper."""
+    received: dict[str, object] = {}
+
+    def fake_generate_text(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        received["prompt"] = prompt
+        received["model"] = model
+        received["system_message"] = system_message
+        return "ok"
+
+    monkeypatch.setattr(tool_llm, "generate_text", fake_generate_text)
+
+    assert sw._call_llm("prompt", system_message="sys") == "ok"
+    assert received == {
+        "prompt": "prompt",
+        "model": None,
+        "system_message": "sys",
+    }
+
+
+def test_fetch_persona_view_empty_stdout_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty persona-builder stdout should map to None."""
+    monkeypatch.setattr(
+        sw.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        ),
+    )
+
+    assert sw._fetch_persona_view("story", "scene") is None
+
+
+def test_fetch_persona_view_non_empty_stdout_returns_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-empty persona-builder stdout should be stripped and returned."""
+    monkeypatch.setattr(
+        sw.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="You are a writer.\n"
+        ),
+    )
+
+    assert sw._fetch_persona_view("story", "scene") == "You are a writer."
 
 
 def _run_tool(
@@ -537,6 +595,86 @@ def test_generate_include_content_returns_content(
     assert out["data"]["content"] == scene_text
 
 
+def test_generate_persona_and_delta_forwarded(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """generate should forward persona text and append emphasis delta."""
+    _stories_dir, name = patched_env
+
+    received: dict[str, object] = {}
+
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        received["prompt"] = prompt
+        received["model"] = model
+        received["system_message"] = system_message
+        return "Generated scene"
+
+    monkeypatch.setattr(sw, "_call_llm", fake_call_llm)
+    monkeypatch.setattr(sw, "_fetch_persona_view", lambda *_a, **_kw: "persona sys")
+
+    sw.cmd_generate(
+        name,
+        chapter_num=1,
+        scene_num=1,
+        scene_definition="Scene definition",
+        chapter_outline="Chapter outline",
+        model="test",
+        persona_view="scene",
+        emphasis_delta="Lean harder into suspense.",
+    )
+
+    json.loads(capsys.readouterr().out)
+    assert received["system_message"] == "persona sys"
+    assert "## Chapter Emphasis" in str(received["prompt"])
+    assert "Lean harder into suspense." in str(received["prompt"])
+
+
+def test_generate_no_persona_no_delta(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """generate should omit persona system message and emphasis section when absent."""
+    _stories_dir, name = patched_env
+
+    received: dict[str, object] = {}
+
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        received["prompt"] = prompt
+        received["model"] = model
+        received["system_message"] = system_message
+        return "Generated scene"
+
+    monkeypatch.setattr(sw, "_call_llm", fake_call_llm)
+
+    sw.cmd_generate(
+        name,
+        chapter_num=1,
+        scene_num=1,
+        scene_definition="Scene definition",
+        chapter_outline="Chapter outline",
+        model="test",
+        persona_view=None,
+        emphasis_delta=None,
+    )
+
+    json.loads(capsys.readouterr().out)
+    assert received["system_message"] is None
+    assert "## Chapter Emphasis" not in str(received["prompt"])
+
+
 def test_generate_auto_loads_previous_scene(
     patched_env: tuple[Path, str],
     monkeypatch: pytest.MonkeyPatch,
@@ -708,6 +846,47 @@ def test_revise_include_content_returns_content(
 
     out = json.loads(capsys.readouterr().out)
     assert out["data"]["content"] == revised_text
+
+
+def test_revise_persona_and_delta_forwarded(
+    patched_env: tuple[Path, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """revise should forward persona text and append emphasis delta."""
+    _stories_dir, name = patched_env
+
+    received: dict[str, object] = {}
+
+    def fake_call_llm(
+        prompt: str,
+        *,
+        model: str | None = None,
+        system_message: str | None = None,
+    ) -> str:
+        received["prompt"] = prompt
+        received["model"] = model
+        received["system_message"] = system_message
+        return "Revised scene"
+
+    monkeypatch.setattr(sw, "_call_llm", fake_call_llm)
+    monkeypatch.setattr(sw, "_fetch_persona_view", lambda *_a, **_kw: "persona sys")
+
+    sw.cmd_revise(
+        name,
+        chapter_num=1,
+        scene_num=1,
+        feedback="Tighten prose",
+        scene_content="Original scene",
+        model="test",
+        persona_view="scene",
+        emphasis_delta="Keep the voice severe.",
+    )
+
+    json.loads(capsys.readouterr().out)
+    assert received["system_message"] == "persona sys"
+    assert "## Chapter Emphasis" in str(received["prompt"])
+    assert "Keep the voice severe." in str(received["prompt"])
 
 
 def test_assemble_chapter_default_returns_chapter_ref(


### PR DESCRIPTION
## Summary

Plumbs `system_message` and per-chapter `--emphasis-delta` support through `outline_generator.py` and `scene_writer.py` so the author persona can be injected on every relevant generative LLM call.

## Closes
Closes #405

## Changes
- [x] `_call_llm` and `_call_llm_messages` in both tools accept optional `system_message` parameter
- [x] `_fetch_persona_view` helper added to both tools — subprocess-invokes `persona-builder get-view`, returns `None` on empty stdout
- [x] `--persona-view` and `--emphasis-delta` added to generative operations only (`expand-chapter`, `refine` in outline-generator; `generate`, `revise` in scene-writer)
- [x] Empty `persona-builder get-view` stdout → no `system_message` injected (graceful degradation)
- [x] Empty/missing `--emphasis-delta` → no delta appended (identical to current behaviour)
- [x] Analytical operations (`analyze-prompt`, `generate-elements`, `parse-definitions`, `assemble-chapter`, `scrub-analyze`, `voice-analyze`) unchanged
- [x] 14 new tests pass, 71 total in touched files — zero failures
- [x] Lint clean (ruff + mypy)

## Plan

### Implementation
- `_call_llm` in both tools: add `system_message: str | None = None` kwarg, forward to `generate_text`
- `_call_llm_messages` in `outline_generator.py`: prepend `{"role": "system", ...}` when `system_message` present
- `_fetch_persona_view(name, view)`: subprocess call to `persona_builder.py --operation get-view`; empty stdout → `None`
- `expand-chapter`, `refine` (outline-generator): resolve persona, append delta to prompt, pass `system_message`
- `generate`, `revise` (scene-writer): same pattern
- Top-level CLI args `--persona-view` and `--emphasis-delta` registered on both tools

### Verification
- 14 new unit tests across `test_outline_generator_tool.py` and `test_scene_writer.py`
- Covers: system_message forwarding, messages prepend, fetch_persona_view empty/non-empty, no-op when args absent, delta appended correctly