### PR TITLE
feat(persona): integration test and documentation

### DIFF
--- a/.github/notes/architecture.md
+++ b/.github/notes/architecture.md
@@ -31,7 +31,9 @@
    - Extract story start date
    - Extract base context
    - Generate story elements
+   - Generate author persona via `persona-builder generate` immediately after `generate-elements`
    - Generate initial outline (optional: chunked, `outline_chunk_size` chapters at a time)
+   - Derive and inject the `outline` persona view for outline expansion and refinement calls
    - Generate chapter list
    - (Optional) Critique loop: 6 critic types evaluate outline, refine if below quality threshold
 3. **Character/Setting phase:**
@@ -85,7 +87,7 @@ Prompt templates are **Markdown files** stored in the top-level `prompts/` direc
 
 ## Tools
 
-Fifteen tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
+Sixteen tools implemented following the hybrid pattern from [ADR 001](docs/planning/adr/001-hybrid-agent-tool-architecture.md):
 
 | Tool | Wrapper | Script | Infrastructure |
 |------|---------|--------|---------------|
@@ -96,6 +98,7 @@ Fifteen tools implemented following the hybrid pattern from [ADR 001](docs/plann
 | `setting-mgr` | `.opencode/tools/setting-mgr.ts` | `src/tools/setting_manager.py` | Direct filesystem — setting sheet JSON I/O with deep-merge updates |
 | `recap-manager` | `.opencode/tools/recap-manager.ts` | `src/tools/recap_manager.py` | `_llm.py` + `FilesystemSavepointRepository` — 5-stage recap pipeline with LLM |
 | `outline-generator` | `.opencode/tools/outline-generator.ts` | `src/tools/outline_generator.py` | `_llm.py` + `FilesystemSavepointRepository` + `PromptLoader` — multi-step outline pipeline with conversation history |
+| `persona-builder` | — | `src/tools/persona_builder.py` | `_llm.py` + `FilesystemSavepointRepository` + `PromptLoader` — persona generation, view derivation, and writes to `stories/<name>/persona/persona.md` |
 | `scene-writer` | `.opencode/tools/scene-writer.ts` | `src/tools/scene_writer.py` | `_llm.py` + `FilesystemSavepointRepository` + `PromptLoader` — per-scene generation, revision, and chapter assembly |
 | `critique-runner` | `.opencode/tools/critique-runner.ts` | `src/tools/critique_runner.py` | `_llm.py` + `src/tools/critique_parser.py` — 6-critic evaluation with scoring and threshold logic |
 | `wiki-init` | `.opencode/tools/wiki-init.ts` | `src/tools/wiki_init.py` | `_wiki.py` — idempotent wiki directory + schema creation |
@@ -117,11 +120,17 @@ Three agent prompt files defined in `prompts/agents/`, registered in `opencode.j
 |-------|-----------|--------|--------|
 | `story-orchestrator` | `prompts/agents/story-orchestrator.md` | `story-pipeline` | Primary pipeline controller — coordinates 10-phase story generation lifecycle, delegates to subagents |
 | `chapter-writer` | `prompts/agents/chapter-writer.md` | `scene-writing`, `character-voice` | Per-chapter scene generation — invoked by orchestrator during Phase 8b, generates scenes sequentially using wiki-snapshot context |
-| `outline-planner` | `prompts/agents/outline-planner.md` | `story-pipeline`, `outline-structure` | Outline generation — invoked by orchestrator during Phase 2, runs 5-phase pipeline: prompt analysis, element synthesis, outline generation (chunked/monolithic), optional critique & refinement |
+| `outline-planner` | `prompts/agents/outline-planner.md` | `story-pipeline`, `outline-structure` | Outline generation — invoked by orchestrator during Phase 3, runs prompt analysis, element synthesis, `persona-builder generate`, outline generation (chunked/monolithic), and optional critique & refinement |
 
 The `chapter-writer` is named to avoid collision with the existing `scene-writer` tool. The orchestrator delegates to `chapter-writer` for the per-chapter scene generation loop; the agent in turn calls the `scene-writer` tool for individual scene generation.
 
-The `outline-planner` uses `outline-generator` and `critique-runner` tools to drive the outline pipeline end-to-end, creating savepoints at each stage for resumability.
+The `outline-planner` uses `outline-generator`, `persona-builder`, and `critique-runner` tools to drive the outline pipeline end-to-end, creating savepoints at each stage for resumability.
+
+## Persona Phase
+
+The current persona step is owned by `outline-planner`, not the top-level orchestrator. After `generate-elements` finishes, `outline-planner` calls `persona-builder generate` to create `stories/<name>/persona/persona.md`, then hands the derived `outline` persona view into outline expansion and refinement calls.
+
+This keeps persona generation adjacent to the analysis chunks that feed it and avoids cross-agent duplication of persona-building logic.
 
 ## Skills
 

--- a/.github/notes/patterns.md
+++ b/.github/notes/patterns.md
@@ -1,0 +1,9 @@
+# Patterns
+
+## Analytical-agent exclusion from persona injection
+
+Never pass `--persona-view` or inject a persona `system_message` into analytical agents (`recap-manager`, `critique-runner`, `consistency-checker`, `outline-critic`). These agents require neutral, unbiased evaluation. Persona injection skews analytical output toward the author's stylistic preferences, compromising correctness. See ADR 015; empirical basis: Kim et al. (2025) arXiv:2408.08631.
+
+## Persona view selection by pipeline phase
+
+Use the `outline` view for outline-level agents (`outline-generator` `expand-chapter`, `outline-generator` `refine`). Use the `chapter` view for scene-level generation (`scene-writer` `generate`, `scene-writer` `revise`). Use the `scrubber` view for prose scrubbing passes (`prose-scrubber`). Use the `editor` view for final editorial passes (`final-editor`). Never use the `chapter` full view at the outline level; it adds noise without benefit.

--- a/docs/features/author-persona.md
+++ b/docs/features/author-persona.md
@@ -1,0 +1,123 @@
+# Author Persona
+
+> Story-scoped authorial style profile that keeps generative phases aligned to one creative fingerprint.
+
+## Overview
+
+The author persona is the story's creative fingerprint: a compact Markdown document that captures authorial identity, narrative philosophy, prose preferences, dialogue tendencies, pacing habits, thematic priorities, and anti-patterns. The system generates it once per story, stores it at `stories/<name>/persona/persona.md`, and derives phase-specific views from that one canonical file at generation time.
+
+The canonical file is not split into separate persisted variants. Instead, `persona-builder get-view` reads `persona.md` and projects one of four views:
+
+| View | Used By | Pipeline Surface | Purpose |
+|------|---------|------------------|---------|
+| `outline` | `outline-generator` | Outline expansion and outline refinement during Phase 3 | Identity, narrative philosophy, thematic focus, pacing philosophy, and anti-patterns for outline-level planning |
+| `chapter` | `scene-writer` | Chapter and scene generation or revision during the chapter loop | Full seven-section persona body for scene-level drafting |
+| `scrubber` | `prose-scrubber` | Prose scrubbing passes | Short style-focused projection for prose texture and dialogue cleanup |
+| `editor` | `final-editor` | Final editorial passes | Identity plus prose, dialogue, narrative philosophy, and anti-pattern constraints for late-stage polish |
+
+The outline-level and chapter-level views are wired into implemented tools now. The scrubber and editor views exist as deterministic projections for the prose-quality passes.
+
+## File Location
+
+The canonical persona file lives at `stories/<name>/persona/persona.md`.
+
+This file is the source of truth. The tool reads it when generation-time persona injection happens. No cached per-view files are written beside it.
+
+## Generation Timing
+
+Persona generation happens during Phase 3, the outline phase. The `outline-planner` workflow generates story elements first, then calls `persona-builder generate`, then proceeds into persona-aware outline expansion and refinement.
+
+This placement keeps persona generation close to its source inputs: the outline-analysis chunks and story elements already owned by the outline phase.
+
+## Inspect, Edit, Regenerate
+
+Use the tool to inspect a specific projection:
+
+```bash
+persona-builder get-view --name <story> --view outline
+persona-builder get-view --name <story> --view chapter
+persona-builder get-view --name <story> --view scrubber
+persona-builder get-view --name <story> --view editor
+```
+
+To edit the persona by hand, open `stories/<name>/persona/persona.md`, change the text, and save the file. Nothing else is required. The runtime reads the file at generation time, so manual edits take effect on the next persona-aware generation call.
+
+To replace it entirely with a fresh generated version:
+
+```bash
+persona-builder regenerate --name <story>
+```
+
+`regenerate` archives the current persona, then generates a new canonical `persona.md`.
+
+## Hand Override
+
+Hand override is intentionally simple: edit `stories/<name>/persona/persona.md` in place.
+
+- No rebuild step required.
+- No derived-view cache to clear.
+- No extra sync command required.
+
+If you prefer full manual control, generate once, then keep refining the file yourself.
+
+## Emphasis Delta
+
+The persona itself is static for the story. Per-chapter tonal variation is handled separately through the emphasis delta.
+
+`scene-writer` receives the chapter persona view through `--persona-view chapter`. When emphasis delta is enabled, a short per-chapter tonal hint is also passed through `--emphasis-delta`. That hint is appended to the user message, not merged into the persona file and not injected as a separate system message.
+
+Use this distinction when debugging output:
+
+- Persona controls stable story-level voice.
+- Emphasis delta controls chapter-level tonal tilt.
+
+## Configuration
+
+The author-persona system is controlled through three generation settings.
+
+### Disable Persona Entirely
+
+Set the master switch to `false`:
+
+```yaml
+generation:
+  enable_author_persona: false
+```
+
+When disabled, the system skips persona generation and suppresses persona-view injection.
+
+### Disable Emphasis Delta Only
+
+Set the chapter-level tonal hint switch to `false`:
+
+```yaml
+generation:
+  enable_emphasis_delta: false
+```
+
+This leaves the static persona active while removing the extra per-chapter tonal hint.
+
+### Tune Persona Length
+
+The persona generator targets `generation.persona_word_budget`.
+
+- Default: `225`
+- Valid range: `100` to `500`
+
+```yaml
+generation:
+  persona_word_budget: 225
+```
+
+Lower values produce tighter personas for smaller-context or smaller-capacity models. Higher values allow a richer style profile when the model and token budget can afford it.
+
+## Analytical-Agent Exclusion
+
+Persona injection is for generative agents only. Analytical agents stay neutral.
+
+The system does not pass persona views into `recap-manager`, `critique-runner`, or `consistency-checker`. This follows ADR 015's exclusion principle: analytical passes should not be skewed toward the author's stylistic preferences. The same principle applies to outline-analysis sub-phases that extract or assess structure rather than generate prose.
+
+## Related
+
+- [ADR 015](../planning/adr/015-author-persona-system.md) — Author persona architecture, view model, and analytical-agent exclusion rationale
+- [Story Orchestrator](./story-orchestrator.md) — Pipeline placement and phase order

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -498,6 +498,7 @@ In addition to the primary phases, the orchestrator now runs three advisory meta
 **What the system does:**
 - Delegates to the `outline-planner` agent
 - Generates a detailed chapter-by-chapter outline
+- After `generate-elements` completes, calls `persona-builder generate` to create the story's author persona at `stories/<name>/persona/persona.md` before outline expansion and refinement use persona-aware views
 - Optionally runs `OutlineCriticAgent` before the approval gate (if `enable_outline_critique: true`)
 - Writes the in-progress outline to `pipeline_state.json` before opening the approval gate
 - When outline critique is enabled, runs six outline critics plus three arc analytics and persists the critic artefacts before the gate opens

--- a/tests/integration/test_persona_injection.py
+++ b/tests/integration/test_persona_injection.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import tools._io as tool_io
+import tools.critique_runner as critique_runner
+import tools.outline_generator as og
+import tools.persona_builder as pb
+import tools.recap_manager as rm
+import tools.scene_writer as sw
+
+
+VALID_PERSONA = """---
+genre: Fantasy
+subgenre: Gothic
+pov: Third person limited
+tense: Past
+created_at: 2026-05-08T12:00:00Z
+---
+
+## Identity
+You write haunted stories. You favour intimate framing.
+
+## Prose Texture
+You use supple sentences.
+
+## Dialogue Style
+You write with restraint.
+
+## Pacing Philosophy
+You prefer dramatized scenes.
+
+## Thematic Sensibility
+You explore moral pressure.
+
+## Narrative Philosophy
+You stay close to character fear.
+
+## Anti-Patterns
+- Avoid purple prose.
+- Avoid exposition dumps.
+"""
+
+LONG_VALID_PERSONA = """---
+genre: Fantasy
+subgenre: Gothic
+pov: Third person limited
+tense: Past
+created_at: 2026-05-08T12:00:00Z
+---
+
+## Identity
+You write haunted stories with intimate dread, precise sensory detail, close emotional pressure, and steady attention to choices, wounds, silence, memory, guilt, longing, ritual, omen, shadow, weather, and consequence in every paragraph.
+
+## Prose Texture
+You use supple sentences, tactile imagery, controlled rhythm, vivid nouns, restrained metaphor, lucid syntax, and deliberate repetition so each line feels musical, tense, legible, atmospheric, and emotionally exact without turning florid.
+
+## Dialogue Style
+You write with restraint, implication, interruption, subtext, hesitation, unfinished admissions, careful cadence, and pointed contrast so spoken language reveals desire, fear, history, class, intimacy, suspicion, and power without blunt explanation.
+
+## Pacing Philosophy
+You prefer dramatized scenes, accumulating pressure, incremental revelation, active choices, reactive consequences, and scene endings that bend the next beat forward with urgency, curiosity, dread, and irreversible movement.
+
+## Thematic Sensibility
+You explore moral pressure, inheritance, devotion, corruption, sacrifice, secrecy, grief, and the cost of love under strain, always tying abstract themes to concrete behavior, conflict, and image.
+
+## Narrative Philosophy
+You stay close to character fear, desire, bias, and misreading so viewpoint remains intimate, fallible, emotionally coherent, and rooted in the body, the room, the moment, and the price of action.
+
+## Anti-Patterns
+- Avoid purple prose, empty grandeur, vague abstraction, and decorative language without narrative function.
+- Avoid exposition dumps, flat summary, detached explanation, and convenient emotional shortcuts.
+"""
+
+
+def _create_story_dir(
+    tmp_path: Path, story_name: str = "test-story"
+) -> tuple[Path, str, Path]:
+    stories_dir = tmp_path / "stories"
+    story_dir = stories_dir / story_name
+    story_dir.mkdir(parents=True, exist_ok=True)
+    return stories_dir, story_name, story_dir
+
+
+def _patch_stories_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    stories_dir: Path,
+    *modules: object,
+) -> None:
+    monkeypatch.setenv("STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(tool_io, "STORIES_DIR", stories_dir)
+    for module in modules:
+        if hasattr(module, "STORIES_DIR"):
+            monkeypatch.setattr(module, "STORIES_DIR", stories_dir)
+
+
+def _write_savepoint(story_dir: Path, step_name: str, data: str) -> None:
+    savepoint_dir = story_dir / "savepoints"
+    if "/" in step_name:
+        parts = step_name.split("/")
+        filename = parts[-1]
+        target_dir = savepoint_dir.joinpath(*parts[:-1])
+        target_dir.mkdir(parents=True, exist_ok=True)
+        filepath = target_dir / f"{filename}.md"
+    else:
+        savepoint_dir.mkdir(parents=True, exist_ok=True)
+        filepath = savepoint_dir / f"{step_name}.md"
+    filepath.write_text(f"# Savepoint: {step_name}\n\n{data}", encoding="utf-8")
+
+
+def _write_required_persona_builder_savepoints(story_dir: Path) -> None:
+    _write_savepoint(story_dir, "core_story_foundation", "Foundation content")
+    _write_savepoint(story_dir, "tone_style", "Tone content")
+    _write_savepoint(story_dir, "theme_message", "Theme content")
+    _write_savepoint(story_dir, "story_elements", "Story elements content")
+
+
+def _write_persona_file(story_dir: Path, content: str = VALID_PERSONA) -> Path:
+    persona_dir = story_dir / "persona"
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    persona_path = persona_dir / "persona.md"
+    persona_path.write_text(content, encoding="utf-8")
+    return persona_path
+
+
+class TestPersonaInjection:
+    def test_persona_file_exists_after_generate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir, pb)
+        _write_required_persona_builder_savepoints(story_dir)
+        monkeypatch.setattr(pb, "_load_prompt", lambda *_a, **_kw: "prompt text")
+        monkeypatch.setattr(pb, "_call_llm", lambda *_a, **_kw: VALID_PERSONA)
+
+        pb.cmd_generate(story_name, word_budget=225)
+
+        persona_path = story_dir / "persona" / "persona.md"
+        assert persona_path.exists()
+        assert persona_path.read_text(encoding="utf-8").strip()
+
+    def test_persona_word_count_within_budget(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir, pb)
+        _write_required_persona_builder_savepoints(story_dir)
+        monkeypatch.setattr(pb, "_load_prompt", lambda *_a, **_kw: "prompt text")
+        monkeypatch.setattr(pb, "_call_llm", lambda *_a, **_kw: LONG_VALID_PERSONA)
+
+        pb.cmd_generate(story_name, word_budget=225)
+
+        content = (story_dir / "persona" / "persona.md").read_text(encoding="utf-8")
+        word_count = len(content.split())
+        assert 180 <= word_count <= 270
+
+    def test_outline_generator_injects_persona_as_system_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir, og)
+        _write_savepoint(story_dir, "story_elements", "Story elements content")
+        _write_savepoint(story_dir, "base_context", "Base context content")
+        _write_persona_file(story_dir)
+        monkeypatch.setattr(og, "_load_prompt", lambda *_a, **_kw: "prompt text")
+
+        calls: list[dict[str, object]] = []
+
+        def recording_llm(
+            *args: object, system_message: str | None = None, **kwargs: object
+        ) -> str:
+            calls.append(
+                {
+                    "args": args,
+                    "kwargs": kwargs,
+                    "system_message": system_message,
+                }
+            )
+            return "outline text"
+
+        monkeypatch.setattr(og, "_call_llm", recording_llm)
+        monkeypatch.setattr(og, "_call_llm_messages", recording_llm)
+
+        og.cmd_expand_chapter(
+            story_name,
+            1,
+            1,
+            5,
+            phase="chapter",
+            persona_view="outline",
+        )
+
+        assert any(call["system_message"] is not None for call in calls)
+        assert any("## Identity" in str(call["system_message"]) for call in calls)
+        assert any("haunted stories" in str(call["system_message"]) for call in calls)
+
+    def test_scene_writer_injects_persona_and_emphasis_delta(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir, sw)
+        _write_persona_file(story_dir)
+        monkeypatch.setattr(sw, "_load_prompt", lambda *_a, **_kw: "prompt text")
+
+        calls: list[dict[str, object]] = []
+
+        def recording_llm(
+            *args: object, system_message: str | None = None, **kwargs: object
+        ) -> str:
+            calls.append(
+                {
+                    "prompt": args[0] if args else "",
+                    "kwargs": kwargs,
+                    "system_message": system_message,
+                }
+            )
+            return "scene content"
+
+        monkeypatch.setattr(sw, "_call_llm", recording_llm)
+
+        sw.cmd_generate(
+            story_name,
+            1,
+            1,
+            "scene def",
+            "chapter outline",
+            persona_view="chapter",
+            emphasis_delta="feel tense",
+        )
+
+        assert any(call["system_message"] is not None for call in calls)
+        assert any("## Chapter Emphasis" in str(call["prompt"]) for call in calls)
+        assert any("feel tense" in str(call["prompt"]) for call in calls)
+
+    def test_recap_manager_no_system_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir)
+        _write_savepoint(story_dir, "chapter_1/content", "Chapter 1 text")
+        monkeypatch.setattr(rm, "_load_prompt", lambda *_a, **_kw: "prompt text")
+
+        calls: list[dict[str, object]] = []
+
+        def recording_llm(*args: object, **kwargs: object) -> str:
+            calls.append(kwargs)
+            return "[]"
+
+        monkeypatch.setattr(rm, "_call_llm", recording_llm)
+        monkeypatch.setattr(rm, "_extract_json_from_response", lambda *_a, **_kw: "[]")
+
+        rm.cmd_generate(story_name, 1, "2024-01-01")
+
+        assert calls
+        assert all("system_message" not in call for call in calls)
+
+    def test_critique_runner_no_system_message(self) -> None:
+        parameters = inspect.signature(critique_runner._call_llm_messages).parameters
+
+        assert "system_message" not in parameters
+
+    def test_no_persona_view_no_system_message_injection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir, og)
+        _write_savepoint(story_dir, "story_elements", "Story elements content")
+        _write_savepoint(story_dir, "base_context", "Base context content")
+        _write_persona_file(story_dir)
+        monkeypatch.setattr(og, "_load_prompt", lambda *_a, **_kw: "prompt text")
+
+        calls: list[dict[str, object]] = []
+
+        def recording_llm(
+            *args: object, system_message: str | None = None, **kwargs: object
+        ) -> str:
+            calls.append(
+                {
+                    "args": args,
+                    "kwargs": kwargs,
+                    "system_message": system_message,
+                }
+            )
+            return "outline text"
+
+        monkeypatch.setattr(og, "_call_llm", recording_llm)
+
+        og.cmd_expand_chapter(story_name, 1, 1, 5, phase="chapter")
+
+        assert calls
+        assert all(call["system_message"] is None for call in calls)
+
+    def test_no_emphasis_delta_no_delta_in_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stories_dir, story_name, story_dir = _create_story_dir(tmp_path)
+        _patch_stories_dir(monkeypatch, stories_dir, sw)
+        _write_persona_file(story_dir)
+        monkeypatch.setattr(sw, "_load_prompt", lambda *_a, **_kw: "prompt text")
+
+        calls: list[dict[str, object]] = []
+
+        def recording_llm(
+            *args: object, system_message: str | None = None, **kwargs: object
+        ) -> str:
+            calls.append(
+                {
+                    "prompt": args[0] if args else "",
+                    "kwargs": kwargs,
+                    "system_message": system_message,
+                }
+            )
+            return "scene content"
+
+        monkeypatch.setattr(sw, "_call_llm", recording_llm)
+
+        sw.cmd_generate(
+            story_name,
+            1,
+            1,
+            "scene def",
+            "chapter outline",
+            persona_view="chapter",
+        )
+
+        assert calls
+        assert all("## Chapter Emphasis" not in str(call["prompt"]) for call in calls)


### PR DESCRIPTION
## Summary

Closes the author-persona feature loop with an end-to-end integration test (Task 9) and four documentation deliverables (Task 10).

## Closes
Closes #407

## Changes
- [x] Implementation complete
- [x] All tests passing (8/8 verified)
- [x] Linting clean (ruff + mypy)

## Plan

### Task 9: Integration test
- `tests/integration/test_persona_injection.py` — 8 assertions verifying the full persona injection path
  1. Persona file generated at `stories/<name>/persona/persona.md`
  2. Word count within ±20% of `persona_word_budget`
  3. `outline_generator expand-chapter --persona-view outline` injects persona as `system_message`
  4. `scene_writer generate --persona-view chapter --emphasis-delta` injects persona + appends delta to prompt
  5. `recap_manager` calls do not include persona in `system_message`
  6. `critique_runner` `_call_llm_messages` API does not accept `system_message` (analytical-agent exclusion verified at API level)
  7. No `persona_view` arg → no `system_message` injection
  8. No `emphasis_delta` arg → no delta appended to prompt

### Task 10: Documentation
- `docs/features/author-persona.md` — new user-facing feature page covering all six required topics
- `docs/manual.md` — persona generation step added to Phase 3 (Outline)
- `.github/notes/architecture.md` — persona-builder added to tools table; pipeline phase documented
- `.github/notes/patterns.md` — new file with analytical-agent exclusion rule and persona view selection rules