### PR TITLE
feat(recap): flatten per-event Chroma storage + LLM markdown render on retrieval

### DIFF
--- a/prompts/recap/render_markdown.md
+++ b/prompts/recap/render_markdown.md
@@ -1,0 +1,18 @@
+# Recap Narrative Renderer
+
+You are a story continuity editor. Convert the structured event data below into a concise, readable narrative recap in plain English markdown.
+
+## Input
+
+<EVENTS>
+{events_json}
+</EVENTS>
+
+## Instructions
+
+- Write in past tense, flowing prose.
+- Group events by chapter or time period under `##` headings (e.g., `## Chapter 1 — Nov 14, 1998`).
+- For each event, write 1–3 sentences covering what happened, who was involved, where it occurred, and why it matters.
+- Include character development and emotional beats where relevant.
+- Keep the total recap concise — do not reproduce field names, JSON keys, or scaffolding.
+- Output markdown only. No preamble, no explanation outside the narrative.

--- a/src/presentation/agents/chapter_outline_expander.py
+++ b/src/presentation/agents/chapter_outline_expander.py
@@ -12,7 +12,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -68,7 +68,7 @@ class ChapterOutlineExpanderAgent:
                 recap_window=("character", 3),
             )
             wiki_context: str = ctx["wiki_snapshot"]
-            recap_context: str = "\n\n".join(ctx["recap_snippets"])
+            recap_context: str = render_recap_as_markdown(ctx["recap_snippets"])
         except Exception as exc:  # noqa: BLE001
             await self.wiki_bus.emit(
                 WikiContextEvent(

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -40,7 +40,7 @@ from presentation.pipeline_primitives import (
 from tools._io import STORIES_DIR, _atomic_write, _validate_story_name
 from tools._llm import extract_paragraph_tail
 from tools._persist import read_markdown_ref
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
 def _savepoint_path(story_name: str) -> Path:
@@ -216,11 +216,7 @@ class ChapterWriterAgent:
             recap_window=("chapter", 5),
         )
         base_context = _chapter_ctx["wiki_snapshot"]
-        recap_context = (
-            "\n\n".join(_chapter_ctx["recap_snippets"])
-            if _chapter_ctx["recap_snippets"]
-            else ""
-        )
+        recap_context = render_recap_as_markdown(_chapter_ctx["recap_snippets"])
         character_context = ""
         setting_context = ""
         await self.wiki_bus.emit(
@@ -764,8 +760,9 @@ class ChapterWriterAgent:
                 )
                 if _scene_ctx["wiki_snapshot"]:
                     scene_base_context = _scene_ctx["wiki_snapshot"]
-                if _scene_ctx["recap_snippets"]:
-                    scene_recap_context = "\n\n".join(_scene_ctx["recap_snippets"])
+                scene_recap_context = render_recap_as_markdown(
+                    _scene_ctx["recap_snippets"]
+                )
             except Exception:
                 pass
 

--- a/src/presentation/agents/consistency_checker.py
+++ b/src/presentation/agents/consistency_checker.py
@@ -13,7 +13,7 @@ from domain.value_objects.model_config import ModelConfig
 from infrastructure.prompts.prompt_loader import PromptLoader
 from tools._io import STORIES_DIR
 from tools._persist import read_markdown_ref
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 from presentation.pipeline_primitives import (
     TokenStreamBus,
     WikiContextBus,
@@ -257,7 +257,7 @@ class ConsistencyCheckerAgent:
             recap_window=("chapter", 3),
         )
         wiki_context: str = ctx["wiki_snapshot"]
-        recap_context: str = "\n\n".join(ctx["recap_snippets"])
+        recap_context: str = render_recap_as_markdown(ctx["recap_snippets"])
         wiki_relationships: str = ""
         scene_definitions = self._load_scene_definitions(story_name, chapter_number)
         system_prompt = loader.load_prompt(

--- a/src/presentation/agents/final_editor.py
+++ b/src/presentation/agents/final_editor.py
@@ -15,7 +15,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 from tools._io import _validate_story_name
 from tools._wiki import get_wiki_dir, match_entities_in_text, read_index
 
@@ -83,9 +83,7 @@ class FinalEditorAgent:
             recap_window=("chapter", 3),
         )
         wiki_context: str = _ctx["wiki_snapshot"]
-        recap_context: str = (
-            "\n\n".join(_ctx["recap_snippets"]) if _ctx["recap_snippets"] else ""
-        )
+        recap_context: str = render_recap_as_markdown(_ctx["recap_snippets"])
 
         if settings.enable_scrubbing:
             character_aliases = ""

--- a/src/presentation/agents/quality_reviewer.py
+++ b/src/presentation/agents/quality_reviewer.py
@@ -13,7 +13,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
 _CRITIQUE_PROMPTS: list[tuple[str, str]] = [
@@ -80,7 +80,7 @@ class QualityReviewerAgent:
                 recap_window=("chapter", 3),
             )
             wiki_context: str = ctx["wiki_snapshot"]
-            recap_context: str = "\n\n".join(ctx["recap_snippets"])
+            recap_context: str = render_recap_as_markdown(ctx["recap_snippets"])
         except Exception as exc:  # noqa: BLE001
             await self.wiki_bus.emit(
                 WikiContextEvent(

--- a/src/presentation/agents/recap_writer.py
+++ b/src/presentation/agents/recap_writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,13 +18,33 @@ from presentation.pipeline_primitives import (
 )
 from tools._io import STORIES_DIR
 from tools._wiki import get_wiki_dir, match_entities_in_text, read_index
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
     models = config.get("models", {})
     model_name = models.get(role, default)
     return ModelConfig.from_string(model_name)
+
+
+def _parse_events_from_json(text: str) -> list[dict]:
+    """Extract a list of event dicts from an LLM JSON response."""
+    if not text:
+        return []
+    stripped = text.strip()
+    fence_match = re.search(r"```(?:json)?\s*([\s\S]*?)```", stripped)
+    candidate = fence_match.group(1).strip() if fence_match else stripped
+    try:
+        obj = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if isinstance(obj, list):
+        return [e for e in obj if isinstance(e, dict)]
+    if isinstance(obj, dict):
+        events = obj.get("events")
+        if isinstance(events, list):
+            return [e for e in events if isinstance(e, dict)]
+    return []
 
 
 class RecapWriterAgent:
@@ -109,9 +130,7 @@ class RecapWriterAgent:
                 recap_window=("character", 5),
             )
             _wiki_context = _ctx["wiki_snapshot"]
-            _recap_snippets = _ctx["recap_snippets"]
-            if _recap_snippets:
-                _related_recap_history = "\n\n".join(_recap_snippets)
+            _related_recap_history = render_recap_as_markdown(_ctx["recap_snippets"])
         except Exception:
             pass
 
@@ -134,20 +153,18 @@ class RecapWriterAgent:
             settings,
         )
         if not events:
-            return {"events": "", "compact": "", "sanitised": ""}
+            return {"events": []}
 
         if not settings.use_multi_stage_recap_sanitizer:
             await self._emit_stage(chapter_number, "format json")
-            compact = await self._run_stage(
+            formatted = await self._run_stage(
                 "recap/format_json",
                 {"enriched_events": events},
                 model_config,
                 settings,
             )
             return {
-                "events": events,
-                "compact": compact,
-                "sanitised": compact,
+                "events": _parse_events_from_json(formatted),
             }
 
         await self._emit_stage(chapter_number, "assign event timing")
@@ -178,31 +195,6 @@ class RecapWriterAgent:
             settings,
         )
 
-        await self._emit_stage(chapter_number, "compact events")
-        compact = await self._run_stage(
-            "recap/compact_events",
-            {"events_json": formatted},
-            model_config,
-            settings,
-        )
-
-        sanitised = compact
-        if settings.use_improved_recap_sanitizer:
-            await self._emit_stage(chapter_number, "sanitize")
-            sanitised = await self._run_stage(
-                "recap/sanitize",
-                {
-                    "recap": compact,
-                    "story_start_date": story_start_date,
-                    "previous_chapter_recap": previous_recap,
-                    "related_recap_history": _related_recap_history,
-                },
-                model_config,
-                settings,
-            )
-
         return {
-            "events": events,
-            "compact": compact,
-            "sanitised": sanitised,
+            "events": _parse_events_from_json(formatted),
         }

--- a/src/presentation/agents/story_metadata.py
+++ b/src/presentation/agents/story_metadata.py
@@ -16,7 +16,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -112,9 +112,7 @@ class StoryMetadataAgent:
             token_budget=20000,
         )
         wiki_context: str = _ctx["wiki_snapshot"]
-        recap_context: str = (
-            "\n\n".join(_ctx["recap_snippets"]) if _ctx["recap_snippets"] else ""
-        )
+        recap_context: str = render_recap_as_markdown(_ctx["recap_snippets"])
 
         model_config = _build_model_config(
             self.config, "story_metadata", "openai-compat://default"

--- a/src/presentation/agents/story_planner.py
+++ b/src/presentation/agents/story_planner.py
@@ -18,7 +18,7 @@ from presentation.pipeline_primitives import (
 )
 from tools._io import STORIES_DIR
 from tools._persist import read_markdown_ref
-from tools.context_assembly import assemble_context
+from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -99,7 +99,7 @@ class StoryPlannerAgent:
                     recap_window=("chapter", 5),
                 )
                 wiki_context: str = ctx["wiki_snapshot"]
-                recap_context: str = "\n\n".join(ctx["recap_snippets"])
+                recap_context: str = render_recap_as_markdown(ctx["recap_snippets"])
             except Exception as exc:  # noqa: BLE001
                 await self.wiki_bus.emit(
                     WikiContextEvent(

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -47,7 +47,7 @@ from presentation.pipeline_primitives import (
 from tools import recap_index, wiki_generation
 from tools._io import STORIES_DIR, _atomic_write, _validate_story_name
 from tools._persist import persist_markdown, read_markdown_ref
-from tools._wiki import find_pages, get_wiki_dir, read_index, slugify as wiki_slugify
+from tools._wiki import find_pages, get_wiki_dir, slugify as wiki_slugify
 from tools.wiki_extract import _bootstrap_single_wiki_entity, _list_wiki_entities
 from tools.wiki_init import _init_wiki_for_story
 from tools.wiki_update import run_batch as wiki_update_run_batch
@@ -1287,70 +1287,25 @@ async def _continue_pipeline(
                         )
                         # --- recap index upsert ---
                         try:
-                            _recap_participants: list[str] = []
-                            _recap_locations: list[str] = []
-                            _raw_events = recap_result.get("events") or ""
-                            if _raw_events:
-                                try:
-                                    _wiki_index = read_index(story_dir / "wiki")
-                                    _name_to_slug: dict[str, str] = {}
-                                    for _entry in _wiki_index:
-                                        _entry_name = str(
-                                            _entry.get("name") or ""
-                                        ).strip()
-                                        _entry_slug = str(
-                                            _entry.get("slug") or ""
-                                        ).strip()
-                                        if _entry_name and _entry_slug:
-                                            _name_to_slug[_entry_name.lower()] = (
-                                                _entry_slug
-                                            )
-                                        for _alias in _coerce_string_list(
-                                            _entry.get("aliases")
-                                        ):
-                                            _name_to_slug[_alias.lower()] = _entry_slug
-                                    _decoded_events = json.loads(_raw_events)
-                                    if isinstance(_decoded_events, list):
-                                        _events_list = [
-                                            _event
-                                            for _event in _decoded_events
-                                            if isinstance(_event, dict)
-                                        ]
-                                    else:
-                                        _events_list = []
-                                except (ValueError, TypeError):
-                                    _events_list = []
-                                    _name_to_slug = {}
-                                for _ev in _events_list:
-                                    for _name in _coerce_string_list(
-                                        _ev.get("participants") or _ev.get("characters")
-                                    ):
-                                        _slug = _name_to_slug.get(_name.lower())
-                                        if _slug:
-                                            _recap_participants.append(_slug)
-                                    for _name in _coerce_string_list(
-                                        _ev.get("locations")
-                                    ):
-                                        _slug = _name_to_slug.get(_name.lower())
-                                        if _slug:
-                                            _recap_locations.append(_slug)
-                            # deduplicate while preserving order
-                            _recap_participants = list(
-                                dict.fromkeys(_recap_participants)
+                            _parsed_events: list[dict] = (
+                                recap_result["events"]
+                                if isinstance(recap_result.get("events"), list)
+                                else []
                             )
-                            _recap_locations = list(dict.fromkeys(_recap_locations))
                             await asyncio.to_thread(
-                                recap_index.upsert_recap,
+                                recap_index.delete_chapter_events,
                                 state.story_name,
                                 chapter_number,
-                                recap_result,
-                                _recap_participants or None,
-                                _recap_locations or None,
+                            )
+                            await asyncio.to_thread(
+                                recap_index.upsert_recap_events,
+                                state.story_name,
+                                chapter_number,
+                                _parsed_events,
                             )
                             await bus.emit(
-                                f"[Recap] indexed chapter {chapter_number} aggregate "
-                                f"({len(_recap_participants)} participants, "
-                                f"{len(_recap_locations)} locations)\n"
+                                f"[Recap] indexed chapter {chapter_number} "
+                                f"({len(_parsed_events)} events)\n"
                             )
                         except Exception as _exc:  # noqa: BLE001
                             await bus.emit(f"[Recap] index upsert failed: {_exc}\n")

--- a/src/tools/_wiki_api.py
+++ b/src/tools/_wiki_api.py
@@ -22,6 +22,7 @@ from tools._wiki import (
 )
 from tools.recap_index import query_recap
 from tools.wiki_update import _upsert_to_chromadb, run_batch
+from tools.context_assembly import render_recap_as_markdown
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -709,7 +710,7 @@ def update_wiki_full_pass(
                 for recap_result in _recap_results
                 if recap_result.get("document")
             ]
-            _prior_recap_context = "\n\n---\n\n".join(_snippets)
+            _prior_recap_context = render_recap_as_markdown(_snippets)
     except Exception as _recap_exc:
         logging.warning(
             "[Wiki] WARNING event recap context unavailable: %s",

--- a/src/tools/context_assembly.py
+++ b/src/tools/context_assembly.py
@@ -6,7 +6,7 @@ import sys
 from typing import Any, Literal
 
 from domain.exceptions import StoryGenerationError
-from tools._llm import count_tokens
+from tools._llm import count_tokens, generate_text
 from tools.recap_index import query_recap
 from tools.wiki_snapshot import get_snapshot
 
@@ -89,6 +89,35 @@ def assemble_context(
     )
 
     return {"wiki_snapshot": wiki_text, "recap_snippets": recap_snippets}
+
+
+def render_recap_as_markdown(snippets: list[str]) -> str:
+    """Convert a list of recap event JSON strings to a concise markdown narrative.
+
+    Returns an empty string if snippets is empty.
+    Calls the local LLM synchronously.
+    """
+    if not snippets:
+        return ""
+    import pathlib
+
+    from infrastructure.prompts.prompt_loader import PromptLoader
+
+    _loader = PromptLoader(
+        prompts_dir=str(pathlib.Path(__file__).resolve().parents[2] / "prompts")
+    )
+    combined = "\n\n---\n\n".join(snippets)
+    try:
+        prompt = _loader.load_prompt(
+            "recap/render_markdown", variables={"events_json": combined}
+        )
+        return generate_text(prompt)
+    except Exception as exc:
+        print(
+            f"[ContextAssembly] Warning: recap markdown render failed: {exc}",
+            file=sys.stderr,
+        )
+        return "\n\n".join(snippets)
 
 
 def _retrieve_wiki(

--- a/src/tools/recap_index.py
+++ b/src/tools/recap_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -70,6 +71,71 @@ def upsert_recap(
         extra_metadata=metadata,
         body=body,
     )
+
+
+def delete_chapter_events(story_name: str, chapter: int) -> None:
+    """Delete all recap event docs for a chapter from the story collection."""
+    collection = _get_or_create_collection(story_name)
+    collection.delete(where={"chapter": chapter})
+
+
+def clear_recap_index(story_name: str) -> None:
+    """Drop and recreate the story recap collection (clean slate on restart)."""
+    import chromadb  # type: ignore[import-not-found]
+
+    client = chromadb.PersistentClient(path=CHROMADB_DIR)
+    collection_name = f"recaps-{_normalize_story_name(story_name)}"
+    client.delete_collection(collection_name)
+    client.get_or_create_collection(name=collection_name)
+
+
+def upsert_recap_events(
+    story_name: str,
+    chapter: int,
+    events: list[dict],
+) -> None:
+    """Upsert each event as its own Chroma document (flat storage)."""
+    collection = _get_or_create_collection(story_name)
+    story_slug = _normalize_story_name(story_name)
+    delete_chapter_events(story_name, chapter)
+    for i, event in enumerate(events, start=1):
+        doc_id = f"event/{chapter}/{i}"
+        raw_participants = event.get("participants") or event.get("characters") or []
+        raw_locations = event.get("locations") or []
+        pipe_participants = "|".join(str(p) for p in raw_participants if p)
+        pipe_locations = "|".join(str(loc) for loc in raw_locations if loc)
+        narrative_fields: dict = {}
+        for key in (
+            "summary",
+            "key_events",
+            "character_development",
+            "symbols_motifs",
+            "impact",
+        ):
+            if key in event:
+                narrative_fields[key] = event[key]
+        body = (
+            f"participants:{pipe_participants}\n"
+            f"locations:{pipe_locations}\n\n"
+            f"{json.dumps(narrative_fields, ensure_ascii=False)}"
+        )
+        metadata = {
+            "chapter": chapter,
+            "kind": "event",
+            "story": story_slug,
+            "participants": pipe_participants,
+            "locations": pipe_locations,
+            "date_start": str(event.get("date_start", "")),
+            "date_end": str(event.get("date_end", "")),
+            "importance": str(event.get("importance", "medium")),
+        }
+        upsert_from_source(
+            collection,
+            doc_id,
+            source_path="",
+            extra_metadata=metadata,
+            body=body,
+        )
 
 
 def _build_where_clause(
@@ -173,7 +239,7 @@ def query_recap(
 
     if chapter is not None and where_doc_clause is None and chapter_range is None:
         result = collection.get(
-            ids=[f"aggregate/{chapter}"],
+            where={"chapter": chapter},
             include=["documents", "metadatas"],
         )
         return _flatten_get_results(result)

--- a/tests/unit/test_orchestrator_recap_index.py
+++ b/tests/unit/test_orchestrator_recap_index.py
@@ -67,67 +67,32 @@ def _extract_recap_entity_slugs(
 
 async def _run_recap_index_upsert_block(
     *,
-    story_dir: Path,
     story_name: str,
     chapter_number: int,
-    recap_result: dict[str, str],
+    recap_result: dict,
     bus: MagicMock,
 ) -> None:
-    recap_participants: list[str] = []
-    recap_locations: list[str] = []
-
     try:
-        raw_events = recap_result.get("events") or ""
-        if raw_events:
-            try:
-                wiki_index = orchestrator.read_index(story_dir / "wiki")
-                name_to_slug: dict[str, str] = {}
-                for entry in wiki_index:
-                    entry_name = str(entry.get("name") or "").strip()
-                    entry_slug = str(entry.get("slug") or "").strip()
-                    if entry_name and entry_slug:
-                        name_to_slug[entry_name.lower()] = entry_slug
-                    for alias in orchestrator._coerce_string_list(entry.get("aliases")):
-                        name_to_slug[alias.lower()] = entry_slug
-                decoded_events = json.loads(raw_events)
-                if isinstance(decoded_events, list):
-                    events_list = [
-                        event for event in decoded_events if isinstance(event, dict)
-                    ]
-                else:
-                    events_list = []
-            except (ValueError, TypeError):
-                events_list = []
-                name_to_slug = {}
-
-            for event in events_list:
-                for name in orchestrator._coerce_string_list(
-                    event.get("participants") or event.get("characters")
-                ):
-                    slug = name_to_slug.get(name.lower())
-                    if slug:
-                        recap_participants.append(slug)
-                for name in orchestrator._coerce_string_list(event.get("locations")):
-                    slug = name_to_slug.get(name.lower())
-                    if slug:
-                        recap_locations.append(slug)
-
-        recap_participants = list(dict.fromkeys(recap_participants))
-        recap_locations = list(dict.fromkeys(recap_locations))
+        _parsed_events: list[dict] = (
+            recap_result["events"]
+            if isinstance(recap_result.get("events"), list)
+            else []
+        )
         await orchestrator.asyncio.to_thread(
-            orchestrator.recap_index.upsert_recap,
+            orchestrator.recap_index.delete_chapter_events,
             story_name,
             chapter_number,
-            recap_result,
-            recap_participants or None,
-            recap_locations or None,
+        )
+        await orchestrator.asyncio.to_thread(
+            orchestrator.recap_index.upsert_recap_events,
+            story_name,
+            chapter_number,
+            _parsed_events,
         )
         await bus.emit(
-            f"[Recap] indexed chapter {chapter_number} aggregate "
-            f"({len(recap_participants)} participants, "
-            f"{len(recap_locations)} locations)\n"
+            f"[Recap] indexed chapter {chapter_number} ({len(_parsed_events)} events)\n"
         )
-    except Exception as exc:  # pragma: no cover - failure path not target here
+    except Exception as exc:  # pragma: no cover
         await bus.emit(f"[Recap] index upsert failed: {exc}\n")
 
 
@@ -184,28 +149,8 @@ def test_slug_resolution_deduplicates_participants() -> None:
 
 @pytest.mark.asyncio
 async def test_upsert_called_for_chapter_with_events(tmp_path: Path) -> None:
-    story_dir = tmp_path / "test-story"
-    story_dir.mkdir()
-    wiki_index = [
-        {
-            "name": "Amy Miller",
-            "slug": "amy-miller",
-            "type": "character",
-            "aliases": ["Amy"],
-            "path": "characters/amy-miller.md",
-        },
-        {
-            "name": "The Park",
-            "slug": "the-park",
-            "type": "location",
-            "aliases": [],
-            "path": "locations/the-park.md",
-        },
-    ]
     recap_result = {
-        "events": json.dumps([{"participants": ["Amy"], "locations": ["The Park"]}]),
-        "compact": "compact text",
-        "sanitised": "sanitised text",
+        "events": [{"participants": ["Amy"], "locations": ["The Park"]}],
     }
     bus = MagicMock()
     bus.emit = AsyncMock()
@@ -214,8 +159,8 @@ async def test_upsert_called_for_chapter_with_events(tmp_path: Path) -> None:
         return func(*args)
 
     with (
-        patch.object(orchestrator, "read_index", return_value=wiki_index),
-        patch.object(orchestrator.recap_index, "upsert_recap") as upsert_mock,
+        patch.object(orchestrator.recap_index, "delete_chapter_events") as delete_mock,
+        patch.object(orchestrator.recap_index, "upsert_recap_events") as upsert_mock,
         patch.object(
             orchestrator.asyncio,
             "to_thread",
@@ -223,33 +168,25 @@ async def test_upsert_called_for_chapter_with_events(tmp_path: Path) -> None:
         ),
     ):
         await _run_recap_index_upsert_block(
-            story_dir=story_dir,
             story_name="test-story",
             chapter_number=1,
             recap_result=recap_result,
             bus=bus,
         )
 
+    delete_mock.assert_called_once_with("test-story", 1)
     upsert_mock.assert_called_once_with(
         "test-story",
         1,
-        recap_result,
-        ["amy-miller"],
-        ["the-park"],
+        [{"participants": ["Amy"], "locations": ["The Park"]}],
     )
-    bus.emit.assert_awaited_once_with(
-        "[Recap] indexed chapter 1 aggregate (1 participants, 1 locations)\n"
-    )
+    bus.emit.assert_awaited_once_with("[Recap] indexed chapter 1 (1 events)\n")
 
 
 @pytest.mark.asyncio
 async def test_upsert_called_for_chapter_without_events(tmp_path: Path) -> None:
-    story_dir = tmp_path / "test-story"
-    story_dir.mkdir()
-    recap_result = {
-        "events": "",
-        "compact": "compact text",
-        "sanitised": "sanitised text",
+    recap_result: dict = {
+        "events": [],
     }
     bus = MagicMock()
     bus.emit = AsyncMock()
@@ -258,8 +195,8 @@ async def test_upsert_called_for_chapter_without_events(tmp_path: Path) -> None:
         return func(*args)
 
     with (
-        patch.object(orchestrator, "read_index") as read_index_mock,
-        patch.object(orchestrator.recap_index, "upsert_recap") as upsert_mock,
+        patch.object(orchestrator.recap_index, "delete_chapter_events") as delete_mock,
+        patch.object(orchestrator.recap_index, "upsert_recap_events") as upsert_mock,
         patch.object(
             orchestrator.asyncio,
             "to_thread",
@@ -267,21 +204,12 @@ async def test_upsert_called_for_chapter_without_events(tmp_path: Path) -> None:
         ),
     ):
         await _run_recap_index_upsert_block(
-            story_dir=story_dir,
             story_name="test-story",
             chapter_number=1,
             recap_result=recap_result,
             bus=bus,
         )
 
-    read_index_mock.assert_not_called()
-    upsert_mock.assert_called_once_with(
-        "test-story",
-        1,
-        recap_result,
-        None,
-        None,
-    )
-    bus.emit.assert_awaited_once_with(
-        "[Recap] indexed chapter 1 aggregate (0 participants, 0 locations)\n"
-    )
+    delete_mock.assert_called_once_with("test-story", 1)
+    upsert_mock.assert_called_once_with("test-story", 1, [])
+    bus.emit.assert_awaited_once_with("[Recap] indexed chapter 1 (0 events)\n")

--- a/tests/unit/test_outline_chunked.py
+++ b/tests/unit/test_outline_chunked.py
@@ -95,7 +95,9 @@ async def test_chunked_exact_call_counts(tmp_path: Path) -> None:
     prompt_names = [call.args[0] for call in mock_load_prompt.call_args_list]
 
     assert isinstance(result, OutlineResult)
-    assert provider.stream_text.call_count == 11  # 1 skeleton + 5 chunks + 4 continuity + 1 enrichment
+    assert (
+        provider.stream_text.call_count == 11
+    )  # 1 skeleton + 5 chunks + 4 continuity + 1 enrichment
     assert prompt_names.count("outline/create_skeleton") == 1
     assert prompt_names.count("outline/create_chunk") == 5
     assert prompt_names.count("outline/analyze_continuity") == 4

--- a/tests/unit/test_recap_writer_agent.py
+++ b/tests/unit/test_recap_writer_agent.py
@@ -49,9 +49,7 @@ async def test_run_full_path_returns_events_compact_sanitised() -> None:
             "events text",
             "timed events",
             "enriched events",
-            '{"events": ["formatted"]}',
-            "compact recap",
-            "sanitised recap",
+            '[{"summary": "formatted event"}]',
         ]
     )
     bus = _StubBus()
@@ -72,16 +70,14 @@ async def test_run_full_path_returns_events_compact_sanitised() -> None:
         )
 
     assert result == {
-        "events": "events text",
-        "compact": "compact recap",
-        "sanitised": "sanitised recap",
+        "events": [{"summary": "formatted event"}],
     }
-    assert provider.generate_text.call_count == 6
+    assert provider.generate_text.call_count == 4
 
 
 @pytest.mark.asyncio
 async def test_run_short_path_two_calls() -> None:
-    provider = _ProviderStub(["events text", '{"events": ["formatted"]}'])
+    provider = _ProviderStub(["events text", '[{"key": "val"}]'])
     bus = _StubBus()
     wiki_bus = _StubWikiBus()
     agent = RecapWriterAgent(provider, {}, bus, wiki_bus)
@@ -104,9 +100,7 @@ async def test_run_short_path_two_calls() -> None:
         )
 
     assert provider.generate_text.call_count == 2
-    assert result["events"] == "events text"
-    assert result["compact"] == '{"events": ["formatted"]}'
-    assert result["sanitised"] == result["compact"]
+    assert result == {"events": [{"key": "val"}]}
 
 
 @pytest.mark.asyncio
@@ -116,8 +110,7 @@ async def test_run_skip_sanitizer_five_calls() -> None:
             "events text",
             "timed events",
             "enriched events",
-            '{"events": ["formatted"]}',
-            "compact recap",
+            '[{"summary": "formatted"}]',
         ]
     )
     bus = _StubBus()
@@ -141,10 +134,8 @@ async def test_run_skip_sanitizer_five_calls() -> None:
             ),
         )
 
-    assert provider.generate_text.call_count == 5
-    assert result["events"] == "events text"
-    assert result["compact"] == "compact recap"
-    assert result["sanitised"] == result["compact"]
+    assert provider.generate_text.call_count == 4
+    assert result == {"events": [{"summary": "formatted"}]}
 
 
 @pytest.mark.asyncio
@@ -168,9 +159,7 @@ async def test_run_stage1_failure_returns_empty_dict() -> None:
         )
 
     assert result == {
-        "events": "",
-        "compact": "",
-        "sanitised": "",
+        "events": [],
     }
 
 
@@ -213,9 +202,7 @@ async def test_run_accepts_empty_previous_recap_and_start_date() -> None:
             "events text",
             "timed events",
             "enriched events",
-            '{"events": ["formatted"]}',
-            "compact recap",
-            "sanitised recap",
+            '[{"summary": "formatted"}]',
         ]
     )
     bus = _StubBus()
@@ -236,7 +223,7 @@ async def test_run_accepts_empty_previous_recap_and_start_date() -> None:
         )
 
     assert isinstance(result, dict)
-    assert result["events"] == "events text"
+    assert isinstance(result["events"], list)
 
 
 @pytest.mark.asyncio
@@ -318,9 +305,7 @@ async def test_related_recap_history_injected_in_extract_events_prompt() -> None
             "events text",
             "timed events",
             "enriched events",
-            '{"events": ["formatted"]}',
-            "compact recap",
-            "sanitised recap",
+            '[{"summary": "formatted"}]',
         ]
     )
     bus = _StubBus()
@@ -342,6 +327,10 @@ async def test_related_recap_history_injected_in_extract_events_prompt() -> None
             },
         ),
         patch(
+            "presentation.agents.recap_writer.render_recap_as_markdown",
+            return_value="prior event 1\n\nprior event 2",
+        ),
+        patch(
             "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
             side_effect=capture_prompt,
         ),
@@ -361,26 +350,19 @@ async def test_related_recap_history_injected_in_extract_events_prompt() -> None
 
 
 @pytest.mark.asyncio
-async def test_related_recap_history_injected_in_sanitize_prompt() -> None:
+async def test_render_recap_as_markdown_called_with_snippets() -> None:
+    """render_recap_as_markdown is called with the snippets from assemble_context."""
     provider = _ProviderStub(
         [
             "events text",
             "timed events",
             "enriched events",
-            '{"events": ["formatted"]}',
-            "compact recap",
-            "sanitised recap",
+            '[{"summary": "formatted"}]',
         ]
     )
     bus = _StubBus()
     wiki_bus = _StubWikiBus()
     agent = RecapWriterAgent(provider, {}, bus, wiki_bus)
-    captured_variables: dict[str, object] = {}
-
-    def capture_prompt(name: str, variables: dict[str, object] | None = None) -> str:
-        if name == "recap/sanitize":
-            captured_variables.update(variables or {})
-        return f"prompt::{name}"
 
     with (
         patch(
@@ -391,8 +373,12 @@ async def test_related_recap_history_injected_in_sanitize_prompt() -> None:
             },
         ),
         patch(
+            "presentation.agents.recap_writer.render_recap_as_markdown",
+            return_value="prior event",
+        ) as render_mock,
+        patch(
             "infrastructure.prompts.prompt_loader.PromptLoader.load_prompt",
-            side_effect=capture_prompt,
+            side_effect=lambda name, variables=None: f"prompt::{name}",
         ),
     ):
         await agent.run(
@@ -404,9 +390,8 @@ async def test_related_recap_history_injected_in_sanitize_prompt() -> None:
             GenerationSettings.from_dict(
                 {
                     "use_multi_stage_recap_sanitizer": True,
-                    "use_improved_recap_sanitizer": True,
                 }
             ),
         )
 
-    assert "prior event" in str(captured_variables["related_recap_history"])
+    render_mock.assert_called_once_with(["prior event"])


### PR DESCRIPTION
## Summary

Flattens the recap pipeline to eliminate redundant JSON scaffolding in ChromaDB and adds LLM-based markdown rendering when recap context is injected into prompts.

## Closes
Closes #413

## Changes
- **`recap_index.py`**: `upsert_recap_events` stores each event as a separate Chroma doc (`event/{ch}/{i}`) with metadata `{chapter, importance, date_start, date_end, participants, locations}`. Added `delete_chapter_events` (idempotency) and `clear_recap_index` (story reset). Fixed `query_recap` fast path to use `where={"chapter": chapter}` filter instead of the now-dead `aggregate/{chapter}` ID lookup.
- **`recap_writer.py`**: Removed `compact_events` and `sanitize` LLM stages. Pipeline is now: extract → time → enrich → format_json → return `list[dict]`. No more `compact`/`sanitised` string fields.
- **`context_assembly.py`**: Added `render_recap_as_markdown(snippets)` — passes retrieved event snippets through `_llm.generate_text` with the new `recap/render_markdown` prompt. Falls back to joined raw text on error.
- **`prompts/recap/render_markdown.md`**: New prompt converting structured event JSON to flowing markdown prose grouped by chapter/date.
- **All agent callers** (`chapter_writer`, `recap_writer`, `final_editor`, `story_planner`, `quality_reviewer`, `chapter_outline_expander`, `story_metadata`, `consistency_checker`, `_wiki_api`): replaced `"\n\n".join(ctx["recap_snippets"])` with `render_recap_as_markdown(ctx["recap_snippets"])`.

## Plan
- [x] Flatten Chroma storage to per-event docs
- [x] Drop compact_events + sanitize stages
- [x] Add render_recap_as_markdown at retrieval
- [x] Add clear_recap_index for story reset
- [x] Update all agent callers
- [x] Tests updated
- [x] Lint + type-check clean
