### PR TITLE
refactor: unify scene critique scoring with CritiqueParser

### DIFF
--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -41,6 +41,7 @@ from tools._io import STORIES_DIR, _atomic_write, _validate_story_name
 from tools._llm import extract_paragraph_tail
 from tools._persist import read_markdown_ref
 from tools.context_assembly import assemble_context, render_recap_as_markdown
+from tools.critique_parser import CritiqueParser, passed_quality_threshold
 
 
 def _savepoint_path(story_name: str) -> Path:
@@ -940,8 +941,10 @@ class ChapterWriterAgent:
                         settings.seed,
                     )
                     critique_text = critique_text.strip()
-                    if critique_text and critique_text != "{}":
-                        # Non-empty findings — run one revision pass
+                    _scene_parser = CritiqueParser()
+                    _scene_result = _scene_parser.parse_scene_critique(critique_text)
+                    if not passed_quality_threshold(_scene_result.overall_score):
+                        # Score below threshold - run one revision pass
                         await self.status_bus.emit(
                             StatusEvent(
                                 phase=phase,

--- a/src/tools/critique_parser.py
+++ b/src/tools/critique_parser.py
@@ -1,9 +1,16 @@
 """Parse critique scores and summaries for the critique-runner tool."""
 
+import json
 import re
-from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
 from domain.exceptions import StoryGenerationError
+
+
+def passed_quality_threshold(score: float, threshold: float = 75.0) -> bool:
+    """Return True if score meets or exceeds threshold (0-100 scale)."""
+    return score >= threshold
 
 
 @dataclass
@@ -263,3 +270,60 @@ class CritiqueParser:
             feedback_parts.append("")
 
         return "\n".join(feedback_parts)
+
+    def parse_scene_critique(self, response: str) -> CritiqueResult:
+        """Parse a scene critique JSON response into a CritiqueResult.
+
+        The scene critique prompt returns a JSON object with optional keys:
+        ``outline_adherence``, ``pov_consistency``, ``continuity``,
+        ``style_violations``, each mapping to a list of finding strings.
+
+        Each category contributes up to 25 points. Every finding in a
+        category deducts 8 points, capped at 0 for that category.
+        An empty JSON object ``{}`` scores 100 (all categories clean).
+        """
+        categories = [
+            "outline_adherence",
+            "pov_consistency",
+            "continuity",
+            "style_violations",
+        ]
+        points_per_category = 25
+        deduction_per_finding = 8
+
+        try:
+            data = json.loads(response) if response.strip() else {}
+        except (json.JSONDecodeError, ValueError):
+            # Malformed response - treat as clean (no actionable findings)
+            data = {}
+
+        if not isinstance(data, dict):
+            data = {}
+
+        scores: list[CritiqueScore] = []
+        for category in categories:
+            findings = data.get(category) or []
+            if not isinstance(findings, list):
+                findings = []
+            findings = [finding for finding in findings if isinstance(finding, str)]
+            deduction = len(findings) * deduction_per_finding
+            raw = max(0.0, float(points_per_category - deduction))
+            percentage = (raw / points_per_category) * 100.0
+            notes = "; ".join(findings) if findings else "No issues found."
+            scores.append(
+                CritiqueScore(
+                    criterion=category,
+                    score=raw,
+                    max_score=float(points_per_category),
+                    percentage=percentage,
+                    notes=notes,
+                )
+            )
+
+        overall_score = self._calculate_overall_score(scores)
+        return CritiqueResult(
+            critic_type="scene-critique",
+            scores=scores,
+            summary=f"Scene critique: {int(overall_score)}/100",
+            overall_score=overall_score,
+        )

--- a/tests/unit/test_critique_parser_scene.py
+++ b/tests/unit/test_critique_parser_scene.py
@@ -1,0 +1,162 @@
+"""Verification tests for scene critique scoring in CritiqueParser."""
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from tools.critique_parser import CritiqueParser, passed_quality_threshold
+
+
+def _score_by_criterion(parser_result: object) -> dict[str, float]:
+    return {score.criterion: score.score for score in parser_result.scores}
+
+
+def test_parse_scene_critique_empty_json_returns_full_score() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique("{}")
+
+    assert result.overall_score == 100.0
+    assert _score_by_criterion(result) == {
+        "outline_adherence": 25.0,
+        "pov_consistency": 25.0,
+        "continuity": 25.0,
+        "style_violations": 25.0,
+    }
+
+
+def test_parse_scene_critique_single_finding_deducts_correctly() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique(
+        json.dumps({"outline_adherence": ["missing beat"]})
+    )
+
+    assert result.overall_score == 92.0
+    assert _score_by_criterion(result)["outline_adherence"] == 17.0
+
+
+def test_parse_scene_critique_multiple_findings_deduct_correctly() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique(json.dumps({"outline_adherence": ["x", "y"]}))
+
+    assert result.overall_score == 84.0
+    assert _score_by_criterion(result)["outline_adherence"] == 9.0
+
+
+def test_parse_scene_critique_findings_capped_at_zero_per_category() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique(
+        json.dumps({"outline_adherence": ["x", "y", "z", "w"]})
+    )
+
+    assert result.overall_score == 75.0
+    assert _score_by_criterion(result)["outline_adherence"] == 0.0
+
+
+def test_parse_scene_critique_all_categories_with_findings() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique(
+        json.dumps(
+            {
+                "outline_adherence": ["x"],
+                "pov_consistency": ["x"],
+                "continuity": ["x"],
+                "style_violations": ["x"],
+            }
+        )
+    )
+
+    assert result.overall_score == 68.0
+    assert _score_by_criterion(result) == {
+        "outline_adherence": 17.0,
+        "pov_consistency": 17.0,
+        "continuity": 17.0,
+        "style_violations": 17.0,
+    }
+
+
+def test_parse_scene_critique_malformed_json_returns_full_score() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique("not valid json")
+
+    assert result.overall_score == 100.0
+    assert all(score.score == 25.0 for score in result.scores)
+
+
+def test_parse_scene_critique_empty_string_returns_full_score() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique("")
+
+    assert result.overall_score == 100.0
+    assert all(score.score == 25.0 for score in result.scores)
+
+
+def test_parse_scene_critique_returns_scene_critique_type() -> None:
+    parser = CritiqueParser()
+
+    result = parser.parse_scene_critique("{}")
+
+    assert result.critic_type == "scene-critique"
+    assert result.summary == "Scene critique: 100/100"
+
+
+def test_passed_quality_threshold_passes_at_threshold() -> None:
+    assert passed_quality_threshold(75.0, 75.0) is True
+
+
+def test_passed_quality_threshold_fails_below_threshold() -> None:
+    assert passed_quality_threshold(74.9, 75.0) is False
+
+
+def test_passed_quality_threshold_default_threshold_is_75() -> None:
+    assert passed_quality_threshold(75.0) is True
+    assert passed_quality_threshold(74.9) is False
+
+
+def test_existing_outline_critic_still_works() -> None:
+    parser = CritiqueParser()
+    response = "\n".join(
+        [
+            "### Pacing (12/15)",
+            "Strong pacing overall.",
+            "",
+            "### Details (13/15)",
+            "Vivid details.",
+            "",
+            "### Flow (14/15)",
+            "Transitions work.",
+            "",
+            "### Genre (8/10)",
+            "Genre fit is clear.",
+            "",
+            "### Consistency (9/10)",
+            "Consistent throughout.",
+            "",
+            "### Character Arc & Theme (17/20)",
+            "Arc lands.",
+            "",
+            "### Structure (13/15)",
+            "Structure is solid.",
+            "",
+            "### Summary",
+            "Overall good work.",
+        ]
+    )
+
+    result = parser.parse_critique("audiobook-producer", response)
+
+    assert result.critic_type == "audiobook-producer"
+    assert len(result.scores) == 7
+    assert result.overall_score == 86.0
+    assert result.summary == "Overall good work."


### PR DESCRIPTION
## Summary

Extends `CritiqueParser` to handle the scene critique JSON category-array format, adding a canonical `passed_quality_threshold()` function shared by outline and scene critique loops. Updates `chapter_writer.py` to replace the raw string comparison with proper threshold-based scoring.

## Closes
Closes #415

## Changes
- [x] `passed_quality_threshold(score, threshold=75.0) -> bool` — module-level function in `critique_parser.py`
- [x] `CritiqueParser.parse_scene_critique(response)` — maps JSON category arrays to 0–100 score (4 categories × 25 pts, 8 pts deducted per finding, capped at 0)
- [x] `chapter_writer.py` updated to use parsed score + threshold check
- [x] 12 new unit tests — scene critique score path fully covered
- [x] All existing outline critique tests still pass (19/19)
- [x] Linting clean

## Plan
### Scoring model
Each of 4 categories (`outline_adherence`, `pov_consistency`, `continuity`, `style_violations`) contributes 25 pts. Each finding deducts 8 pts (capped at 0). Empty `{}` → score 100. Malformed/non-dict JSON → treated as clean.

### Threshold
Default 75.0 — matches the per-criterion threshold already used in `should_refine_outline`. Scenes scoring below 75 trigger a revision pass.

### Test coverage
- Empty JSON → score 100
- Single finding → correct deduction
- Multiple findings → correct deduction
- Findings capped at 0 per category
- All 4 categories with findings
- Malformed JSON → score 100 (graceful fallback)
- Empty string → score 100
- critic_type returns 'scene-critique'
- passed_quality_threshold: at threshold, below threshold, default=75