### PR TITLE
feat(critique): iterative scene critique loop with score threshold

### DIFF
--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -27,6 +27,9 @@ class GenerationSettings:
     enable_outline_critique: bool = True
     enable_concurrent_critics: bool = False
     enable_scene_critique: bool = True
+    enable_scene_critique_loop: bool = True
+    scene_critique_score_threshold: float = 80.0
+    scene_critique_max_iterations: int = 3
     enable_decomposition_critique: bool = True
     enable_beat_sheet: bool = False
     enable_living_scene_plan: bool = False
@@ -91,6 +94,18 @@ class GenerationSettings:
                 "and min must be <= max"
             )
 
+        if not (0.0 <= self.scene_critique_score_threshold <= 100.0):
+            raise ValidationError(
+                "scene_critique_score_threshold must be between 0.0 and 100.0, "
+                f"got {self.scene_critique_score_threshold}"
+            )
+
+        if not (1 <= self.scene_critique_max_iterations <= 10):
+            raise ValidationError(
+                "scene_critique_max_iterations must be between 1 and 10, "
+                f"got {self.scene_critique_max_iterations}"
+            )
+
         if self.scene_word_target_floor < 1:
             raise ValidationError(
                 "scene_word_target_floor must be at least 1, "
@@ -135,6 +150,9 @@ class GenerationSettings:
             "scene_word_target_ceiling": self.scene_word_target_ceiling,
             "enable_outline_critique": self.enable_outline_critique,
             "enable_scene_critique": self.enable_scene_critique,
+            "enable_scene_critique_loop": self.enable_scene_critique_loop,
+            "scene_critique_score_threshold": self.scene_critique_score_threshold,
+            "scene_critique_max_iterations": self.scene_critique_max_iterations,
             "enable_decomposition_critique": self.enable_decomposition_critique,
             "enable_beat_sheet": self.enable_beat_sheet,
             "enable_living_scene_plan": self.enable_living_scene_plan,

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -943,21 +943,51 @@ class ChapterWriterAgent:
                     critique_text = critique_text.strip()
                     _scene_parser = CritiqueParser()
                     _scene_result = _scene_parser.parse_scene_critique(critique_text)
-                    if not passed_quality_threshold(_scene_result.overall_score):
-                        # Score below threshold - run one revision pass
+                    _critique_score = _scene_result.overall_score
+                    _critique_iteration = 0
+
+                    while (
+                        settings.enable_scene_critique_loop
+                        and _critique_iteration < settings.scene_critique_max_iterations
+                        and not passed_quality_threshold(
+                            _critique_score,
+                            settings.scene_critique_score_threshold,
+                        )
+                    ):
+                        _critique_iteration += 1
+                        _iter_label = (
+                            "iter "
+                            f"{_critique_iteration}/"
+                            f"{settings.scene_critique_max_iterations}"
+                        )
                         await self.status_bus.emit(
                             StatusEvent(
                                 phase=phase,
                                 message=(
                                     f"Ch {chapter_number}: revising scene "
-                                    f"{index}/{total_scenes}"
+                                    f"{index}/{total_scenes} ({_iter_label}, "
+                                    f"score {_critique_score:.0f})"
                                 ),
                                 kind="step",
                             )
                         )
                         await self.bus.emit(
-                            f"\n[Chapter {chapter_number}] Revising scene {index}...\n"
+                            f"\n[Chapter {chapter_number}] Revising scene {index} "
+                            f"({_iter_label}, score {_critique_score:.0f}/100)...\n"
                         )
+
+                        _iter_critique_file = (
+                            scenes_dir
+                            / f"scene_{index}_critique_iter_{_critique_iteration}.txt"
+                        )
+                        try:
+                            _iter_critique_file.parent.mkdir(
+                                parents=True, exist_ok=True
+                            )
+                            _atomic_write(_iter_critique_file, critique_text)
+                        except OSError:
+                            pass
+
                         revise_prompt = loader.load_prompt(
                             "scenes/revise_content",
                             variables={
@@ -992,11 +1022,80 @@ class ChapterWriterAgent:
                             revised = revised.strip()
                             if revised:
                                 scene_text = revised
+                                _iter_scene_file = (
+                                    scenes_dir / f"scene_{index}_critique_iter_"
+                                    f"{_critique_iteration}.md"
+                                )
+                                try:
+                                    _atomic_write(_iter_scene_file, scene_text)
+                                except OSError:
+                                    pass
                         except Exception as exc:
                             await self.bus.emit(
                                 f"\n[Chapter {chapter_number}] scene {index} revision "
-                                f"failed ({type(exc).__name__}: {exc}); using draft.\n"
+                                f"({_iter_label}) failed "
+                                f"({type(exc).__name__}: {exc}); keeping current draft.\n"
                             )
+                            break
+
+                        if _critique_iteration < settings.scene_critique_max_iterations:
+                            re_critique_prompt = loader.load_prompt(
+                                "scenes/critique_draft",
+                                variables={
+                                    "chapter_num": str(chapter_number),
+                                    "scene_num": str(index),
+                                    "scene_content": scene_text,
+                                    "scene_definition": json.dumps(
+                                        scene, ensure_ascii=False
+                                    ),
+                                    "chapter_outline": chapter_summary,
+                                    "previous_scene": prev_tail,
+                                },
+                            )
+                            try:
+                                critique_text = await self._stream_to_bus(
+                                    [
+                                        {
+                                            "role": "system",
+                                            "content": re_critique_prompt,
+                                        },
+                                        {
+                                            "role": "user",
+                                            "content": "Critique the scene now.",
+                                        },
+                                    ],
+                                    scene_model,
+                                    settings.seed,
+                                )
+                                critique_text = critique_text.strip()
+                                _scene_result = _scene_parser.parse_scene_critique(
+                                    critique_text
+                                )
+                                _critique_score = _scene_result.overall_score
+                            except Exception as exc:
+                                await self.bus.emit(
+                                    f"\n[Chapter {chapter_number}] scene {index} "
+                                    f"re-critique ({_iter_label}) failed "
+                                    f"({type(exc).__name__}: {exc}); stopping loop.\n"
+                                )
+                                break
+
+                    await self.status_bus.emit(
+                        StatusEvent(
+                            phase=phase,
+                            message=(
+                                f"Ch {chapter_number}: scene {index}/{total_scenes} "
+                                f"critique done - score {_critique_score:.0f}/100 "
+                                f"after {_critique_iteration} revision(s)"
+                            ),
+                            kind="step",
+                        )
+                    )
+                    await self.bus.emit(
+                        f"\n[Chapter {chapter_number}] Scene {index} critique complete: "
+                        f"score {_critique_score:.0f}/100 "
+                        f"after {_critique_iteration} revision(s).\n"
+                    )
                 except Exception as exc:
                     await self.bus.emit(
                         f"\n[Chapter {chapter_number}] scene {index} critique "

--- a/tests/unit/test_chapter_writer.py
+++ b/tests/unit/test_chapter_writer.py
@@ -1,0 +1,267 @@
+"""Verification tests for iterative scene critique loop (#416)."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import OutlineResult
+from domain.exceptions import ValidationError
+from domain.value_objects.generation_settings import GenerationSettings
+from presentation.agents.chapter_writer import ChapterWriterAgent
+from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+
+
+@pytest.fixture(autouse=True)
+def stub_assemble_context(monkeypatch, tmp_path: Path):
+    wiki_dir = tmp_path / "test-story" / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "presentation.agents.chapter_writer.assemble_context",
+        lambda *args, **kwargs: {
+            "wiki_snapshot": "## Wiki",
+            "recap_snippets": [],
+        },
+    )
+
+
+def _outline_result() -> OutlineResult:
+    return OutlineResult(
+        story_name="test-story",
+        chapter_outlines=[
+            {"chapter_number": 1, "title": "Ch 1", "summary": "Chapter 1 summary"},
+        ],
+        summary="Story summary",
+        genre="fantasy",
+        themes=["courage"],
+    )
+
+
+def _settings(**overrides: object) -> GenerationSettings:
+    base = {
+        "wanted_chapters": 1,
+        "seed": 42,
+        "scene_generation_pipeline": True,
+        "scenes_per_chapter_min": 1,
+        "scenes_per_chapter_max": 2,
+        "enable_scene_critique": True,
+        "enable_scene_critique_loop": True,
+        "scene_critique_score_threshold": 80.0,
+        "scene_critique_max_iterations": 3,
+        "enable_scrubbing": False,
+        "enable_decomposition_critique": False,
+        "enable_beat_sheet": False,
+        "enable_living_scene_plan": False,
+        "enable_outline_critique": False,
+        "enable_author_persona": False,
+        "expand_outline": False,
+    }
+    base.update(overrides)
+    return GenerationSettings(**base)
+
+
+def _make_provider(responses: list[str]) -> MagicMock:
+    provider = MagicMock()
+    response_iter = iter(responses)
+
+    async def fake_stream(messages, model_config, seed=None):
+        try:
+            text = next(response_iter)
+        except StopIteration:
+            text = ""
+        yield text
+
+    provider.stream_text = fake_stream
+    return provider
+
+
+def _one_scene() -> list[dict[str, object]]:
+    return [
+        {
+            "title": "Scene A",
+            "description": "First scene.",
+            "characters": ["Alice"],
+            "setting": "Forest",
+            "key_events": ["Alice arrives"],
+            "ending": "Alice rests",
+        }
+    ]
+
+
+def _render_prompt(prompt_key: str, *, variables: dict[str, object]) -> str:
+    return (
+        f"PROMPT::{prompt_key}\n"
+        f"{json.dumps(variables, sort_keys=True, ensure_ascii=False)}"
+    )
+
+
+async def _run_agent(
+    tmp_path: Path,
+    responses: list[str],
+    settings: GenerationSettings,
+) -> object:
+    provider = _make_provider(responses)
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    config = {
+        "models": {
+            "chapter_writer": "openai-compat://test",
+            "chapter_outline_writer": "openai-compat://test",
+            "scene_writer": "openai-compat://test",
+        }
+    }
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader = loader_cls.return_value
+        loader.load_prompt.side_effect = _render_prompt
+        agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
+        return await agent.run(
+            story_name="test-story",
+            chapter_number=1,
+            outline_result=_outline_result(),
+            settings=settings,
+        )
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_loop_exits_when_score_reaches_threshold(
+    tmp_path: Path,
+) -> None:
+    scenes_json = json.dumps(_one_scene())
+    crit_60 = json.dumps(
+        {
+            "outline_adherence": ["missing beat A", "missing beat B"],
+            "pov_consistency": ["POV shift at para 3"],
+            "continuity": ["break at opening"],
+            "style_violations": ["purple prose"],
+        }
+    )
+    crit_76 = json.dumps(
+        {
+            "outline_adherence": ["missing beat A"],
+            "pov_consistency": ["POV shift"],
+            "continuity": ["minor break"],
+        }
+    )
+    crit_84 = json.dumps(
+        {
+            "outline_adherence": ["minor issue"],
+            "pov_consistency": ["slight drift"],
+        }
+    )
+
+    draft = await _run_agent(
+        tmp_path,
+        [
+            "Expanded synopsis.",
+            scenes_json,
+            "Scene prose draft.",
+            crit_60,
+            "Revised scene v1.",
+            crit_76,
+            "Revised scene v2.",
+            crit_84,
+            "Scene ending recap.",
+        ],
+        _settings(),
+    )
+
+    assert "Revised scene v2." in draft.content
+    assert (
+        tmp_path
+        / "test-story"
+        / "chapters"
+        / "chapter_1"
+        / "scene_1_critique_iter_1.txt"
+    ).exists()
+    assert (
+        tmp_path
+        / "test-story"
+        / "chapters"
+        / "chapter_1"
+        / "scene_1_critique_iter_2.md"
+    ).exists()
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_loop_disabled_runs_no_revision(tmp_path: Path) -> None:
+    scenes_json = json.dumps(_one_scene())
+    crit_below = json.dumps({"outline_adherence": ["missing beat A", "missing beat B"]})
+
+    draft = await _run_agent(
+        tmp_path,
+        [
+            "Expanded synopsis.",
+            scenes_json,
+            "Scene prose draft.",
+            crit_below,
+            "Scene ending recap.",
+        ],
+        _settings(enable_scene_critique_loop=False),
+    )
+
+    assert "Scene prose draft." in draft.content
+    assert "Revised scene" not in draft.content
+
+
+@pytest.mark.asyncio
+async def test_scene_critique_loop_exits_immediately_when_score_passes(
+    tmp_path: Path,
+) -> None:
+    scenes_json = json.dumps(_one_scene())
+
+    draft = await _run_agent(
+        tmp_path,
+        [
+            "Expanded synopsis.",
+            scenes_json,
+            "Scene prose draft.",
+            json.dumps({}),
+            "Scene ending recap.",
+        ],
+        _settings(),
+    )
+
+    assert "Scene prose draft." in draft.content
+    assert not (
+        tmp_path
+        / "test-story"
+        / "chapters"
+        / "chapter_1"
+        / "scene_1_critique_iter_1.txt"
+    ).exists()
+
+
+def test_generation_settings_scene_critique_loop_defaults() -> None:
+    settings = GenerationSettings()
+
+    assert settings.enable_scene_critique_loop is True
+    assert settings.scene_critique_score_threshold == 80.0
+    assert settings.scene_critique_max_iterations == 3
+    assert settings.to_dict()["scene_critique_score_threshold"] == 80.0
+
+
+def test_generation_settings_critique_threshold_validation() -> None:
+    with pytest.raises(ValidationError):
+        GenerationSettings(scene_critique_score_threshold=101.0)
+
+    with pytest.raises(ValidationError):
+        GenerationSettings(scene_critique_score_threshold=-1.0)
+
+
+def test_generation_settings_critique_max_iterations_validation() -> None:
+    with pytest.raises(ValidationError):
+        GenerationSettings(scene_critique_max_iterations=0)
+
+    with pytest.raises(ValidationError):
+        GenerationSettings(scene_critique_max_iterations=11)


### PR DESCRIPTION
## Summary

Adds an iterative scene critique loop to the auto-mode pipeline. Instead of a fixed single-pass revision, the pipeline now loops up to `scene_critique_max_iterations` times, re-critiquing after each revision and exiting when the scene scores ≥ `scene_critique_score_threshold`. Each iteration is persisted to disk for resumability, and the final score and iteration count are logged to the event bus and TUI status line.

## Closes
Closes #416

## Changes
- [x] `GenerationSettings`: add `enable_scene_critique_loop` (bool, default `True`), `scene_critique_score_threshold` (float, default `80.0`), `scene_critique_max_iterations` (int, default `3`) with validation
- [x] `chapter_writer.py`: replace single-pass revision with iterative critique/revise loop using configured threshold and max iterations; savepoint each iteration; log final score/revision count
- [x] `tests/unit/test_chapter_writer.py` (new): 6 unit tests covering loop exit on threshold, disabled loop, immediate pass, and settings defaults/validation
- [x] All new tests passing (6/6)
- [x] Linting clean

## Plan

**Summary**: Add iterative scene critique loop. When `enable_scene_critique_loop=True`, loop re-critiques after each revision up to `scene_critique_max_iterations` (default 3), exiting when score ≥ `scene_critique_score_threshold` (default 80.0). Each iteration persisted as file. Final score/iteration count logged to event bus.

**Task Checklist**:
- [x] `src/domain/value_objects/generation_settings.py` — add 3 new fields + validation + `to_dict()` entries
- [x] `src/presentation/agents/chapter_writer.py` — replace single-pass critique with iterative loop; savepoint each iter; log final score+count
- [x] `tests/unit/test_chapter_writer.py` (new) — 6 tests covering all loop scenarios
