### PR TITLE
feat: auto-mode chapter consistency revision loop

### DIFF
--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -30,6 +30,8 @@ class GenerationSettings:
     enable_scene_critique_loop: bool = True
     scene_critique_score_threshold: float = 80.0
     scene_critique_max_iterations: int = 3
+    enable_consistency_revision_loop: bool = True
+    consistency_max_iterations: int = 2
     enable_decomposition_critique: bool = True
     enable_beat_sheet: bool = False
     enable_living_scene_plan: bool = False
@@ -106,6 +108,12 @@ class GenerationSettings:
                 f"got {self.scene_critique_max_iterations}"
             )
 
+        if not (1 <= self.consistency_max_iterations <= 10):
+            raise ValidationError(
+                "consistency_max_iterations must be between 1 and 10, "
+                f"got {self.consistency_max_iterations}"
+            )
+
         if self.scene_word_target_floor < 1:
             raise ValidationError(
                 "scene_word_target_floor must be at least 1, "
@@ -153,6 +161,8 @@ class GenerationSettings:
             "enable_scene_critique_loop": self.enable_scene_critique_loop,
             "scene_critique_score_threshold": self.scene_critique_score_threshold,
             "scene_critique_max_iterations": self.scene_critique_max_iterations,
+            "enable_consistency_revision_loop": self.enable_consistency_revision_loop,
+            "consistency_max_iterations": self.consistency_max_iterations,
             "enable_decomposition_critique": self.enable_decomposition_critique,
             "enable_beat_sheet": self.enable_beat_sheet,
             "enable_living_scene_plan": self.enable_living_scene_plan,

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -515,6 +515,7 @@ async def _generate_chapter_with_gate(
         recaps=state.recaps,
         state=state,
     )
+    consistency_result: dict[str, Any] | None = None
     last_consistency_text = ""
     if consistency_agent is not None and bus is not None:
         try:
@@ -542,6 +543,65 @@ async def _generate_chapter_with_gate(
     while True:
         decision = await gate.await_decision()
         if decision.approved:
+            if (
+                decision.auto_approved
+                and settings.enable_consistency_revision_loop
+                and consistency_agent is not None
+                and bus is not None
+            ):
+                for _cr_iter in range(settings.consistency_max_iterations):
+                    if consistency_result is None:
+                        break
+                    _has_critical = any(
+                        issue.get("severity") == "critical"
+                        for issue in consistency_result.get("issues", [])
+                    )
+                    if not _has_critical:
+                        break
+                    _cr_feedback = _format_consistency_results(
+                        chapter_number, consistency_result
+                    )
+                    if draft.content:
+                        _cr_feedback = f"{_cr_feedback}\n\n## Current Chapter Draft\n{draft.content}"
+                    draft = await agent.run(
+                        story_name,
+                        chapter_number,
+                        outline_result,
+                        settings,
+                        feedback=_cr_feedback,
+                        recaps=state.recaps,
+                        state=state,
+                    )
+                    await _mark_work_item_done(
+                        state,
+                        f"chapter-{chapter_number}",
+                        f"chapter-{chapter_number}/consistency-revision-{_cr_iter + 1}",
+                    )
+                    await _write_savepoint(state)
+                    try:
+                        consistency_result = await consistency_agent.run(
+                            story_name,
+                            chapter_number,
+                            draft.content,
+                            outline_result=outline_result,
+                        )
+                        await _emit_consistency_results(
+                            bus, chapter_number, consistency_result
+                        )
+                    except Exception as exc:
+                        await bus.emit(f"\n[Consistency] Revision check error: {exc}\n")
+                        break
+                else:
+                    if consistency_result is not None:
+                        _residual = [
+                            i
+                            for i in consistency_result.get("issues", [])
+                            if i.get("severity") in ("warning", "info")
+                        ]
+                        if _residual:
+                            await bus.emit(
+                                f"\n[Consistency] {len(_residual)} advisory issue(s) remain after max iterations.\n"
+                            )
             return draft
         if decision.feedback is None:
             state.status = "rejected"

--- a/tests/unit/test_generation_settings.py
+++ b/tests/unit/test_generation_settings.py
@@ -107,3 +107,49 @@ class TestPersonaSettings:
         settings = GenerationSettings.from_dict({"persona_model": None})
 
         assert settings.persona_model is None
+
+
+class TestConsistencyRevisionLoopSettings:
+    """Verification tests for consistency revision loop generation settings."""
+
+    def test_consistency_fields_defaults(self) -> None:
+        """Consistency revision loop defaults match spec."""
+        settings = GenerationSettings()
+
+        assert settings.enable_consistency_revision_loop is True
+        assert settings.consistency_max_iterations == 2
+
+    def test_consistency_max_iterations_validation_too_low(self) -> None:
+        """consistency_max_iterations below 1 is rejected."""
+        with pytest.raises(ValidationError):
+            GenerationSettings(consistency_max_iterations=0)
+
+    def test_consistency_max_iterations_validation_too_high(self) -> None:
+        """consistency_max_iterations above 10 is rejected."""
+        with pytest.raises(ValidationError):
+            GenerationSettings(consistency_max_iterations=11)
+
+    def test_consistency_max_iterations_lower_bound_valid(self) -> None:
+        """consistency_max_iterations=1 is accepted."""
+        settings = GenerationSettings(consistency_max_iterations=1)
+
+        assert settings.consistency_max_iterations == 1
+
+    def test_consistency_max_iterations_upper_bound_valid(self) -> None:
+        """consistency_max_iterations=10 is accepted."""
+        settings = GenerationSettings(consistency_max_iterations=10)
+
+        assert settings.consistency_max_iterations == 10
+
+    def test_to_dict_includes_consistency_fields(self) -> None:
+        """to_dict includes both consistency revision fields."""
+        settings = GenerationSettings(
+            enable_consistency_revision_loop=False,
+            consistency_max_iterations=3,
+        )
+        result = settings.to_dict()
+
+        assert "enable_consistency_revision_loop" in result
+        assert "consistency_max_iterations" in result
+        assert result["enable_consistency_revision_loop"] is False
+        assert result["consistency_max_iterations"] == 3

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2558,3 +2558,309 @@ async def test_tui_resume_banner_suppressed_for_empty_ledger(tmp_path: Path) -> 
 
     events = [event async for event in status_bus]
     assert not any(event.message == "(resumed)" for event in events)
+
+
+def _critical_consistency_result() -> dict:
+    return {
+        "issues": [
+            {
+                "severity": "critical",
+                "description": "Timeline violation",
+                "type": "continuity",
+                "location": "para 1",
+                "scene_number": None,
+            }
+        ],
+        "passed": False,
+    }
+
+
+def _warning_consistency_result() -> dict:
+    return {
+        "issues": [
+            {
+                "severity": "warning",
+                "description": "Minor inconsistency",
+                "type": "continuity",
+                "location": "para 2",
+                "scene_number": None,
+            }
+        ],
+        "passed": True,
+    }
+
+
+def _clean_consistency_result() -> dict:
+    return {"issues": [], "passed": True}
+
+
+def _revised_draft(n: int) -> ChapterDraft:
+    return ChapterDraft(
+        story_name="test-story",
+        chapter_number=1,
+        title="Chapter 1",
+        content=f"Revised content {n}",
+        word_count=2,
+    )
+
+
+def _config_with_consistency(
+    enabled: bool = True, max_iterations: int = 2
+) -> dict:
+    cfg = _config()
+    cfg["generation"]["enable_consistency_revision_loop"] = enabled
+    cfg["generation"]["consistency_max_iterations"] = max_iterations
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_consistency_revision_loop_runs_on_critical_findings(
+    tmp_path: Path,
+) -> None:
+    """Revision loop executes both iterations when criticals persist across checks."""
+    provider = MagicMock()
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+
+    def fake_savepoint_path(story_name: str) -> Path:
+        return tmp_path / story_name / "savepoints" / "pipeline_state.json"
+
+    with (
+        patch(
+            "presentation.orchestrator._savepoint_path", side_effect=fake_savepoint_path
+        ),
+        patch("presentation.orchestrator.STORIES_DIR", tmp_path),
+        patch("tools._io.STORIES_DIR", tmp_path),
+        patch("presentation.orchestrator.OutlinePlannerAgent") as outline_cls,
+        patch("presentation.orchestrator.ChapterWriterAgent") as chapter_cls,
+        patch("presentation.orchestrator.WikiMaintainerAgent") as wiki_cls,
+        patch("presentation.orchestrator.ConsistencyCheckerAgent") as consistency_cls,
+        patch(
+            "tools.wiki_generation.generate_character_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_location_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_outline_entity_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+    ):
+        outline_cls.return_value.run = AsyncMock(return_value=_outline_result())
+        # Initial check: critical; loop iter 0 check: critical (continues);
+        # loop iter 1 check: clean (loop exhausted, all iterations used).
+        consistency_cls.return_value.run = AsyncMock(
+            side_effect=[
+                _critical_consistency_result(),
+                _critical_consistency_result(),
+                _clean_consistency_result(),
+            ]
+        )
+        chapter_cls.return_value.run = AsyncMock(
+            side_effect=[
+                _chapter_draft(),
+                _revised_draft(1),
+                _revised_draft(2),
+            ]
+        )
+        wiki_cls.return_value.run = AsyncMock(return_value=_wiki_batch())
+
+        state = await run_pipeline(
+            "test-story",
+            NullApprovalGate(),
+            bus,
+            wiki_bus,
+            config=_config_with_consistency(enabled=True, max_iterations=2),
+            provider=provider,
+        )
+
+    assert state.status == "complete"
+    # Initial draft + 2 revisions = 3 total
+    assert chapter_cls.return_value.run.await_count == 3
+    # Initial check + 2 loop checks = 3 total
+    assert consistency_cls.return_value.run.await_count == 3
+    # Final approved chapter should be the last revised draft
+    assert state.approved_chapters[0].content == "Revised content 2"
+
+
+@pytest.mark.asyncio
+async def test_consistency_revision_loop_stops_when_no_criticals(
+    tmp_path: Path,
+) -> None:
+    """Revision loop does not run when initial check returns only warnings."""
+    provider = MagicMock()
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+
+    def fake_savepoint_path(story_name: str) -> Path:
+        return tmp_path / story_name / "savepoints" / "pipeline_state.json"
+
+    with (
+        patch(
+            "presentation.orchestrator._savepoint_path", side_effect=fake_savepoint_path
+        ),
+        patch("presentation.orchestrator.STORIES_DIR", tmp_path),
+        patch("tools._io.STORIES_DIR", tmp_path),
+        patch("presentation.orchestrator.OutlinePlannerAgent") as outline_cls,
+        patch("presentation.orchestrator.ChapterWriterAgent") as chapter_cls,
+        patch("presentation.orchestrator.WikiMaintainerAgent") as wiki_cls,
+        patch("presentation.orchestrator.ConsistencyCheckerAgent") as consistency_cls,
+        patch(
+            "tools.wiki_generation.generate_character_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_location_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_outline_entity_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+    ):
+        outline_cls.return_value.run = AsyncMock(return_value=_outline_result())
+        consistency_cls.return_value.run = AsyncMock(
+            side_effect=[_warning_consistency_result()]
+        )
+        chapter_cls.return_value.run = AsyncMock(side_effect=[_chapter_draft()])
+        wiki_cls.return_value.run = AsyncMock(return_value=_wiki_batch())
+
+        state = await run_pipeline(
+            "test-story",
+            NullApprovalGate(),
+            bus,
+            wiki_bus,
+            config=_config_with_consistency(enabled=True, max_iterations=2),
+            provider=provider,
+        )
+
+    assert state.status == "complete"
+    assert chapter_cls.return_value.run.await_count == 1
+    assert consistency_cls.return_value.run.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_consistency_revision_loop_disabled_by_setting(
+    tmp_path: Path,
+) -> None:
+    """Critical findings do not trigger revision when loop is disabled."""
+    provider = MagicMock()
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+
+    def fake_savepoint_path(story_name: str) -> Path:
+        return tmp_path / story_name / "savepoints" / "pipeline_state.json"
+
+    with (
+        patch(
+            "presentation.orchestrator._savepoint_path", side_effect=fake_savepoint_path
+        ),
+        patch("presentation.orchestrator.STORIES_DIR", tmp_path),
+        patch("tools._io.STORIES_DIR", tmp_path),
+        patch("presentation.orchestrator.OutlinePlannerAgent") as outline_cls,
+        patch("presentation.orchestrator.ChapterWriterAgent") as chapter_cls,
+        patch("presentation.orchestrator.WikiMaintainerAgent") as wiki_cls,
+        patch("presentation.orchestrator.ConsistencyCheckerAgent") as consistency_cls,
+        patch(
+            "tools.wiki_generation.generate_character_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_location_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_outline_entity_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+    ):
+        outline_cls.return_value.run = AsyncMock(return_value=_outline_result())
+        consistency_cls.return_value.run = AsyncMock(
+            side_effect=[_critical_consistency_result()]
+        )
+        chapter_cls.return_value.run = AsyncMock(side_effect=[_chapter_draft()])
+        wiki_cls.return_value.run = AsyncMock(return_value=_wiki_batch())
+
+        state = await run_pipeline(
+            "test-story",
+            NullApprovalGate(),
+            bus,
+            wiki_bus,
+            config=_config_with_consistency(enabled=False, max_iterations=2),
+            provider=provider,
+        )
+
+    assert state.status == "complete"
+    # Loop disabled — only initial draft, no revisions
+    assert chapter_cls.return_value.run.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_consistency_revision_loop_max_iterations_respected(
+    tmp_path: Path,
+) -> None:
+    """Revision loop stops after max_iterations even when criticals remain."""
+    provider = MagicMock()
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+
+    def fake_savepoint_path(story_name: str) -> Path:
+        return tmp_path / story_name / "savepoints" / "pipeline_state.json"
+
+    with (
+        patch(
+            "presentation.orchestrator._savepoint_path", side_effect=fake_savepoint_path
+        ),
+        patch("presentation.orchestrator.STORIES_DIR", tmp_path),
+        patch("tools._io.STORIES_DIR", tmp_path),
+        patch("presentation.orchestrator.OutlinePlannerAgent") as outline_cls,
+        patch("presentation.orchestrator.ChapterWriterAgent") as chapter_cls,
+        patch("presentation.orchestrator.WikiMaintainerAgent") as wiki_cls,
+        patch("presentation.orchestrator.ConsistencyCheckerAgent") as consistency_cls,
+        patch(
+            "tools.wiki_generation.generate_character_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_location_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+        patch(
+            "tools.wiki_generation.generate_outline_entity_pages",
+            new=MagicMock(return_value={"generated": 2, "skipped": 0}),
+        ),
+    ):
+        outline_cls.return_value.run = AsyncMock(return_value=_outline_result())
+        # All 3 checks return critical — loop exhausts max_iterations
+        consistency_cls.return_value.run = AsyncMock(
+            side_effect=[
+                _critical_consistency_result(),
+                _critical_consistency_result(),
+                _critical_consistency_result(),
+            ]
+        )
+        chapter_cls.return_value.run = AsyncMock(
+            side_effect=[
+                _chapter_draft(),
+                _revised_draft(1),
+                _revised_draft(2),
+            ]
+        )
+        wiki_cls.return_value.run = AsyncMock(return_value=_wiki_batch())
+
+        state = await run_pipeline(
+            "test-story",
+            NullApprovalGate(),
+            bus,
+            wiki_bus,
+            config=_config_with_consistency(enabled=True, max_iterations=2),
+            provider=provider,
+        )
+
+    assert state.status == "complete"
+    # Initial + 2 loop revisions = 3 total (capped by max_iterations)
+    assert chapter_cls.return_value.run.await_count == 3
+    # Initial check + 2 loop checks = 3 total
+    assert consistency_cls.return_value.run.await_count == 3


### PR DESCRIPTION
## Summary

Implements an automatic revision loop in `_generate_chapter_with_gate` that triggers when the auto-approval gate approves a chapter with critical consistency findings. Instead of discarding critical issues, the orchestrator rewrites the chapter using the findings as feedback — up to `consistency_max_iterations` times — before moving on.

## Closes
Closes #417

## Changes
- [x] `GenerationSettings`: added `enable_consistency_revision_loop: bool = True` and `consistency_max_iterations: int = 2` with validation (1–10) and `to_dict()` serialisation
- [x] `_generate_chapter_with_gate`: auto-revision loop fires on `auto_approved=True` + critical findings; exits when no criticals remain or iterations exhausted; residual warning/info emitted as advisory
- [x] Auto-revision path decoupled from `last_consistency_text` (human feedback path unchanged)
- [x] Each revision iteration savepointed for resumability
- [x] All tests passing (10 new, 0 failures)
- [x] Linting clean

## Plan

**Summary:** When the auto-gate approves a chapter that has critical consistency issues, the orchestrator now runs a revision loop: it rewrites the chapter with the consistency findings as feedback, re-checks, and repeats up to `consistency_max_iterations` times or until no criticals remain.

**Affected Areas:** Python domain logic; ChromaDB schema change: no

**Task Checklist:**
- [x] `GenerationSettings` — new fields, validation, serialisation
- [x] `_generate_chapter_with_gate` — auto-revision loop (distinct code path from human feedback)
- [x] `test_orchestrator.py` — 4 new async tests (loop runs, stops early, disabled, max iterations)
- [x] `test_generation_settings.py` — 6 new tests (defaults, validation bounds, to_dict)

**Execution Order:** Implementation → Tests → Confirmed passing

**Risks & Edge Cases addressed:**
- `consistency_result` scoped before `while True:` to guarantee availability
- Loop only fires when `auto_approved=True`; human-gate path fully unchanged
- `last_consistency_text` not touched in auto-revision path
- `for/else` clause emits advisory count when iterations exhausted with residual issues
