### PR TITLE
feat: cross-scene learning via recurring-finding memory

### DIFF
--- a/prompts/multistep/scene/create_content_final.md
+++ b/prompts/multistep/scene/create_content_final.md
@@ -61,6 +61,7 @@ Your scene must begin in continuity with this — same characters, same time-flo
 Incorporate these devices naturally in your prose for this scene.
 
 {beat_sheet_section}
+{critique_lessons_section}
 
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)

--- a/prompts/multistep/scene/create_content_first.md
+++ b/prompts/multistep/scene/create_content_first.md
@@ -49,6 +49,7 @@ Incorporate these devices naturally in your prose for this scene.
 </NEXT_SCENE_OUTLINE>
 
 {beat_sheet_section}
+{critique_lessons_section}
 
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)

--- a/prompts/multistep/scene/create_content_middle.md
+++ b/prompts/multistep/scene/create_content_middle.md
@@ -61,6 +61,7 @@ Incorporate these devices naturally in your prose for this scene.
 </NEXT_SCENE_OUTLINE>
 
 {beat_sheet_section}
+{critique_lessons_section}
 
 ## Core Requirements
 - **Word Count**: AT LEAST {scene_word_target} words (mandatory)

--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -60,6 +60,8 @@ class GenerationSettings:
     persona_model: Optional[str] = None
     persona_word_budget: int = 225
     enable_emphasis_delta: bool = True
+    enable_critique_learning: bool = True
+    critique_learning_top_n: int = 3
 
     def __post_init__(self):
         """Validate the generation settings."""
@@ -132,6 +134,12 @@ class GenerationSettings:
                 f"persona_word_budget must be between 100 and 500, got {self.persona_word_budget}"
             )
 
+        if not (1 <= self.critique_learning_top_n <= 10):
+            raise ValidationError(
+                "critique_learning_top_n must be between 1 and 10, "
+                f"got {self.critique_learning_top_n}"
+            )
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GenerationSettings":
         """Create GenerationSettings from a dictionary."""
@@ -180,6 +188,8 @@ class GenerationSettings:
             "persona_model": self.persona_model,
             "persona_word_budget": self.persona_word_budget,
             "enable_emphasis_delta": self.enable_emphasis_delta,
+            "enable_critique_learning": self.enable_critique_learning,
+            "critique_learning_top_n": self.critique_learning_top_n,
         }
 
     def with_updates(self, **kwargs) -> "GenerationSettings":

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -666,6 +666,7 @@ class ChapterWriterAgent:
         scene_prose: list[str] = []
         scenes_completed_meta: list[dict[str, Any]] = []
         actual_recaps: dict[int, str] = {}
+        lessons_buffer: dict[str, int] = {}
         total_scenes = len(scenes)
         scenes_dir = STORIES_DIR / story_name / "chapters" / f"chapter_{chapter_number}"
         for index, scene in enumerate(scenes, start=1):
@@ -800,6 +801,22 @@ class ChapterWriterAgent:
                 else scene
             )
 
+            critique_lessons_section = ""
+            if settings.enable_critique_learning and lessons_buffer:
+                _top = sorted(lessons_buffer.items(), key=lambda x: x[1], reverse=True)[
+                    : settings.critique_learning_top_n
+                ]
+                _lines = [
+                    f"- **{cat}** (flagged {count} time{'s' if count != 1 else ''})"
+                    for cat, count in _top
+                ]
+                critique_lessons_section = (
+                    "\n\n## Lessons From Earlier Scenes\n"
+                    "Your previous scenes in this chapter were repeatedly flagged "
+                    "for these issues. Actively avoid them in this scene:\n"
+                    + "\n".join(_lines)
+                )
+
             beat_sheet_section = ""
             if settings.enable_beat_sheet:
                 await self.status_bus.emit(
@@ -884,6 +901,7 @@ class ChapterWriterAgent:
                     "style_guide": style_guide,
                     "literary_devices": literary_devices_str,
                     "beat_sheet_section": beat_sheet_section,
+                    "critique_lessons_section": critique_lessons_section,
                 },
             )
             try:
@@ -1096,6 +1114,23 @@ class ChapterWriterAgent:
                         f"score {_critique_score:.0f}/100 "
                         f"after {_critique_iteration} revision(s).\n"
                     )
+                    if settings.enable_critique_learning:
+                        for _score in _scene_result.scores:
+                            if _score.score < 25.0:
+                                lessons_buffer[_score.criterion] = (
+                                    lessons_buffer.get(_score.criterion, 0) + 1
+                                )
+                        try:
+                            _lessons_file = scenes_dir / "critique_lessons.json"
+                            _lessons_file.parent.mkdir(parents=True, exist_ok=True)
+                            _atomic_write(
+                                _lessons_file,
+                                json.dumps(
+                                    lessons_buffer, indent=2, ensure_ascii=False
+                                ),
+                            )
+                        except OSError:
+                            pass
                 except Exception as exc:
                     await self.bus.emit(
                         f"\n[Chapter {chapter_number}] scene {index} critique "

--- a/tests/unit/test_chapter_writer.py
+++ b/tests/unit/test_chapter_writer.py
@@ -1,4 +1,4 @@
-"""Verification tests for iterative scene critique loop (#416)."""
+"""Verification tests for iterative scene critique loop (#416) and cross-scene learning (#418)."""
 
 import json
 import sys
@@ -265,3 +265,218 @@ def test_generation_settings_critique_max_iterations_validation() -> None:
 
     with pytest.raises(ValidationError):
         GenerationSettings(scene_critique_max_iterations=11)
+
+
+# ---------------------------------------------------------------------------
+# Issue #418 — cross-scene learning via recurring-finding memory
+# ---------------------------------------------------------------------------
+
+
+def test_generation_settings_critique_learning_defaults() -> None:
+    settings = GenerationSettings()
+    assert settings.enable_critique_learning is True
+    assert settings.critique_learning_top_n == 3
+    assert settings.to_dict()["enable_critique_learning"] is True
+    assert settings.to_dict()["critique_learning_top_n"] == 3
+
+
+def test_generation_settings_critique_learning_top_n_validation() -> None:
+    with pytest.raises(ValidationError):
+        GenerationSettings(critique_learning_top_n=0)
+    with pytest.raises(ValidationError):
+        GenerationSettings(critique_learning_top_n=11)
+
+
+@pytest.mark.asyncio
+async def test_cross_scene_lessons_injected_into_scene_3_prompt(
+    tmp_path: Path,
+) -> None:
+    """style_violations flagged in scenes 1 and 2 appears in scene 3 lessons section."""
+
+    def _three_scenes() -> list[dict]:
+        return [
+            {
+                "title": f"Scene {i}",
+                "description": f"Scene {i} description.",
+                "characters": ["Alice"],
+                "setting": "Forest",
+                "key_events": [f"event {i}"],
+                "ending": f"Scene {i} ends",
+            }
+            for i in range(1, 4)
+        ]
+
+    scenes_json = json.dumps(_three_scenes())
+    # style_violations score = 25 - 8*1 = 17 (< 25) → buffer updated
+    crit_with_violation = json.dumps({"style_violations": ["purple prose"]})
+    # Clean critique: all scores = 25, total = 100 → passes threshold=0.0
+    crit_clean = json.dumps({})
+
+    # threshold=0.0 means every critique passes immediately (score >= 0 always)
+    # so no revision loop runs, keeping exactly 3 LLM calls per scene.
+    responses = [
+        "Expanded synopsis.",  # chapter synopsis
+        scenes_json,  # scenes JSON
+        "Scene 1 prose.",  # scene 1 draft
+        crit_with_violation,  # scene 1 critique (style_violations flagged)
+        "Scene 1 recap.",  # scene 1 recap
+        "Scene 2 prose.",  # scene 2 draft
+        crit_with_violation,  # scene 2 critique (style_violations flagged)
+        "Scene 2 recap.",  # scene 2 recap
+        "Scene 3 prose.",  # scene 3 draft
+        crit_clean,  # scene 3 critique (clean)
+        "Scene 3 recap.",  # scene 3 recap
+    ]
+
+    captured_calls: list[tuple[str, dict]] = []
+
+    def _capturing_render(prompt_key: str, *, variables: dict) -> str:
+        captured_calls.append((prompt_key, dict(variables)))
+        return _render_prompt(prompt_key, variables=variables)
+
+    provider = _make_provider(responses)
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    config = {
+        "models": {
+            "chapter_writer": "openai-compat://test",
+            "chapter_outline_writer": "openai-compat://test",
+            "scene_writer": "openai-compat://test",
+        }
+    }
+    settings = _settings(
+        scenes_per_chapter_min=3,
+        scenes_per_chapter_max=3,
+        enable_critique_learning=True,
+        critique_learning_top_n=3,
+        scene_critique_score_threshold=0.0,  # all critiques pass → no revisions
+        scene_critique_max_iterations=1,
+    )
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader = loader_cls.return_value
+        loader.load_prompt.side_effect = _capturing_render
+        agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
+        await agent.run(
+            story_name="test-story",
+            chapter_number=1,
+            outline_result=_outline_result(),
+            settings=settings,
+        )
+
+    scene_3_calls = [
+        (key, vars_)
+        for key, vars_ in captured_calls
+        if key
+        in (
+            "multistep/scene/create_content_final",
+            "multistep/scene/create_content_middle",
+        )
+        and vars_.get("scene_index") == "3"
+    ]
+    assert scene_3_calls, "Scene 3 create_content prompt not captured"
+    _, scene_3_vars = scene_3_calls[0]
+    lessons_section = scene_3_vars.get("critique_lessons_section", "")
+    assert "style_violations" in lessons_section, (
+        f"Expected 'style_violations' in scene 3 lessons section, got: {lessons_section!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_critique_learning_disabled_lessons_not_injected(
+    tmp_path: Path,
+) -> None:
+    """When enable_critique_learning=False, scene 2 prompt has empty lessons section."""
+
+    def _two_scenes() -> list[dict]:
+        return [
+            {
+                "title": "Scene 1",
+                "description": "s1",
+                "characters": ["Alice"],
+                "setting": "Forest",
+                "key_events": ["e1"],
+                "ending": "end1",
+            },
+            {
+                "title": "Scene 2",
+                "description": "s2",
+                "characters": ["Alice"],
+                "setting": "Forest",
+                "key_events": ["e2"],
+                "ending": "end2",
+            },
+        ]
+
+    scenes_json = json.dumps(_two_scenes())
+    crit_with_violation = json.dumps({"style_violations": ["purple prose"]})
+    crit_clean = json.dumps({})
+
+    responses = [
+        "Expanded synopsis.",
+        scenes_json,
+        "Scene 1 prose.",
+        crit_with_violation,
+        "Scene 1 recap.",
+        "Scene 2 prose.",
+        crit_clean,
+        "Scene 2 recap.",
+    ]
+
+    captured_calls: list[tuple[str, dict]] = []
+
+    def _capturing_render(prompt_key: str, *, variables: dict) -> str:
+        captured_calls.append((prompt_key, dict(variables)))
+        return _render_prompt(prompt_key, variables=variables)
+
+    provider = _make_provider(responses)
+    bus = TokenStreamBus()
+    wiki_bus = WikiContextBus()
+    config = {
+        "models": {
+            "chapter_writer": "openai-compat://test",
+            "chapter_outline_writer": "openai-compat://test",
+            "scene_writer": "openai-compat://test",
+        }
+    }
+    settings = _settings(
+        scenes_per_chapter_min=2,
+        scenes_per_chapter_max=2,
+        enable_critique_learning=False,
+        scene_critique_score_threshold=0.0,
+        scene_critique_max_iterations=1,
+    )
+
+    with (
+        patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,
+        patch("presentation.agents.chapter_writer.STORIES_DIR", tmp_path),
+    ):
+        loader = loader_cls.return_value
+        loader.load_prompt.side_effect = _capturing_render
+        agent = ChapterWriterAgent(provider, config, bus, wiki_bus)
+        await agent.run(
+            story_name="test-story",
+            chapter_number=1,
+            outline_result=_outline_result(),
+            settings=settings,
+        )
+
+    scene_2_calls = [
+        (key, vars_)
+        for key, vars_ in captured_calls
+        if key
+        in (
+            "multistep/scene/create_content_final",
+            "multistep/scene/create_content_middle",
+        )
+        and vars_.get("scene_index") == "2"
+    ]
+    assert scene_2_calls, "Scene 2 create_content prompt not captured"
+    _, scene_2_vars = scene_2_calls[0]
+    lessons_section = scene_2_vars.get("critique_lessons_section", "")
+    assert lessons_section == "", (
+        f"Expected empty lessons section when learning disabled, got: {lessons_section!r}"
+    )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2604,9 +2604,7 @@ def _revised_draft(n: int) -> ChapterDraft:
     )
 
 
-def _config_with_consistency(
-    enabled: bool = True, max_iterations: int = 2
-) -> dict:
+def _config_with_consistency(enabled: bool = True, max_iterations: int = 2) -> dict:
     cfg = _config()
     cfg["generation"]["enable_consistency_revision_loop"] = enabled
     cfg["generation"]["consistency_max_iterations"] = max_iterations


### PR DESCRIPTION
## Summary

Implements a per-chapter lessons buffer that accumulates recurring critique findings (by category) across scenes and injects the top-N flagged categories into the scene-draft prompt for scenes 2+. The buffer resets at each chapter boundary, so lessons from chapter N do not carry into chapter N+1.

## Closes
Closes #418

## Changes
- [x] Implementation complete
- [x] All tests passing (10/10)
- [x] Linting clean

## Plan

### Implementation

1. **`src/domain/value_objects/generation_settings.py`** — added `enable_critique_learning: bool = True` and `critique_learning_top_n: int = 3`; validation `1 <= top_n <= 10`; both in `to_dict()`

2. **`src/presentation/agents/chapter_writer.py`**:
   - `lessons_buffer: dict[str, int] = {}` declared before scene `for` loop (resets per chapter)
   - Before each scene's prompt render: `critique_lessons_section` built from buffer — empty for scene 1, top-N sorted categories for scene 2+
   - `critique_lessons_section` passed to all three `create_content_{first,middle,final}` prompt renders
   - After critique loop completes (gated on `enable_critique_learning`): for each `CritiqueScore` with `score < 25.0` (has findings), increment `lessons_buffer[criterion]`
   - Buffer persisted to `chapters/{n}/critique_lessons.json` for resumability

3. **`prompts/multistep/scene/create_content_{first,middle,final}.md`** — `{critique_lessons_section}` added after `{beat_sheet_section}`

### Verification tests

- `test_generation_settings_critique_learning_defaults` ✅
- `test_generation_settings_critique_learning_top_n_validation` ✅
- `test_cross_scene_lessons_injected_into_scene_3_prompt` ✅
- `test_critique_learning_disabled_lessons_not_injected` ✅
