### PR TITLE
feat: persist critique scores as run-level quality telemetry

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -22,6 +22,7 @@
 12. [Agents & Tools](#12-agents--tools)
 13. [Strategies](#13-strategies)
 14. [Working with Savepoints](#14-working-with-savepoints)
+- [Quality Reports](#quality-reports)
 15. [General Operation](#15-general-operation)
 16. [Troubleshooting](#16-troubleshooting)
 17. [Prompt Writing Tips](#17-prompt-writing-tips)
@@ -1582,6 +1583,37 @@ story-writer tui --story my-story
 1. Copy the entire `stories/<name>/` directory to the new machine
 2. Ensure the new machine has the same `config.yml` (or equivalent)
 3. Run `story-writer resume --story <name>`
+
+---
+
+## Quality Reports
+
+After each story run completes, the pipeline writes `stories/<name>/quality_report.json`.
+This file accumulates one entry per run (append-safe: multiple runs produce multiple entries).
+
+### Report Structure
+
+Each entry contains:
+
+- **timestamp** — UTC ISO-8601 datetime of the run
+- **model** — model identifier used for chapter generation
+- **settings_snapshot** — key generation settings (seed, wanted chapters, score thresholds)
+- **chapters** — array of per-chapter records:
+  - **scenes** — per-scene: `final_score`, `iteration_count`, `residual_categories`
+  - **consistency** — `passed`, `critical_count`, `warning_count`, `iteration_count`, `final_status`
+
+### Viewing a Report
+
+```
+story-writer report <story-name>
+```
+
+Prints a formatted table of all runs for the given story to stdout.
+
+### Notes
+
+- If scene critique or consistency checks are disabled, the corresponding fields will be empty or `null`.
+- The report is not overwritten between runs; each run appends a new entry.
 
 ---
 

--- a/src/application/pipeline/handoffs.py
+++ b/src/application/pipeline/handoffs.py
@@ -154,6 +154,7 @@ class PipelineState:
     completed_work_items: dict[str, list[str]] = field(default_factory=dict)
     status: str = "running"
     style_guide: str = ""
+    quality_telemetry: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict for savepoint persistence.
@@ -276,6 +277,7 @@ class PipelineState:
             status=data.get("status", "running"),
             completed_work_items=data.get("completed_work_items", {}),
             style_guide=_resolve(data.get("style_guide", "")),
+            quality_telemetry=data.get("quality_telemetry", []),
         )
 
     def to_json(self) -> str:

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -268,7 +268,7 @@ class ChapterWriterAgent:
         # Multi-stage pipeline: synopsis → scenes → per-scene drafting.
         # Skipped on revisions (feedback path) and when disabled by settings.
         if feedback is None and settings.scene_generation_pipeline:
-            multi_stage_text = await self._run_scene_pipeline(
+            multi_stage_text, scene_records = await self._run_scene_pipeline(
                 story_name=story_name,
                 chapter_number=chapter_number,
                 chapter_title=title,
@@ -288,6 +288,7 @@ class ChapterWriterAgent:
                     title=title,
                     content=multi_stage_text,
                     word_count=len(multi_stage_text.split()),
+                    critic_findings=scene_records,
                 )
             await self.bus.emit(
                 f"\n[Chapter {chapter_number}] scene pipeline empty — "
@@ -374,12 +375,12 @@ class ChapterWriterAgent:
         previous_chapter_recap: str = "",
         recap_context: str = "",
         state: PipelineState | None = None,
-    ) -> str:
+    ) -> tuple[str, list[dict[str, Any]]]:
         """Run synopsis → scene-decomposition → per-scene drafting.
 
-        Returns the concatenated chapter prose, or an empty string if any
-        critical step fails so the caller can fall back to single-shot
-        drafting.
+        Returns the concatenated chapter prose and a list of per-scene critique
+        records, or an empty string and empty list if any critical step fails so
+        the caller can fall back to single-shot drafting.
         """
         style_guide: str = state.style_guide if state is not None else ""
         if isinstance(style_guide, dict):
@@ -499,7 +500,7 @@ class ChapterWriterAgent:
                         f"\n[Chapter {chapter_number}] scene decomposition failed "
                         f"({type(exc).__name__}: {exc}); falling back to direct drafting.\n"
                     )
-                    return ""
+                    return ("", [])
 
                 candidate = _extract_json_array(scenes_raw)
                 if not candidate:
@@ -520,7 +521,7 @@ class ChapterWriterAgent:
                     f"\n[Chapter {chapter_number}] scene decomposition returned no "
                     "parsable scenes; falling back to direct drafting.\n"
                 )
-                return ""
+                return ("", [])
 
             if not (scenes_min <= len(scenes) <= scenes_max):
                 await self.bus.emit(
@@ -667,6 +668,7 @@ class ChapterWriterAgent:
         scenes_completed_meta: list[dict[str, Any]] = []
         actual_recaps: dict[int, str] = {}
         lessons_buffer: dict[str, int] = {}
+        scene_records: list[dict[str, Any]] = []
         total_scenes = len(scenes)
         scenes_dir = STORIES_DIR / story_name / "chapters" / f"chapter_{chapter_number}"
         for index, scene in enumerate(scenes, start=1):
@@ -707,6 +709,14 @@ class ChapterWriterAgent:
                     actual_recaps[index] = recap_cache_file.read_text(
                         encoding="utf-8"
                     ).strip()
+                scene_records.append(
+                    {
+                        "scene_num": index,
+                        "final_score": None,
+                        "iteration_count": 0,
+                        "residual_categories": [],
+                    }
+                )
                 continue
 
             if index == 1:
@@ -924,6 +934,10 @@ class ChapterWriterAgent:
             if not scene_text:
                 continue
 
+            _scene_result = None
+            _critique_score = 0.0
+            _critique_iteration = 0
+
             if settings.enable_scene_critique:
                 await self.status_bus.emit(
                     StatusEvent(
@@ -1137,6 +1151,29 @@ class ChapterWriterAgent:
                         f"failed ({type(exc).__name__}: {exc}); skipping critique.\n"
                     )
 
+            if _scene_result is not None:
+                scene_records.append(
+                    {
+                        "scene_num": index,
+                        "final_score": _critique_score,
+                        "iteration_count": _critique_iteration,
+                        "residual_categories": [
+                            s.criterion
+                            for s in _scene_result.scores
+                            if s.score < s.max_score * 0.6
+                        ],
+                    }
+                )
+            else:
+                scene_records.append(
+                    {
+                        "scene_num": index,
+                        "final_score": None,
+                        "iteration_count": 0,
+                        "residual_categories": [],
+                    }
+                )
+
             if settings.enable_scrubbing:
                 await self.status_bus.emit(
                     StatusEvent(
@@ -1276,10 +1313,10 @@ class ChapterWriterAgent:
                     )
 
         if not scene_prose:
-            return ""
+            return ("", [])
 
         chapter_body = f"# {chapter_title}\n\n" + "\n\n".join(scene_prose)
-        return chapter_body
+        return (chapter_body, scene_records)
 
     async def _revise_scene_pipeline(
         self,

--- a/src/presentation/cli/argument_parser.py
+++ b/src/presentation/cli/argument_parser.py
@@ -95,4 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--story", required=True, metavar="NAME", help="Story name."
     )
 
+    report_p = sub.add_parser("report", help="Print quality report for a story.")
+    report_p.add_argument("name", metavar="NAME", help="Story name.")
+
     return parser

--- a/src/presentation/cli/main.py
+++ b/src/presentation/cli/main.py
@@ -131,6 +131,52 @@ def _cmd_resume(story: str, savepoint: str | None, prompt: str | None = None) ->
     print(f"Pipeline resumed: status={state.status}")
 
 
+def _cmd_report(story_name: str) -> None:
+    import json
+    from pathlib import Path
+
+    report_path = Path("stories") / story_name / "quality_report.json"
+    if not report_path.exists():
+        print(f"No quality report found for story '{story_name}'.", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        runs: list[dict] = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Malformed quality report: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    if not runs:
+        print("Quality report is empty.", file=sys.stderr)
+        raise SystemExit(0)
+
+    for run in runs:
+        print(
+            f"\nRun: {run.get('timestamp', 'unknown')}  Model: {run.get('model', 'unknown')}"
+        )
+        print(f"  Settings: {run.get('settings_snapshot', {})}")
+        chapters = run.get("chapters", [])
+        if not chapters:
+            print("  No chapter data recorded.")
+            continue
+        print(
+            f"  {'Ch':>3}  {'Scenes':>6}  {'Avg Score':>9}  {'Consistency':>12}  {'Crit':>4}  {'Warn':>4}"
+        )
+        print(f"  {'-' * 3}  {'-' * 6}  {'-' * 9}  {'-' * 12}  {'-' * 4}  {'-' * 4}")
+        for ch in chapters:
+            ch_num = ch.get("chapter_number", "?")
+            scenes = ch.get("scenes", [])
+            scores = [
+                s["final_score"] for s in scenes if s.get("final_score") is not None
+            ]
+            avg_score = f"{sum(scores) / len(scores):.1f}" if scores else "n/a"
+            con = ch.get("consistency", {})
+            con_status = "passed" if con.get("passed", True) else "failed"
+            crit = con.get("critical_count", 0)
+            warn = con.get("warning_count", 0)
+            print(
+                f"  {ch_num:>3}  {len(scenes):>6}  {avg_score:>9}  {con_status:>12}  {crit:>4}  {warn:>4}"
+            )
+
+
 def main() -> None:
     from presentation.cli.argument_parser import build_parser
 
@@ -162,6 +208,8 @@ def main() -> None:
 
         clear_recap_index(args.story)
         print(f"Recap index cleared for story: {args.story}")
+    elif args.subcommand == "report":
+        _cmd_report(args.name)
     else:
         parser.print_help()
         raise SystemExit(1)

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -701,6 +701,51 @@ async def _emit_status(
     )
 
 
+def _write_quality_report(
+    state: PipelineState,
+    story_dir: Path,
+    config: dict[str, Any],
+) -> None:
+    """Append a quality-telemetry entry to stories/{name}/quality_report.json."""
+    report_path = story_dir / "quality_report.json"
+    try:
+        existing: list[dict[str, Any]] = (
+            json.loads(report_path.read_text(encoding="utf-8"))
+            if report_path.exists()
+            else []
+        )
+    except (json.JSONDecodeError, OSError):
+        existing = []
+
+    model_name = (
+        config.get("models", {}).get("chapter_writer")
+        or config.get("models", {}).get("default")
+        or "unknown"
+    )
+    generation = config.get("generation", {}) or {}
+    settings_snapshot = {
+        k: generation.get(k)
+        for k in (
+            "seed",
+            "wanted_chapters",
+            "min_scene_score",
+            "max_critique_iterations",
+        )
+        if generation.get(k) is not None
+    }
+
+    entry: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "model": model_name,
+        "settings_snapshot": settings_snapshot,
+        "chapters": state.quality_telemetry,
+    }
+    existing.append(entry)
+    report_path.write_text(
+        json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
 async def _continue_pipeline(
     state: PipelineState,
     gate: ApprovalGate,
@@ -1226,6 +1271,11 @@ async def _continue_pipeline(
                 else:
                     draft = state.approved_chapters[chapter_number - 1]
 
+                consistency_meta: dict[str, Any] = {
+                    "passed": True,
+                    "critical_count": 0,
+                    "warning_count": 0,
+                }
                 consistency_item_id = f"chapter-{chapter_number}/consistency-check"
                 if not _work_item_done(state, phase, consistency_item_id):
                     if consistency_agent is not None and bus is not None:
@@ -1239,6 +1289,23 @@ async def _continue_pipeline(
                             await _emit_consistency_results(
                                 bus, chapter_number, consistency_result
                             )
+                            draft.consistency_findings = consistency_result.get(
+                                "issues", []
+                            )
+                            _issues = consistency_result.get("issues", [])
+                            _critical = sum(
+                                1 for i in _issues if i.get("severity") == "critical"
+                            )
+                            _warnings = sum(
+                                1
+                                for i in _issues
+                                if i.get("severity") in ("warning", "info")
+                            )
+                            consistency_meta = {
+                                "passed": consistency_result.get("passed", True),
+                                "critical_count": _critical,
+                                "warning_count": _warnings,
+                            }
                         except Exception as exc:
                             await bus.emit(
                                 f"\n[Consistency] Chapter {chapter_number} check failed "
@@ -1433,6 +1500,21 @@ async def _continue_pipeline(
                             await bus.emit(
                                 f"\n[Metadata] chapter-1 metadata skipped ({type(exc).__name__}: {exc})\n"
                             )
+                state.quality_telemetry.append(
+                    {
+                        "chapter_number": chapter_number,
+                        "scenes": draft.critic_findings or [],
+                        "consistency": {
+                            "passed": consistency_meta.get("passed", True),
+                            "iteration_count": 0,
+                            "critical_count": consistency_meta.get("critical_count", 0),
+                            "warning_count": consistency_meta.get("warning_count", 0),
+                            "final_status": "passed"
+                            if consistency_meta.get("passed", True)
+                            else "failed",
+                        },
+                    }
+                )
                 await _mark_phase_complete(
                     state,
                     f"chapter-{chapter_number}",
@@ -1584,6 +1666,12 @@ async def _continue_pipeline(
         state.savepoint_id = "complete"
         if "complete" not in state.savepoints:
             state.savepoints.append("complete")
+        try:
+            _write_quality_report(state, story_dir, resolved_config)
+        except Exception as exc:
+            await bus.emit(
+                f"\n[Quality Report] Failed to write quality report: {exc}\n"
+            )
         await _write_savepoint(state)
         await _emit_status(sbus, "complete", "Pipeline complete", kind="phase_end")
         return state

--- a/tests/unit/test_quality_report.py
+++ b/tests/unit/test_quality_report.py
@@ -1,0 +1,188 @@
+"""Unit tests for quality telemetry persistence (issue #419).
+
+Verifies _write_quality_report and the CLI `report` subcommand parser.
+No LLM calls are made — pure file-system and argparse logic only.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from application.pipeline.handoffs import PipelineState
+from presentation.cli.argument_parser import build_parser
+from presentation.orchestrator import _write_quality_report
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CHAPTER_ENTRY: dict = {
+    "chapter_number": 1,
+    "scenes": [
+        {
+            "final_score": 8,
+            "iteration_count": 2,
+            "residual_categories": [],
+        }
+    ],
+    "consistency": {
+        "passed": True,
+        "critical_count": 0,
+        "warning_count": 1,
+        "final_status": "ok",
+    },
+}
+
+_CONFIG: dict = {
+    "models": {"chapter_writer": "test-model"},
+    "generation": {
+        "seed": 42,
+        "wanted_chapters": 3,
+        "min_scene_score": 7,
+        "max_critique_iterations": 4,
+    },
+}
+
+
+def _make_state(telemetry: list | None = None) -> PipelineState:
+    return PipelineState(
+        story_name="test-story",
+        current_phase="done",
+        quality_telemetry=telemetry if telemetry is not None else [_CHAPTER_ENTRY],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_write_quality_report_creates_file(tmp_path: Path) -> None:
+    state = _make_state()
+    _write_quality_report(state, tmp_path, _CONFIG)
+
+    report_path = tmp_path / "quality_report.json"
+    assert report_path.exists(), "quality_report.json was not created"
+
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert len(data) == 1
+
+
+def test_write_quality_report_structure(tmp_path: Path) -> None:
+    state = _make_state()
+    _write_quality_report(state, tmp_path, _CONFIG)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    entry = data[0]
+
+    assert "timestamp" in entry
+    assert "model" in entry
+    assert "settings_snapshot" in entry
+    assert "chapters" in entry
+
+    assert entry["model"] == "test-model"
+
+    assert len(entry["chapters"]) == 1
+    chapter = entry["chapters"][0]
+    assert "chapter_number" in chapter
+    assert "scenes" in chapter
+    assert "consistency" in chapter
+
+
+def test_write_quality_report_chapter_scene_fields(tmp_path: Path) -> None:
+    state = _make_state()
+    _write_quality_report(state, tmp_path, _CONFIG)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    scene = data[0]["chapters"][0]["scenes"][0]
+    assert "final_score" in scene
+    assert "iteration_count" in scene
+    assert "residual_categories" in scene
+
+
+def test_write_quality_report_chapter_consistency_fields(tmp_path: Path) -> None:
+    state = _make_state()
+    _write_quality_report(state, tmp_path, _CONFIG)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    consistency = data[0]["chapters"][0]["consistency"]
+    assert "passed" in consistency
+    assert "critical_count" in consistency
+    assert "warning_count" in consistency
+    assert "final_status" in consistency
+
+
+def test_write_quality_report_appends(tmp_path: Path) -> None:
+    entry_a = dict(_CHAPTER_ENTRY, chapter_number=1)
+    entry_b = dict(_CHAPTER_ENTRY, chapter_number=2)
+
+    _write_quality_report(_make_state([entry_a]), tmp_path, _CONFIG)
+    _write_quality_report(_make_state([entry_b]), tmp_path, _CONFIG)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    assert len(data) == 2
+    assert data[0]["chapters"][0]["chapter_number"] == 1
+    assert data[1]["chapters"][0]["chapter_number"] == 2
+
+
+def test_write_quality_report_handles_malformed_json(tmp_path: Path) -> None:
+    report_path = tmp_path / "quality_report.json"
+    report_path.write_text("{not valid json!!!", encoding="utf-8")
+
+    state = _make_state()
+    # Must not raise even though the existing file is malformed
+    _write_quality_report(state, tmp_path, _CONFIG)
+
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+
+def test_write_quality_report_settings_snapshot(tmp_path: Path) -> None:
+    state = _make_state()
+    _write_quality_report(state, tmp_path, _CONFIG)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    snap = data[0]["settings_snapshot"]
+    assert snap.get("seed") == 42
+    assert snap.get("wanted_chapters") == 3
+    assert snap.get("min_scene_score") == 7
+    assert snap.get("max_critique_iterations") == 4
+
+
+def test_write_quality_report_model_fallback_default(tmp_path: Path) -> None:
+    config = {"models": {"default": "fallback-model"}, "generation": {}}
+    state = _make_state()
+    _write_quality_report(state, tmp_path, config)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    assert data[0]["model"] == "fallback-model"
+
+
+def test_write_quality_report_model_unknown_when_missing(tmp_path: Path) -> None:
+    config: dict = {}
+    state = _make_state()
+    _write_quality_report(state, tmp_path, config)
+
+    data = json.loads((tmp_path / "quality_report.json").read_text(encoding="utf-8"))
+    assert data[0]["model"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_subcommand_in_parser() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["report", "my-story"])
+    assert args.subcommand == "report"
+    assert args.name == "my-story"


### PR DESCRIPTION
## Summary

Implements run-level quality telemetry persistence. After each story run completes, per-scene critique scores and per-chapter consistency results are aggregated and written to `stories/{name}/quality_report.json`. A new CLI subcommand `story-writer report <name>` prints a formatted table of all runs.

## Closes
Closes #419

## Changes
- [x] `src/application/pipeline/handoffs.py` — Added `quality_telemetry` field to `PipelineState`; serialize/deserialize in `to_dict`/`from_dict`
- [x] `src/presentation/agents/chapter_writer.py` — `_run_scene_pipeline` now returns `tuple[str, list[dict]]`; captures per-scene final score, iteration count, residual categories; stored in `ChapterDraft.critic_findings`
- [x] `src/presentation/orchestrator.py` — Captures consistency meta per chapter into `draft.consistency_findings`; builds per-chapter quality records into `state.quality_telemetry`; new `_write_quality_report()` appends to `quality_report.json` at run completion
- [x] `src/presentation/cli/argument_parser.py` — Added `report` subcommand
- [x] `src/presentation/cli/main.py` — Added `_cmd_report()` with formatted table output
- [x] `docs/manual.md` — Added "Quality Reports" section
- [x] `tests/unit/test_quality_report.py` — 10 unit tests (all passing)
- [x] Linting clean (`ruff check`, `ruff format`)

## Plan

**Summary**: Persist per-scene critique scores and per-chapter consistency results to `stories/{name}/quality_report.json` as append-safe JSON. Expose via `story-writer report <name>` CLI command.

**Affected Areas**: Python domain logic; ChromaDB schema change: no

**Task Checklist**:
- [x] `PipelineState.quality_telemetry` field with serialize support
- [x] `_run_scene_pipeline` returns scene critique records
- [x] `ChapterDraft.critic_findings` populated from scene records
- [x] Consistency meta captured and stored per chapter
- [x] `_write_quality_report()` standalone function
- [x] Called at pipeline completion (non-fatal, wrapped try/except)
- [x] `report` CLI subcommand (argument_parser + main)
- [x] `docs/manual.md` Quality Reports section
- [x] Unit tests: 10 tests passing

**Risks addressed**:
- Existing savepoints without `quality_telemetry` still load (defaults to `[]`)
- Malformed existing JSON recovered gracefully
- Critique/consistency disabled → empty fields, report still valid
