### PR TITLE
feat: promote chapter-level recurring findings to wiki style notes

### DIFF
--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -1459,6 +1459,29 @@ async def _continue_pipeline(
                             f"\n[Recap] chapter {chapter_number} recap skipped "
                             f"({type(exc).__name__}: {exc})\n"
                         )
+                style_notes_item_id = f"chapter-{chapter_number}/style-notes"
+                if settings.enable_critique_learning and not _work_item_done(
+                    state, phase, style_notes_item_id
+                ):
+                    try:
+                        from tools import wiki_style_notes as _wiki_style_notes
+
+                        sn_result = await asyncio.to_thread(
+                            _wiki_style_notes.promote_findings,
+                            state.story_name,
+                            chapter_number,
+                        )
+                        if sn_result["written"]:
+                            await bus.emit(
+                                f"[StyleNotes] Promoted {len(sn_result['promoted'])} "
+                                "finding(s) to wiki/style-notes.md\n"
+                            )
+                        await _mark_work_item_done(state, phase, style_notes_item_id)
+                    except Exception as exc:  # noqa: BLE001
+                        await bus.emit(
+                            f"\n[StyleNotes] chapter {chapter_number} style-notes "
+                            f"skipped ({type(exc).__name__}: {exc})\n"
+                        )
                 if (
                     chapter_number == 1
                     and "metadata-chapter-1" not in state.completed_phases

--- a/src/tools/wiki_lint.py
+++ b/src/tools/wiki_lint.py
@@ -489,6 +489,23 @@ def cmd_check_full(args: argparse.Namespace) -> None:
     # Append to contradictions.md
     _append_contradictions(wiki_dir, "Full lint", findings)
 
+    style_notes_path = wiki_dir / "style-notes.md"
+    if style_notes_path.exists():
+        sn_content = style_notes_path.read_text()
+        sn_fm, _ = parse_frontmatter(sn_content)
+        for field in ("type", "slug", "last_updated"):
+            if field not in sn_fm:
+                findings.append(
+                    _finding(
+                        "error",
+                        "factual_consistency",
+                        "missing_frontmatter_field",
+                        ["style-notes"],
+                        f"wiki/style-notes.md is missing required frontmatter field '{field}'",
+                        f"Add '{field}' to the frontmatter of wiki/style-notes.md",
+                    )
+                )
+
     _output("check-full", findings)
 
 

--- a/src/tools/wiki_style_notes.py
+++ b/src/tools/wiki_style_notes.py
@@ -1,0 +1,193 @@
+"""Tool for promoting chapter-level critique findings to wiki/style-notes.md."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src = str(Path(__file__).resolve().parents[1])
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from tools._io import STORIES_DIR, _atomic_write, _validate_story_name  # noqa: E402
+from tools._wiki import get_wiki_dir, parse_frontmatter, render_frontmatter  # noqa: E402
+
+CHROMADB_DIR = os.environ.get("CHROMADB_DIR", str(PROJECT_ROOT / ".chromadb"))
+
+_MIN_CHAPTERS = 2
+_STYLE_NOTES_REQUIRED_FIELDS = ("type", "slug", "last_updated")
+
+
+def _read_chapter_lessons(
+    name: str,
+    chapter_number: int,
+    *,
+    stories_dir: Path | None = None,
+) -> dict[str, int]:
+    """Read critique_lessons.json for a single chapter. Returns {} if not found."""
+    base = stories_dir if stories_dir is not None else STORIES_DIR
+    story_dir = _validate_story_name(name, base_dir=base)
+    lessons_file = (
+        story_dir / "chapters" / f"chapter_{chapter_number}" / "critique_lessons.json"
+    )
+    if not lessons_file.exists():
+        return {}
+
+    try:
+        data = json.loads(lessons_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    lessons: dict[str, int] = {}
+    for criterion, count in data.items():
+        if (
+            isinstance(criterion, str)
+            and isinstance(count, int)
+            and not isinstance(count, bool)
+        ):
+            lessons[criterion] = count
+    return lessons
+
+
+def _aggregate_cross_chapter_findings(
+    name: str,
+    chapter_number: int,
+    *,
+    stories_dir: Path | None = None,
+) -> dict[str, list[int]]:
+    """Return {criterion: [chapter_numbers_that_flagged_it]} for chapters 1..N."""
+    result: dict[str, list[int]] = {}
+    for number in range(1, chapter_number + 1):
+        lessons = _read_chapter_lessons(name, number, stories_dir=stories_dir)
+        for criterion, count in lessons.items():
+            if count > 0:
+                result.setdefault(criterion, []).append(number)
+    return result
+
+
+def _build_style_notes_body(promoted: dict[str, list[int]], chapter_number: int) -> str:
+    """Build markdown body for wiki/style-notes.md."""
+    lines: list[str] = [
+        "# Style Notes",
+        "",
+        "Recurring critique patterns promoted from chapter lessons. "
+        "Injected into scene drafts via wiki context machinery.",
+        "",
+        f"*Last updated: chapter {chapter_number}*",
+        "",
+        "## Promoted Findings",
+        "",
+    ]
+    for criterion in sorted(promoted):
+        chapters = sorted(promoted[criterion])
+        lines.append(f"### {criterion}")
+        lines.append(f"Flagged in chapters: {', '.join(str(ch) for ch in chapters)}")
+        lines.append(f"Total chapter occurrences: {len(chapters)}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _upsert_to_chromadb(
+    story_name: str,
+    page_path: Path,
+    body: str,
+    frontmatter: dict[str, Any],
+) -> None:
+    """Upsert style-notes.md to the wiki ChromaDB collection. Graceful on failure."""
+    try:
+        import chromadb  # type: ignore[import-not-found]
+
+        from tools._chroma_sync import upsert_from_source  # noqa: E402
+
+        client = chromadb.PersistentClient(path=CHROMADB_DIR)
+        collection = client.get_or_create_collection(name=f"wiki-{story_name}")
+        extra_meta: dict[str, str | int | float | bool] = {
+            "type": str(frontmatter.get("type", "style_notes")),
+            "slug": str(frontmatter.get("slug", "style-notes")),
+        }
+        upsert_from_source(
+            collection,
+            doc_id="style-notes",
+            source_path=str(page_path.relative_to(PROJECT_ROOT)),
+            extra_metadata=extra_meta,
+            body=body,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"Warning: ChromaDB upsert for style-notes failed (non-fatal): {exc}",
+            file=sys.stderr,
+        )
+
+
+def promote_findings(
+    name: str,
+    chapter_number: int,
+    *,
+    stories_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Promote recurring critique findings to wiki/style-notes.md."""
+    base = stories_dir if stories_dir is not None else STORIES_DIR
+    story_dir = _validate_story_name(name, base_dir=base)
+    wiki_dir = get_wiki_dir(story_dir)
+    style_notes_path = wiki_dir / "style-notes.md"
+
+    existing_fm: dict[str, Any] = {}
+    if style_notes_path.exists():
+        existing_content = style_notes_path.read_text()
+        existing_fm, _ = parse_frontmatter(existing_content)
+        if existing_fm.get("pinned") is True:
+            return {"written": False, "promoted": []}
+
+    cross_chapter = _aggregate_cross_chapter_findings(
+        story_dir.name,
+        chapter_number,
+        stories_dir=base,
+    )
+    promoted = {
+        criterion: chapters
+        for criterion, chapters in cross_chapter.items()
+        if len(chapters) >= _MIN_CHAPTERS
+    }
+
+    if not promoted:
+        return {"written": False, "promoted": []}
+
+    now_ts = datetime.now(timezone.utc).isoformat()
+    suppress = existing_fm.get("suppress", False) is True
+    version = 1
+    if existing_fm:
+        version_value = existing_fm.get("version", 1)
+        if isinstance(version_value, int) and not isinstance(version_value, bool):
+            version = version_value + 1
+
+    frontmatter: dict[str, Any] = {
+        "type": "style_notes",
+        "slug": "style-notes",
+        "last_updated": now_ts,
+        "version": version,
+        "pinned": False,
+        "suppress": suppress,
+    }
+
+    for field in _STYLE_NOTES_REQUIRED_FIELDS:
+        if field not in frontmatter:
+            raise ValueError(f"Missing required style notes frontmatter field: {field}")
+
+    body = _build_style_notes_body(promoted, chapter_number)
+    full_content = render_frontmatter(frontmatter, body) + "\n"
+
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    _atomic_write(style_notes_path, full_content)
+
+    if not suppress:
+        _upsert_to_chromadb(story_dir.name, style_notes_path, body, frontmatter)
+
+    return {"written": True, "promoted": sorted(promoted.keys())}

--- a/tests/unit/test_wiki_style_notes.py
+++ b/tests/unit/test_wiki_style_notes.py
@@ -1,0 +1,196 @@
+"""Unit tests for wiki_style_notes promotion tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from tools._wiki import parse_frontmatter
+from tools.wiki_style_notes import promote_findings
+
+
+def _story_dir(base: Path, name: str = "test-story") -> Path:
+    story_dir = base / name
+    story_dir.mkdir(parents=True, exist_ok=True)
+    return story_dir
+
+
+def _write_lessons(base: Path, name: str, chapter: int, lessons: dict) -> None:
+    path = base / name / "chapters" / f"chapter_{chapter}" / "critique_lessons.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(lessons))
+
+
+def _style_notes_path(base: Path, name: str = "test-story") -> Path:
+    return base / name / "wiki" / "style-notes.md"
+
+
+def _write_existing_style_notes(
+    base: Path, content: str, name: str = "test-story"
+) -> Path:
+    path = _style_notes_path(base, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def test_no_lessons_returns_not_written(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {})
+    _write_lessons(tmp_path, "test-story", 2, {})
+    _write_lessons(tmp_path, "test-story", 3, {})
+
+    result = promote_findings("test-story", 3, stories_dir=tmp_path)
+
+    assert result == {"written": False, "promoted": []}
+    assert not _style_notes_path(tmp_path).exists()
+
+
+def test_single_chapter_finding_not_promoted(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {"style_violations": 2})
+
+    result = promote_findings("test-story", 1, stories_dir=tmp_path)
+
+    assert result == {"written": False, "promoted": []}
+    assert not _style_notes_path(tmp_path).exists()
+
+
+def test_two_chapter_finding_promoted(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {"style_violations": 1})
+    _write_lessons(tmp_path, "test-story", 2, {"style_violations": 3})
+
+    result = promote_findings("test-story", 2, stories_dir=tmp_path)
+
+    style_notes_path = _style_notes_path(tmp_path)
+    assert result == {"written": True, "promoted": ["style_violations"]}
+    assert style_notes_path.exists()
+    assert "### style_violations" in style_notes_path.read_text()
+
+
+def test_three_chapters_same_finding_creates_file(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {"style_violations": 1})
+    _write_lessons(tmp_path, "test-story", 2, {"style_violations": 2})
+    _write_lessons(tmp_path, "test-story", 3, {"style_violations": 1})
+
+    result = promote_findings("test-story", 3, stories_dir=tmp_path)
+
+    style_notes_path = _style_notes_path(tmp_path)
+    assert result == {"written": True, "promoted": ["style_violations"]}
+    assert style_notes_path.exists()
+
+    frontmatter, body = parse_frontmatter(style_notes_path.read_text())
+    assert frontmatter["type"] == "style_notes"
+    assert frontmatter["slug"] == "style-notes"
+    assert "last_updated" in frontmatter
+    assert body.startswith("# Style Notes")
+    assert "Flagged in chapters: 1, 2, 3" in body
+
+
+def test_pinned_page_not_updated(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {"style_violations": 1})
+    _write_lessons(tmp_path, "test-story", 2, {"style_violations": 1})
+    existing = "---\ntype: style_notes\nslug: style-notes\npinned: true\nversion: 4\n---\n\noriginal body\n"
+    style_notes_path = _write_existing_style_notes(tmp_path, existing)
+
+    result = promote_findings("test-story", 2, stories_dir=tmp_path)
+
+    assert result == {"written": False, "promoted": []}
+    assert style_notes_path.read_text() == existing
+
+
+def test_suppress_flag_preserved_on_update(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {"style_violations": 1})
+    _write_lessons(tmp_path, "test-story", 2, {"style_violations": 1})
+    _write_existing_style_notes(
+        tmp_path,
+        "---\ntype: style_notes\nslug: style-notes\nsuppress: true\nversion: 1\n---\n\nold body\n",
+    )
+
+    result = promote_findings("test-story", 2, stories_dir=tmp_path)
+
+    frontmatter, body = parse_frontmatter(_style_notes_path(tmp_path).read_text())
+    assert result == {"written": True, "promoted": ["style_violations"]}
+    assert frontmatter["suppress"] is True
+    assert frontmatter["version"] == 2
+    assert "### style_violations" in body
+
+
+def test_version_increments_on_update(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(tmp_path, "test-story", 1, {"style_violations": 1})
+    _write_lessons(tmp_path, "test-story", 2, {"style_violations": 1})
+    _write_existing_style_notes(
+        tmp_path,
+        "---\ntype: style_notes\nslug: style-notes\nversion: 1\n---\n\nold body\n",
+    )
+
+    result = promote_findings("test-story", 2, stories_dir=tmp_path)
+
+    frontmatter, _ = parse_frontmatter(_style_notes_path(tmp_path).read_text())
+    assert result == {"written": True, "promoted": ["style_violations"]}
+    assert frontmatter["version"] == 2
+
+
+def test_only_criteria_in_two_plus_chapters_promoted(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(
+        tmp_path,
+        "test-story",
+        1,
+        {
+            "alpha_issue": 1,
+            "beta_issue": 1,
+            "charlie_issue": 1,
+        },
+    )
+    _write_lessons(
+        tmp_path,
+        "test-story",
+        2,
+        {
+            "alpha_issue": 2,
+            "charlie_issue": 1,
+        },
+    )
+    _write_lessons(tmp_path, "test-story", 3, {"charlie_issue": 1})
+
+    result = promote_findings("test-story", 3, stories_dir=tmp_path)
+
+    assert result == {
+        "written": True,
+        "promoted": ["alpha_issue", "charlie_issue"],
+    }
+
+
+def test_return_promoted_list_is_sorted(tmp_path: Path) -> None:
+    _story_dir(tmp_path)
+    _write_lessons(
+        tmp_path,
+        "test-story",
+        1,
+        {
+            "zeta_issue": 1,
+            "alpha_issue": 1,
+            "middle_issue": 1,
+        },
+    )
+    _write_lessons(
+        tmp_path,
+        "test-story",
+        2,
+        {
+            "middle_issue": 1,
+            "zeta_issue": 1,
+            "alpha_issue": 1,
+        },
+    )
+
+    result = promote_findings("test-story", 2, stories_dir=tmp_path)
+
+    assert result["promoted"] == ["alpha_issue", "middle_issue", "zeta_issue"]


### PR DESCRIPTION
## Summary

At each chapter close, `wiki_style_notes.promote_findings()` scans `critique_lessons.json` for all completed chapters. When a criterion appears in ≥2 distinct chapters, it writes/updates `wiki/style-notes.md` with YAML frontmatter and a markdown body listing the promoted findings. The page is upserted to the `wiki-{story}` ChromaDB collection so it is injected into scene drafts via existing wiki context machinery — no new injection path required.

## Closes
Closes #420

## Changes
- [x] `src/tools/wiki_style_notes.py` — new module: `promote_findings()`, `_read_chapter_lessons()`, `_aggregate_cross_chapter_findings()`, `_build_style_notes_body()`, `_upsert_to_chromadb()`
- [x] `src/presentation/orchestrator.py` — `chapter-{N}/style-notes` work item after recap, gated by `settings.enable_critique_learning`
- [x] `src/tools/wiki_lint.py` — `check-full` validates `wiki/style-notes.md` frontmatter if present (required fields: `type`, `slug`, `last_updated`)
- [x] `tests/unit/test_wiki_style_notes.py` — 9 unit tests covering all acceptance criteria
- [x] All tests passing (9/9)
- [x] Linting clean (`ruff`, `mypy`)

## Human Override Support
- `pinned: true` frontmatter on `wiki/style-notes.md` → page skipped on auto-update
- `suppress: true` frontmatter → page written to disk but ChromaDB upsert skipped (no injection)
