### PR TITLE
feat(critique): adaptive quality thresholds by chapter position

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -37,6 +37,13 @@ generation:
   enable_outline_critique: true
   enable_scene_critique: true
   enable_decomposition_critique: true
+  scene_critique_score_threshold: 80.0
+  scene_critique_max_iterations: 3
+  # Threshold mode: "fixed" applies threshold uniformly; "adaptive" starts
+  # permissive for early chapters and tightens as wiki style notes accumulate.
+  scene_critique_threshold_mode: "fixed"
+  # Slack subtracted from threshold at chapter 1 in adaptive mode.
+  scene_critique_adaptive_slack: 10.0
   enable_beat_sheet: true
   enable_living_scene_plan: true
   stream: true

--- a/src/application/pipeline/handoffs.py
+++ b/src/application/pipeline/handoffs.py
@@ -154,6 +154,7 @@ class PipelineState:
     completed_work_items: dict[str, list[str]] = field(default_factory=dict)
     status: str = "running"
     style_guide: str = ""
+    style_notes_first_chapter: int | None = None
     quality_telemetry: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -277,6 +278,7 @@ class PipelineState:
             status=data.get("status", "running"),
             completed_work_items=data.get("completed_work_items", {}),
             style_guide=_resolve(data.get("style_guide", "")),
+            style_notes_first_chapter=data.get("style_notes_first_chapter"),
             quality_telemetry=data.get("quality_telemetry", []),
         )
 

--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -30,6 +30,8 @@ class GenerationSettings:
     enable_scene_critique_loop: bool = True
     scene_critique_score_threshold: float = 80.0
     scene_critique_max_iterations: int = 3
+    scene_critique_threshold_mode: str = "fixed"
+    scene_critique_adaptive_slack: float = 10.0
     enable_consistency_revision_loop: bool = True
     consistency_max_iterations: int = 2
     enable_decomposition_critique: bool = True
@@ -104,6 +106,18 @@ class GenerationSettings:
                 f"got {self.scene_critique_score_threshold}"
             )
 
+        if self.scene_critique_threshold_mode not in ("fixed", "adaptive"):
+            raise ValidationError(
+                "scene_critique_threshold_mode must be 'fixed' or 'adaptive', "
+                f"got {self.scene_critique_threshold_mode!r}"
+            )
+
+        if not (0.0 <= self.scene_critique_adaptive_slack <= 100.0):
+            raise ValidationError(
+                "scene_critique_adaptive_slack must be between 0.0 and 100.0, "
+                f"got {self.scene_critique_adaptive_slack}"
+            )
+
         if not (1 <= self.scene_critique_max_iterations <= 10):
             raise ValidationError(
                 "scene_critique_max_iterations must be between 1 and 10, "
@@ -169,6 +183,8 @@ class GenerationSettings:
             "enable_scene_critique_loop": self.enable_scene_critique_loop,
             "scene_critique_score_threshold": self.scene_critique_score_threshold,
             "scene_critique_max_iterations": self.scene_critique_max_iterations,
+            "scene_critique_threshold_mode": self.scene_critique_threshold_mode,
+            "scene_critique_adaptive_slack": self.scene_critique_adaptive_slack,
             "enable_consistency_revision_loop": self.enable_consistency_revision_loop,
             "consistency_max_iterations": self.consistency_max_iterations,
             "enable_decomposition_critique": self.enable_decomposition_critique,

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -40,6 +40,7 @@ from presentation.pipeline_primitives import (
 from tools._io import STORIES_DIR, _atomic_write, _validate_story_name
 from tools._llm import extract_paragraph_tail
 from tools._persist import read_markdown_ref
+from tools.adaptive_threshold import compute_effective_threshold
 from tools.context_assembly import assemble_context, render_recap_as_markdown
 from tools.critique_parser import CritiqueParser, passed_quality_threshold
 
@@ -385,6 +386,14 @@ class ChapterWriterAgent:
         style_guide: str = state.style_guide if state is not None else ""
         if isinstance(style_guide, dict):
             style_guide = ""
+        _style_notes_first_chapter = (
+            getattr(state, "style_notes_first_chapter", None) if state else None
+        )
+        _effective_threshold = compute_effective_threshold(
+            settings,
+            chapter_number,
+            _style_notes_first_chapter,
+        )
 
         loader = self._loader
         synopsis_model = _build_model_config(
@@ -715,6 +724,7 @@ class ChapterWriterAgent:
                         "final_score": None,
                         "iteration_count": 0,
                         "residual_categories": [],
+                        "threshold_used": _effective_threshold,
                     }
                 )
                 continue
@@ -983,7 +993,7 @@ class ChapterWriterAgent:
                         and _critique_iteration < settings.scene_critique_max_iterations
                         and not passed_quality_threshold(
                             _critique_score,
-                            settings.scene_critique_score_threshold,
+                            _effective_threshold,
                         )
                     ):
                         _critique_iteration += 1
@@ -1157,6 +1167,7 @@ class ChapterWriterAgent:
                         "scene_num": index,
                         "final_score": _critique_score,
                         "iteration_count": _critique_iteration,
+                        "threshold_used": _effective_threshold,
                         "residual_categories": [
                             s.criterion
                             for s in _scene_result.scores
@@ -1171,6 +1182,7 @@ class ChapterWriterAgent:
                         "final_score": None,
                         "iteration_count": 0,
                         "residual_categories": [],
+                        "threshold_used": _effective_threshold,
                     }
                 )
 

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -1471,6 +1471,11 @@ async def _continue_pipeline(
                             state.story_name,
                             chapter_number,
                         )
+                        if (
+                            sn_result.get("written")
+                            and state.style_notes_first_chapter is None
+                        ):
+                            state.style_notes_first_chapter = chapter_number
                         if sn_result["written"]:
                             await bus.emit(
                                 f"[StyleNotes] Promoted {len(sn_result['promoted'])} "

--- a/src/tools/adaptive_threshold.py
+++ b/src/tools/adaptive_threshold.py
@@ -1,0 +1,40 @@
+"""Adaptive scene critique threshold computation."""
+
+from __future__ import annotations
+
+from domain.value_objects.generation_settings import GenerationSettings
+
+
+def compute_effective_threshold(
+    settings: GenerationSettings,
+    chapter_number: int,
+    style_notes_first_chapter: int | None,
+) -> float:
+    """Return the effective critique threshold for the given chapter.
+
+    In "fixed" mode returns ``settings.scene_critique_score_threshold`` unchanged.
+
+    In "adaptive" mode the threshold starts at
+    ``scene_critique_score_threshold - scene_critique_adaptive_slack`` for
+    chapter 1 and increases linearly to ``scene_critique_score_threshold`` by
+    ``style_notes_first_chapter``. If style notes have not appeared yet
+    (``style_notes_first_chapter is None``) the floor value is used.
+    """
+    threshold = settings.scene_critique_score_threshold
+
+    if settings.scene_critique_threshold_mode == "fixed":
+        return threshold
+
+    slack = settings.scene_critique_adaptive_slack
+    floor = max(0.0, threshold - slack)
+
+    if style_notes_first_chapter is None:
+        return floor
+
+    n = style_notes_first_chapter
+    if n <= 1:
+        return threshold
+
+    progress = (chapter_number - 1) / (n - 1)
+    effective = floor + (threshold - floor) * progress
+    return min(threshold, effective)

--- a/tests/unit/test_adaptive_threshold.py
+++ b/tests/unit/test_adaptive_threshold.py
@@ -1,0 +1,143 @@
+"""Verification tests for adaptive quality thresholds (#421)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_src_dir = str(PROJECT_ROOT / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from domain.value_objects.generation_settings import GenerationSettings
+from tools.adaptive_threshold import compute_effective_threshold
+
+
+def _settings(**overrides: object) -> GenerationSettings:
+    base = {
+        "scene_critique_score_threshold": 80.0,
+        "scene_critique_threshold_mode": "fixed",
+        "scene_critique_adaptive_slack": 10.0,
+    }
+    base.update(overrides)
+    return GenerationSettings(**base)
+
+
+def test_fixed_mode_returns_threshold_unchanged() -> None:
+    settings = _settings(scene_critique_threshold_mode="fixed")
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=5, style_notes_first_chapter=10
+        )
+        == 80.0
+    )
+
+
+def test_adaptive_chapter_1_uses_floor() -> None:
+    settings = _settings(
+        scene_critique_threshold_mode="adaptive",
+        scene_critique_score_threshold=80.0,
+        scene_critique_adaptive_slack=10.0,
+    )
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=1, style_notes_first_chapter=10
+        )
+        == 70.0
+    )
+
+
+def test_adaptive_chapter_equals_n_uses_threshold() -> None:
+    settings = _settings(scene_critique_threshold_mode="adaptive")
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=10, style_notes_first_chapter=10
+        )
+        == 80.0
+    )
+
+
+def test_adaptive_chapter_5_linear_ramp() -> None:
+    settings = _settings(
+        scene_critique_threshold_mode="adaptive",
+        scene_critique_score_threshold=80.0,
+        scene_critique_adaptive_slack=10.0,
+    )
+
+    assert compute_effective_threshold(
+        settings, chapter_number=5, style_notes_first_chapter=10
+    ) == pytest.approx(
+        74.44,
+        abs=0.01,
+    )
+
+
+def test_adaptive_chapter_10_linear_ramp() -> None:
+    settings = _settings(
+        scene_critique_threshold_mode="adaptive",
+        scene_critique_score_threshold=80.0,
+        scene_critique_adaptive_slack=10.0,
+    )
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=10, style_notes_first_chapter=10
+        )
+        == 80.0
+    )
+
+
+def test_adaptive_style_notes_none_returns_floor() -> None:
+    settings = _settings(
+        scene_critique_threshold_mode="adaptive",
+        scene_critique_score_threshold=80.0,
+        scene_critique_adaptive_slack=10.0,
+    )
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=3, style_notes_first_chapter=None
+        )
+        == 70.0
+    )
+
+
+def test_adaptive_chapter_beyond_n_clamped_to_threshold() -> None:
+    settings = _settings(scene_critique_threshold_mode="adaptive")
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=15, style_notes_first_chapter=10
+        )
+        == 80.0
+    )
+
+
+def test_adaptive_style_notes_first_chapter_1_returns_threshold() -> None:
+    settings = _settings(scene_critique_threshold_mode="adaptive")
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=1, style_notes_first_chapter=1
+        )
+        == 80.0
+    )
+
+
+def test_fixed_mode_ignores_slack() -> None:
+    settings = _settings(
+        scene_critique_threshold_mode="fixed",
+        scene_critique_score_threshold=80.0,
+        scene_critique_adaptive_slack=50.0,
+    )
+
+    assert (
+        compute_effective_threshold(
+            settings, chapter_number=1, style_notes_first_chapter=None
+        )
+        == 80.0
+    )


### PR DESCRIPTION
## Summary
Implements adaptive scene critique thresholds that start permissive for early chapters and tighten linearly as wiki style notes accumulate.

## Closes
Closes #421

## Changes
- Add `scene_critique_threshold_mode` (`fixed`|`adaptive`) config field to `GenerationSettings`
- Add `scene_critique_adaptive_slack` (default 10.0) config field
- Track `style_notes_first_chapter` in `PipelineState`; set in orchestrator on first style-notes write
- New `src/tools/adaptive_threshold.py`: `compute_effective_threshold()` — linear ramp from `threshold-slack` at ch1 to `threshold` at `style_notes_first_chapter`
- `chapter_writer._run_scene_pipeline` uses effective threshold for critique pass/fail; logs `threshold_used` per scene record
- `config.example.yml` documents new fields

## Plan
- [x] `GenerationSettings`: 2 new fields + validation + serialisation
- [x] `PipelineState`: `style_notes_first_chapter` field
- [x] `src/tools/adaptive_threshold.py`: pure computation function
- [x] `orchestrator.py`: set `style_notes_first_chapter` on first wiki style-notes write
- [x] `chapter_writer.py`: use effective threshold; log `threshold_used`
- [x] `config.example.yml`: document new fields
- [x] `tests/unit/test_adaptive_threshold.py`: 9 unit tests — 9 passed, 0 failed