### PR TITLE
feat: critic ensemble for scene critique (multi-persona scoring)

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -44,6 +44,10 @@ generation:
   scene_critique_threshold_mode: "fixed"
   # Slack subtracted from threshold at chapter 1 in adaptive mode.
   scene_critique_adaptive_slack: 10.0
+  # scene_critique_critics:     # Uncomment and extend for ensemble mode
+  #   - "scene-default"         # Default: single implicit critic (current behaviour)
+  #   - "commercial-fiction-editor"
+  #   - "literary-fiction-reviewer"
   enable_beat_sheet: true
   enable_living_scene_plan: true
   stream: true

--- a/src/domain/value_objects/generation_settings.py
+++ b/src/domain/value_objects/generation_settings.py
@@ -1,6 +1,6 @@
 """Generation settings value objects."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Dict, Any
 from ..exceptions import ValidationError
 
@@ -32,6 +32,7 @@ class GenerationSettings:
     scene_critique_max_iterations: int = 3
     scene_critique_threshold_mode: str = "fixed"
     scene_critique_adaptive_slack: float = 10.0
+    scene_critique_critics: list[str] = field(default_factory=lambda: ["scene-default"])
     enable_consistency_revision_loop: bool = True
     consistency_max_iterations: int = 2
     enable_decomposition_critique: bool = True
@@ -118,6 +119,11 @@ class GenerationSettings:
                 f"got {self.scene_critique_adaptive_slack}"
             )
 
+        if not self.scene_critique_critics or len(self.scene_critique_critics) < 1:
+            raise ValidationError(
+                "scene_critique_critics must have at least 1 entry, got empty list"
+            )
+
         if not (1 <= self.scene_critique_max_iterations <= 10):
             raise ValidationError(
                 "scene_critique_max_iterations must be between 1 and 10, "
@@ -185,6 +191,7 @@ class GenerationSettings:
             "scene_critique_max_iterations": self.scene_critique_max_iterations,
             "scene_critique_threshold_mode": self.scene_critique_threshold_mode,
             "scene_critique_adaptive_slack": self.scene_critique_adaptive_slack,
+            "scene_critique_critics": list(self.scene_critique_critics),
             "enable_consistency_revision_loop": self.enable_consistency_revision_loop,
             "consistency_max_iterations": self.consistency_max_iterations,
             "enable_decomposition_critique": self.enable_decomposition_critique,

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -42,7 +42,11 @@ from tools._llm import extract_paragraph_tail
 from tools._persist import read_markdown_ref
 from tools.adaptive_threshold import compute_effective_threshold
 from tools.context_assembly import assemble_context, render_recap_as_markdown
-from tools.critique_parser import CritiqueParser, passed_quality_threshold
+from tools.critique_parser import (
+    CritiqueParser,
+    CritiqueResult,
+    passed_quality_threshold,
+)
 
 
 def _savepoint_path(story_name: str) -> Path:
@@ -962,30 +966,50 @@ class ChapterWriterAgent:
                 await self.bus.emit(
                     f"\n[Chapter {chapter_number}] Critiquing scene {index}...\n"
                 )
-                critique_prompt = loader.load_prompt(
-                    "scenes/critique_draft",
-                    variables={
-                        "chapter_num": str(chapter_number),
-                        "scene_num": str(index),
-                        "scene_content": scene_text,
-                        "scene_definition": json.dumps(scene, ensure_ascii=False),
-                        "chapter_outline": chapter_summary,
-                        "previous_scene": prev_tail,
-                    },
-                )
+                _critique_prompt_vars = {
+                    "chapter_num": str(chapter_number),
+                    "scene_num": str(index),
+                    "scene_content": scene_text,
+                    "scene_definition": json.dumps(scene, ensure_ascii=False),
+                    "chapter_outline": chapter_summary,
+                    "previous_scene": prev_tail,
+                }
                 try:
-                    critique_text = await self._stream_to_bus(
-                        [
-                            {"role": "system", "content": critique_prompt},
-                            {"role": "user", "content": "Critique the scene now."},
-                        ],
-                        scene_model,
-                        settings.seed,
-                    )
-                    critique_text = critique_text.strip()
                     _scene_parser = CritiqueParser()
-                    _scene_result = _scene_parser.parse_scene_critique(critique_text)
-                    _critique_score = _scene_result.overall_score
+                    _critic_results: list[CritiqueResult] = []
+                    critique_text = ""
+                    for _critic_name in settings.scene_critique_critics:
+                        _critique_prompt = loader.load_prompt(
+                            "scenes/critique_draft",
+                            variables=_critique_prompt_vars,
+                        )
+                        _critic_system = (
+                            f"You are evaluating from the perspective of: {_critic_name.replace('-', ' ')}.\n\n{_critique_prompt}"
+                            if _critic_name != "scene-default"
+                            else _critique_prompt
+                        )
+                        _critic_response = await self._stream_to_bus(
+                            [
+                                {"role": "system", "content": _critic_system},
+                                {"role": "user", "content": "Critique the scene now."},
+                            ],
+                            scene_model,
+                            settings.seed,
+                        )
+                        _critic_response = _critic_response.strip()
+                        if not critique_text:
+                            critique_text = _critic_response
+                        _critic_results.append(
+                            _scene_parser.parse_scene_critique(_critic_response)
+                        )
+                    if len(_critic_results) == 1:
+                        _scene_result = _critic_results[0]
+                        _critique_score = _scene_result.overall_score
+                    else:
+                        _scene_result = _critic_results[0]
+                        _critique_score = _scene_parser.get_overall_average_score(
+                            _critic_results
+                        )
                     _critique_iteration = 0
 
                     while (
@@ -1036,7 +1060,13 @@ class ChapterWriterAgent:
                                 "chapter_num": str(chapter_number),
                                 "scene_num": str(index),
                                 "scene_content": scene_text,
-                                "feedback": critique_text,
+                                "feedback": (
+                                    _scene_parser.format_critique_feedback(
+                                        _critic_results
+                                    )
+                                    if len(_critic_results) > 1
+                                    else critique_text
+                                ),
                                 "scene_definition": json.dumps(
                                     scene, ensure_ascii=False
                                 ),
@@ -1081,39 +1111,61 @@ class ChapterWriterAgent:
                             break
 
                         if _critique_iteration < settings.scene_critique_max_iterations:
-                            re_critique_prompt = loader.load_prompt(
-                                "scenes/critique_draft",
-                                variables={
-                                    "chapter_num": str(chapter_number),
-                                    "scene_num": str(index),
-                                    "scene_content": scene_text,
-                                    "scene_definition": json.dumps(
-                                        scene, ensure_ascii=False
-                                    ),
-                                    "chapter_outline": chapter_summary,
-                                    "previous_scene": prev_tail,
-                                },
-                            )
+                            _re_critique_prompt_vars = {
+                                "chapter_num": str(chapter_number),
+                                "scene_num": str(index),
+                                "scene_content": scene_text,
+                                "scene_definition": json.dumps(
+                                    scene, ensure_ascii=False
+                                ),
+                                "chapter_outline": chapter_summary,
+                                "previous_scene": prev_tail,
+                            }
                             try:
-                                critique_text = await self._stream_to_bus(
-                                    [
-                                        {
-                                            "role": "system",
-                                            "content": re_critique_prompt,
-                                        },
-                                        {
-                                            "role": "user",
-                                            "content": "Critique the scene now.",
-                                        },
-                                    ],
-                                    scene_model,
-                                    settings.seed,
-                                )
-                                critique_text = critique_text.strip()
-                                _scene_result = _scene_parser.parse_scene_critique(
-                                    critique_text
-                                )
-                                _critique_score = _scene_result.overall_score
+                                _critic_results = []
+                                critique_text = ""
+                                for _critic_name in settings.scene_critique_critics:
+                                    re_critique_prompt = loader.load_prompt(
+                                        "scenes/critique_draft",
+                                        variables=_re_critique_prompt_vars,
+                                    )
+                                    _re_critic_system = (
+                                        f"You are evaluating from the perspective of: {_critic_name.replace('-', ' ')}.\n\n{re_critique_prompt}"
+                                        if _critic_name != "scene-default"
+                                        else re_critique_prompt
+                                    )
+                                    critique_text_part = await self._stream_to_bus(
+                                        [
+                                            {
+                                                "role": "system",
+                                                "content": _re_critic_system,
+                                            },
+                                            {
+                                                "role": "user",
+                                                "content": "Critique the scene now.",
+                                            },
+                                        ],
+                                        scene_model,
+                                        settings.seed,
+                                    )
+                                    critique_text_part = critique_text_part.strip()
+                                    if not critique_text:
+                                        critique_text = critique_text_part
+                                    _critic_results.append(
+                                        _scene_parser.parse_scene_critique(
+                                            critique_text_part
+                                        )
+                                    )
+                                if len(_critic_results) == 1:
+                                    _scene_result = _critic_results[0]
+                                    _critique_score = _scene_result.overall_score
+                                else:
+                                    _scene_result = _critic_results[0]
+                                    _critique_score = (
+                                        _scene_parser.get_overall_average_score(
+                                            _critic_results
+                                        )
+                                    )
                             except Exception as exc:
                                 await self.bus.emit(
                                     f"\n[Chapter {chapter_number}] scene {index} "
@@ -1162,19 +1214,22 @@ class ChapterWriterAgent:
                     )
 
             if _scene_result is not None:
-                scene_records.append(
-                    {
-                        "scene_num": index,
-                        "final_score": _critique_score,
-                        "iteration_count": _critique_iteration,
-                        "threshold_used": _effective_threshold,
-                        "residual_categories": [
-                            s.criterion
-                            for s in _scene_result.scores
-                            if s.score < s.max_score * 0.6
-                        ],
+                _scene_record: dict[str, Any] = {
+                    "scene_num": index,
+                    "final_score": _critique_score,
+                    "iteration_count": _critique_iteration,
+                    "threshold_used": _effective_threshold,
+                    "residual_categories": [
+                        s.criterion
+                        for s in _scene_result.scores
+                        if s.score < s.max_score * 0.6
+                    ],
+                }
+                if len(settings.scene_critique_critics) > 1:
+                    _scene_record["per_critic_scores"] = {
+                        r.critic_type: r.overall_score for r in _critic_results
                     }
-                )
+                scene_records.append(_scene_record)
             else:
                 scene_records.append(
                     {

--- a/tests/unit/test_scene_critic_ensemble.py
+++ b/tests/unit/test_scene_critic_ensemble.py
@@ -1,0 +1,124 @@
+"""Tests for issue #422: scene critic ensemble."""
+
+import pytest
+
+from src.domain.value_objects.generation_settings import GenerationSettings
+from src.tools.critique_parser import CritiqueParser
+
+
+class TestSceneCritiqueEnsembleSettings:
+    def test_default_critics_list_has_one_entry(self):
+        settings = GenerationSettings()
+        assert settings.scene_critique_critics == ["scene-default"]
+
+    def test_multiple_critics_accepted(self):
+        settings = GenerationSettings(
+            scene_critique_critics=["scene-default", "commercial-fiction-editor"]
+        )
+        assert len(settings.scene_critique_critics) == 2
+
+    def test_empty_critics_list_raises_validation_error(self):
+        from src.domain.exceptions import ValidationError
+
+        with pytest.raises(ValidationError):
+            GenerationSettings(scene_critique_critics=[])
+
+    def test_single_custom_critic_accepted(self):
+        settings = GenerationSettings(
+            scene_critique_critics=["literary-fiction-reviewer"]
+        )
+        assert settings.scene_critique_critics == ["literary-fiction-reviewer"]
+
+    def test_to_dict_includes_critics(self):
+        settings = GenerationSettings(
+            scene_critique_critics=["scene-default", "commercial-fiction-editor"]
+        )
+        d = settings.to_dict()
+        assert d["scene_critique_critics"] == [
+            "scene-default",
+            "commercial-fiction-editor",
+        ]
+
+    def test_from_dict_roundtrip(self):
+        original = GenerationSettings(
+            scene_critique_critics=["scene-default", "literary-fiction-reviewer"]
+        )
+        d = original.to_dict()
+        restored = GenerationSettings.from_dict(d)
+        assert restored.scene_critique_critics == original.scene_critique_critics
+
+
+class TestEnsembleScoreAggregation:
+    """Tests for the two-critic ensemble aggregation (AC#6).
+
+    AC#6: Unit test: two-critic ensemble; verify aggregated score is average of both.
+
+    Score calculation:
+      - 4 categories, 25 points each → max 100
+      - deduction_per_finding = 8; raw = max(0, 25 - n*8)
+      - "{}" → all categories clean → overall = 100.0
+      - 1 finding each in all 4 categories → raw = 17 each → overall = 68.0
+      - 1 finding in outline_adherence only → overall = 17+25+25+25 = 92.0
+      - 2 findings in style_violations only → raw = max(0,25-16)=9 → overall = 25+25+25+9 = 84.0
+    """
+
+    def test_two_critic_average_score(self):
+        """Two critics with known scores: aggregate equals arithmetic mean."""
+        parser = CritiqueParser()
+        # Critic 1: all categories clean → score 100
+        response_100 = "{}"
+        # Critic 2: one finding in each of 4 categories → raw=17 each → overall=68
+        response_68 = (
+            '{"outline_adherence": ["missing A"], "pov_consistency": ["shift B"],'
+            ' "continuity": ["break C"], "style_violations": ["purple D"]}'
+        )
+
+        result_100 = parser.parse_scene_critique(response_100)
+        result_68 = parser.parse_scene_critique(response_68)
+
+        assert result_100.overall_score == 100.0
+        assert result_68.overall_score == 68.0
+
+        average = parser.get_overall_average_score([result_100, result_68])
+        assert average == pytest.approx((100.0 + 68.0) / 2)  # 84.0
+
+    def test_three_critics_average_score(self):
+        """Three critics: aggregate equals arithmetic mean of all three."""
+        parser = CritiqueParser()
+        # r1: all clean → 100.0
+        r1 = parser.parse_scene_critique("{}")
+        # r2: 1 finding in outline_adherence → 17+25+25+25 = 92.0
+        r2 = parser.parse_scene_critique('{"outline_adherence": ["issue1"]}')
+        # r3: 2 findings in style_violations → 25+25+25+9 = 84.0
+        r3 = parser.parse_scene_critique('{"style_violations": ["issue1", "issue2"]}')
+
+        assert r1.overall_score == pytest.approx(100.0)
+        assert r2.overall_score == pytest.approx(92.0)
+        assert r3.overall_score == pytest.approx(84.0)
+
+        expected = (100.0 + 92.0 + 84.0) / 3
+        actual = parser.get_overall_average_score([r1, r2, r3])
+        assert actual == pytest.approx(expected)
+
+    def test_single_critic_no_aggregation_needed(self):
+        """Single-entry list: overall_average_score equals single result score."""
+        parser = CritiqueParser()
+        result = parser.parse_scene_critique("{}")
+        assert parser.get_overall_average_score([result]) == result.overall_score
+
+    def test_get_average_scores_per_criterion_two_critics(self):
+        """Per-criterion averages computed correctly across two critics."""
+        parser = CritiqueParser()
+        # r1: outline_adherence has 1 finding → raw=17, pct=68%; others pct=100%
+        r1 = parser.parse_scene_critique('{"outline_adherence": ["issue"]}')
+        # r2: all clean → all pct=100%
+        r2 = parser.parse_scene_critique("{}")
+
+        averages = parser.get_average_scores([r1, r2])
+
+        # outline_adherence: (68 + 100) / 2 = 84.0
+        assert averages["outline_adherence"] == pytest.approx(84.0)
+        # others: (100 + 100) / 2 = 100.0
+        assert averages["pov_consistency"] == pytest.approx(100.0)
+        assert averages["continuity"] == pytest.approx(100.0)
+        assert averages["style_violations"] == pytest.approx(100.0)


### PR DESCRIPTION
## Summary

Adds multi-persona critic ensemble support to scene critique. When `scene_critique_critics` contains more than one entry, the system runs each critic against the scene in sequence, aggregates scores via `CritiqueParser.get_overall_average_score`, and passes formatted composite feedback to the revision prompt. Single-critic mode (default) is completely unchanged.

## Closes

Closes #422

## Changes

- [x] `GenerationSettings.scene_critique_critics: list[str]` added, defaults to `["scene-default"]` (current single-critic behaviour)
- [x] `chapter_writer.py` ensemble loop: iterates critics, injects persona prefix into system message, aggregates via `CritiqueParser`
- [x] Revision prompt receives `format_critique_feedback(results)` for ensemble; raw JSON for single-critic (backward compat)
- [x] Re-critique loop inside revision iteration also uses ensemble pattern
- [x] `scene_records` includes `per_critic_scores` dict when ensemble is active (quality telemetry, AC#5)
- [x] `config.example.yml` documents ensemble configuration as commented example
- [x] 10 unit tests passing — settings validation + two-critic ensemble score aggregation (AC#6)
- [x] Lint clean, mypy clean (pre-existing `tui/app.py` error unrelated)

## Plan

### Affected Areas
Python domain logic + presentation layer. No ChromaDB schema change.

### Task Checklist
- [x] `src/domain/value_objects/generation_settings.py` — add field + validation + to_dict
- [x] `src/presentation/agents/chapter_writer.py` — ensemble critique loop (initial + re-critique)
- [x] `config.example.yml` — commented example
- [x] `tests/unit/test_scene_critic_ensemble.py` — 10 tests

### Risks & Edge Cases
- Single-critic default (`["scene-default"]`) fully preserves existing behaviour
- `_scene_result` set to `_critic_results[0]` in ensemble mode to keep critique_learning loop working correctly
- Re-critique loop mirrors initial critique logic to maintain consistency across iterations