### PR TITLE
feat: Thinking mode support (Gemma 4 / LM Studio reasoning_content)

### DIFF
--- a/src/application/interfaces/model_provider.py
+++ b/src/application/interfaces/model_provider.py
@@ -1,8 +1,18 @@
 """Model provider interface."""
 
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional, AsyncGenerator
+from dataclasses import dataclass
+from typing import AsyncGenerator, Any, Dict, List, Literal, Optional
+
 from domain.value_objects.model_config import ModelConfig
+
+
+@dataclass
+class StreamToken:
+    """Tagged token from stream_text — content or thinking channel."""
+
+    text: str
+    kind: Literal["content", "thinking"]
 
 
 class ModelProvider(ABC):
@@ -54,7 +64,7 @@ class ModelProvider(ABC):
         model_config: ModelConfig,
         seed: Optional[int] = None,
         format_type: Optional[str] = None,
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[StreamToken, None]:
         """Stream text generation from messages."""
         pass
 

--- a/src/infrastructure/prompts/prompt_handler.py
+++ b/src/infrastructure/prompts/prompt_handler.py
@@ -457,65 +457,18 @@ class PromptHandler:
     ) -> str:
         """Execute prompt with streaming output to console."""
         full_response = ""
-        buffer = ""
-        in_thinking = False
-        thinking_buffer = ""
 
-        # print(f"Streaming prompt: {messages}")
         print(f"Model config: {model_config}")
 
-        async for chunk in self.model_provider.stream_text(
+        async for st in self.model_provider.stream_text(
             messages=messages,
             model_config=model_config,
             seed=seed,
             format_type=format_type,
         ):
-            # Add chunk to buffer
-            buffer += chunk
-
-            # Process buffer for complete tags
-            while True:
-                if not in_thinking:
-                    # Look for start of think tag
-                    think_start = buffer.find("<think>")
-                    if think_start != -1:
-                        # Print content before think tag
-                        if think_start > 0:
-                            content_before = buffer[:think_start]
-                            print(content_before, end="", flush=True)
-
-                        # Remove content up to and including think tag start
-                        buffer = buffer[think_start + 7 :]  # 7 is len('<think>')
-                        in_thinking = True
-                        continue
-                    else:
-                        # No think tag found, print the buffer
-                        if buffer:
-                            print(buffer, end="", flush=True)
-                            buffer = ""
-                        break
-                else:
-                    # We're inside a think tag, look for end
-                    think_end = buffer.find("</think>")
-                    if think_end != -1:
-                        # Collect thinking content
-                        thinking_buffer += buffer[:think_end]
-
-                        # Display thinking content with visual distinction
-                        print(f"\n[THINKING] {thinking_buffer}\n", end="", flush=True)
-
-                        # Remove content up to and including think tag end
-                        buffer = buffer[think_end + 8 :]  # 8 is len('</think>')
-                        in_thinking = False
-                        thinking_buffer = ""
-                        continue
-                    else:
-                        # Think tag not complete, keep buffering
-                        thinking_buffer += buffer
-                        buffer = ""
-                        break
-
-            full_response += chunk
+            if st.kind == "content":
+                print(st.text, end="", flush=True)
+                full_response += st.text
 
         print()  # New line after streaming
 

--- a/src/infrastructure/providers/openai_async_provider.py
+++ b/src/infrastructure/providers/openai_async_provider.py
@@ -12,7 +12,7 @@ from openai import AsyncOpenAI, AsyncStream
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 
-from application.interfaces.model_provider import ModelProvider
+from application.interfaces.model_provider import ModelProvider, StreamToken
 from domain.exceptions import ModelProviderError
 from domain.value_objects.model_config import ModelConfig
 
@@ -21,6 +21,7 @@ def _append_debug_log(
     messages: List[Dict[str, str]],
     model: str,
     response: str,
+    reasoning: str = "",
 ) -> None:
     """Append one JSONL record to LLM_DEBUG_LOG if the env var is set."""
     log_path = os.environ.get("LLM_DEBUG_LOG")
@@ -32,6 +33,8 @@ def _append_debug_log(
         "messages": messages,
         "response": response,
     }
+    if reasoning:
+        record["reasoning"] = reasoning
     try:
         with open(log_path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
@@ -113,13 +116,6 @@ class OpenAIAsyncProvider(ModelProvider):
             self._clients[base_url] = client
         return client
 
-    def _filter_think_tags(self, text: str) -> str:
-        """Remove <think>...</think> tags from text while preserving the rest."""
-        filtered = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
-        filtered = re.sub(r"<think>.*", "", filtered, flags=re.DOTALL)
-        filtered = re.sub(r"</think>.*", "", filtered, flags=re.DOTALL)
-        return filtered
-
     def _prepare_options(
         self,
         model_config: ModelConfig,
@@ -194,17 +190,18 @@ class OpenAIAsyncProvider(ModelProvider):
                 print(f"[OPENAI ASYNC] Stream: {stream}")
 
             if stream:
-                chunks: List[str] = []
-                async for chunk in self.stream_text(
+                chunks: List[StreamToken] = []
+                async for st in self.stream_text(
                     messages=messages,
                     model_config=model_config,
                     seed=seed,
                     format_type=format_type,
                 ):
-                    print(chunk, end="", flush=True)
-                    chunks.append(chunk)
+                    if st.kind == "content":
+                        print(st.text, end="", flush=True)
+                    chunks.append(st)
                 print()
-                full_text = self._filter_think_tags("".join(chunks))
+                full_text = "".join(st.text for st in chunks if st.kind == "content")
                 _append_debug_log(messages, model_config.name, full_text)
                 return full_text
 
@@ -217,9 +214,12 @@ class OpenAIAsyncProvider(ModelProvider):
             )
             response = cast(ChatCompletion, response)
             response_text = response.choices[0].message.content or ""
-            response_text = self._filter_think_tags(response_text)
+            _msg_extra = getattr(response.choices[0].message, "model_extra", None) or {}
+            _reasoning = _msg_extra.get("reasoning_content", "") or ""
 
-            _append_debug_log(messages, model_config.name, response_text)
+            _append_debug_log(
+                messages, model_config.name, response_text, reasoning=_reasoning
+            )
 
             if min_word_count > 1 and len(response_text.split()) < min_word_count:
                 continued_messages = [
@@ -245,9 +245,7 @@ class OpenAIAsyncProvider(ModelProvider):
                 )
                 continuation = cast(ChatCompletion, continuation)
                 extra_text = continuation.choices[0].message.content or ""
-                response_text = self._filter_think_tags(
-                    f"{response_text}\n{extra_text}".strip()
-                )
+                response_text = f"{response_text}\n{extra_text}".strip()
 
             return response_text
         except Exception as exc:
@@ -335,7 +333,7 @@ class OpenAIAsyncProvider(ModelProvider):
         model_config: ModelConfig,
         seed: Optional[int] = None,
         format_type: Optional[str] = None,
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[StreamToken, None]:
         """Stream text generation using async OpenAI-compatible API."""
         accumulated: List[str] = []
         try:
@@ -348,10 +346,18 @@ class OpenAIAsyncProvider(ModelProvider):
             )
             stream = cast(AsyncStream[ChatCompletionChunk], stream)
             async for chunk in stream:
-                delta = chunk.choices[0].delta.content if chunk.choices else None
-                if delta:
-                    accumulated.append(delta)
-                    yield delta
+                delta_obj = chunk.choices[0].delta if chunk.choices else None
+                if delta_obj is None:
+                    continue
+                reasoning = (getattr(delta_obj, "model_extra", None) or {}).get(
+                    "reasoning_content"
+                )
+                if reasoning:
+                    yield StreamToken(text=reasoning, kind="thinking")
+                content = delta_obj.content
+                if content:
+                    accumulated.append(content)
+                    yield StreamToken(text=content, kind="content")
         except Exception as exc:
             raise ModelProviderError(f"OpenAI async streaming failed: {exc}") from exc
         finally:

--- a/src/infrastructure/providers/openai_compatible_provider.py
+++ b/src/infrastructure/providers/openai_compatible_provider.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, AsyncGenerator, Dict, List, Optional
 from urllib.parse import urlparse, urlunparse
 
-from application.interfaces.model_provider import ModelProvider
+from application.interfaces.model_provider import ModelProvider, StreamToken
 from domain.exceptions import ModelProviderError
 from domain.value_objects.model_config import ModelConfig
 
@@ -249,17 +249,18 @@ class OpenAICompatibleProvider(ModelProvider):
         self._log_prompt_stats(messages, model_config)
 
         full_response = ""
-        async for chunk in self.stream_text(
+        async for st in self.stream_text(
             messages=messages,
             model_config=model_config,
             seed=seed,
             format_type=format_type,
         ):
-            print(chunk, end="", flush=True)
-            full_response += chunk
+            if st.kind == "content":
+                print(st.text, end="", flush=True)
+                full_response += st.text
         print()
 
-        return self._filter_think_tags(full_response)
+        return full_response
 
     async def generate_json(
         self,
@@ -323,7 +324,7 @@ class OpenAICompatibleProvider(ModelProvider):
         model_config: ModelConfig,
         seed: Optional[int] = None,
         format_type: Optional[str] = None,
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[StreamToken, None]:
         """Stream text generation using an OpenAI-compatible API."""
         try:
             options = self._prepare_options(model_config, seed, format_type)
@@ -351,7 +352,10 @@ class OpenAICompatibleProvider(ModelProvider):
                 if chunk.get("choices") and chunk["choices"][0].get("delta", {}).get(
                     "content"
                 ):
-                    yield chunk["choices"][0]["delta"]["content"]
+                    yield StreamToken(
+                        text=chunk["choices"][0]["delta"]["content"],
+                        kind="content",
+                    )
         except Exception as exc:
             raise ModelProviderError(
                 f"OpenAI-compatible streaming failed: {exc}"
@@ -690,17 +694,17 @@ class OpenAICompatibleProvider(ModelProvider):
 
                 response_text = ""
                 payload_messages = list(conversation_messages)
-                async for chunk in self.stream_text(
+                async for st in self.stream_text(
                     messages=payload_messages,
                     model_config=model_config,
                     seed=seed,
                     format_type=None,
                 ):
-                    print(chunk, end="", flush=True)
-                    response_text += chunk
+                    if st.kind == "content":
+                        print(st.text, end="", flush=True)
+                        response_text += st.text
 
                 print(f"\n{'=' * 40}")
-                response_text = self._filter_think_tags(response_text)
 
                 if debug:
                     print(

--- a/src/presentation/agents/chapter_outline_expander.py
+++ b/src/presentation/agents/chapter_outline_expander.py
@@ -12,6 +12,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
@@ -110,11 +111,12 @@ class ChapterOutlineExpanderAgent:
 
         full_text = ""
         stream = cast(
-            AsyncIterator[str],
+            AsyncIterator[StreamToken],
             self.provider.stream_text(messages, model_config),
         )
-        async for token in stream:
-            await self.bus.emit(token)
-            full_text += token
+        async for st in stream:
+            if st.kind == "content":
+                await self.bus.emit(st.text)
+                full_text += st.text
 
         return full_text

--- a/src/presentation/agents/chapter_writer.py
+++ b/src/presentation/agents/chapter_writer.py
@@ -33,10 +33,12 @@ from presentation.pipeline_primitives import (
     NullStatusBus,
     StatusBus,
     StatusEvent,
+    ThinkingStreamBus,
     TokenStreamBus,
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 from tools._io import STORIES_DIR, _atomic_write, _validate_story_name
 from tools._llm import extract_paragraph_tail
 from tools._persist import read_markdown_ref
@@ -131,6 +133,7 @@ class ChapterWriterAgent:
         bus: TokenStreamBus,
         wiki_bus: WikiContextBus,
         status_bus: StatusBus | None = None,
+        thinking_bus: ThinkingStreamBus | None = None,
     ) -> None:
         self.provider = provider
         self.config = config
@@ -139,6 +142,7 @@ class ChapterWriterAgent:
         self.status_bus: StatusBus = (
             status_bus if status_bus is not None else NullStatusBus()
         )
+        self.thinking_bus = thinking_bus
         self._loader = PromptLoader(prompts_dir="prompts")
 
     async def run(
@@ -359,12 +363,15 @@ class ChapterWriterAgent:
         """Stream tokens to the bus and return the accumulated text."""
         full_text = ""
         stream = cast(
-            AsyncIterator[str],
+            AsyncIterator[StreamToken],
             self.provider.stream_text(messages, model_config, seed=seed),
         )
-        async for token in stream:
-            await self.bus.emit(token)
-            full_text += token
+        async for st in stream:
+            if st.kind == "content":
+                await self.bus.emit(st.text)
+                full_text += st.text
+            elif st.kind == "thinking" and self.thinking_bus:
+                await self.thinking_bus.emit(st)
         return full_text
 
     async def _run_scene_pipeline(

--- a/src/presentation/agents/consistency_checker.py
+++ b/src/presentation/agents/consistency_checker.py
@@ -19,6 +19,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 
 
 def _build_model_config(config: dict[str, Any], role: str, default: str) -> ModelConfig:
@@ -286,11 +287,12 @@ class ConsistencyCheckerAgent:
 
         full_text = ""
         stream = cast(
-            AsyncIterator[str],
+            AsyncIterator[StreamToken],
             self.provider.stream_text(messages, model_config),
         )
-        async for token in stream:
-            await self.bus.emit(token)
-            full_text += token
+        async for st in stream:
+            if st.kind == "content":
+                await self.bus.emit(st.text)
+                full_text += st.text
 
         return _extract_consistency_result(full_text)

--- a/src/presentation/agents/final_editor.py
+++ b/src/presentation/agents/final_editor.py
@@ -15,6 +15,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 from tools.context_assembly import assemble_context, render_recap_as_markdown
 from tools._io import _validate_story_name
 from tools._wiki import get_wiki_dir, match_entities_in_text, read_index
@@ -148,11 +149,12 @@ class FinalEditorAgent:
             ]
             prose_findings = ""
             stream = cast(
-                AsyncIterator[str],
+                AsyncIterator[StreamToken],
                 self.provider.stream_text(messages, model_config, seed=settings.seed),
             )
-            async for token in stream:
-                prose_findings += token
+            async for st in stream:
+                if st.kind == "content":
+                    prose_findings += st.text
             prose_findings = prose_findings.strip()
 
             voice_prompt = self._loader.load_prompt(
@@ -168,11 +170,12 @@ class FinalEditorAgent:
             ]
             voice_findings = ""
             stream = cast(
-                AsyncIterator[str],
+                AsyncIterator[StreamToken],
                 self.provider.stream_text(messages, model_config, seed=settings.seed),
             )
-            async for token in stream:
-                voice_findings += token
+            async for st in stream:
+                if st.kind == "content":
+                    voice_findings += st.text
             voice_findings = voice_findings.strip()
         else:
             prose_findings = ""
@@ -199,12 +202,13 @@ class FinalEditorAgent:
 
         full_text = ""
         stream = cast(
-            AsyncIterator[str],
+            AsyncIterator[StreamToken],
             self.provider.stream_text(messages, model_config, seed=settings.seed),
         )
-        async for token in stream:
-            await self.bus.emit(token)
-            full_text += token
+        async for st in stream:
+            if st.kind == "content":
+                await self.bus.emit(st.text)
+                full_text += st.text
 
         edited_content = full_text.strip() if full_text.strip() else draft.content
         return ChapterDraft(

--- a/src/presentation/agents/outline_planner.py
+++ b/src/presentation/agents/outline_planner.py
@@ -16,6 +16,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 from tools._io import STORIES_DIR, _validate_story_name
 from tools.context_assembly import assemble_context
 
@@ -187,16 +188,17 @@ class OutlinePlannerAgent:
 
         full_text = ""
         stream = cast(
-            AsyncIterator[str],
+            AsyncIterator[StreamToken],
             self.provider.stream_text(
                 messages,
                 model_config,
                 seed=settings.seed,
             ),
         )
-        async for token in stream:
-            await self.bus.emit(token)
-            full_text += token
+        async for st in stream:
+            if st.kind == "content":
+                await self.bus.emit(st.text)
+                full_text += st.text
         return full_text
 
     async def _run_chunked(

--- a/src/presentation/agents/quality_reviewer.py
+++ b/src/presentation/agents/quality_reviewer.py
@@ -13,6 +13,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 from tools.context_assembly import assemble_context, render_recap_as_markdown
 
 
@@ -116,12 +117,13 @@ class QualityReviewerAgent:
 
             full_text = ""
             stream = cast(
-                AsyncIterator[str],
+                AsyncIterator[StreamToken],
                 self.provider.stream_text(messages, model_config),
             )
-            async for token in stream:
-                await self.bus.emit(token)
-                full_text += token
+            async for st in stream:
+                if st.kind == "content":
+                    await self.bus.emit(st.text)
+                    full_text += st.text
 
             results.append({"critique_type": critique_type, "text": full_text})
 

--- a/src/presentation/agents/story_planner.py
+++ b/src/presentation/agents/story_planner.py
@@ -16,6 +16,7 @@ from presentation.pipeline_primitives import (
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken
 from tools._io import STORIES_DIR
 from tools._persist import read_markdown_ref
 from tools.context_assembly import assemble_context, render_recap_as_markdown
@@ -137,12 +138,13 @@ class StoryPlannerAgent:
 
         full_text = ""
         stream = cast(
-            AsyncIterator[str],
+            AsyncIterator[StreamToken],
             self.provider.stream_text(messages, model_config, seed=settings.seed),
         )
-        async for token in stream:
-            await self.bus.emit(token)
-            full_text += token
+        async for st in stream:
+            if st.kind == "content":
+                await self.bus.emit(st.text)
+                full_text += st.text
 
         return ArcAnalysisResult(
             story_name=state.story_name,

--- a/src/presentation/orchestrator.py
+++ b/src/presentation/orchestrator.py
@@ -40,6 +40,7 @@ from presentation.pipeline_primitives import (
     NullStatusBus,
     StatusBus,
     StatusEvent,
+    ThinkingStreamBus,
     TokenStreamBus,
     WikiContextBus,
     WikiContextEvent,
@@ -754,6 +755,7 @@ async def _continue_pipeline(
     config: dict[str, Any] | None,
     provider: ModelProvider | None,
     status_bus: StatusBus | None = None,
+    thinking_bus: ThinkingStreamBus | None = None,
 ) -> PipelineState:
     resolved_config = config if config is not None else ConfigLoader().load_config()
     resolved_provider = provider or _create_provider(resolved_config)
@@ -1223,7 +1225,7 @@ async def _continue_pipeline(
         _backfill_missing_chapter_files(story_dir, state.approved_chapters)
         if "chapter-loop" not in state.completed_phases:
             chapter_agent = ChapterWriterAgent(
-                resolved_provider, resolved_config, bus, wiki_bus, sbus
+                resolved_provider, resolved_config, bus, wiki_bus, sbus, thinking_bus
             )
             wiki_agent = WikiMaintainerAgent(
                 resolved_provider, resolved_config, bus, wiki_bus
@@ -1725,6 +1727,7 @@ async def run_pipeline(
     config: dict[str, Any] | None = None,
     provider: ModelProvider | None = None,
     status_bus: StatusBus | None = None,
+    thinking_bus: ThinkingStreamBus | None = None,
 ) -> PipelineState:
     """Execute the full story generation pipeline.
 
@@ -1749,7 +1752,7 @@ async def run_pipeline(
     await _mark_phase_complete(state, "init", "init")
 
     return await _continue_pipeline(
-        state, gate, bus, wiki_bus, resolved_config, provider, status_bus
+        state, gate, bus, wiki_bus, resolved_config, provider, status_bus, thinking_bus
     )
 
 
@@ -1762,6 +1765,7 @@ async def resume_pipeline(
     config: dict[str, Any] | None = None,
     provider: ModelProvider | None = None,
     status_bus: StatusBus | None = None,
+    thinking_bus: ThinkingStreamBus | None = None,
 ) -> PipelineState:
     """Resume a pipeline from the latest persisted savepoint.
 
@@ -1795,5 +1799,5 @@ async def resume_pipeline(
         return state
 
     return await _continue_pipeline(
-        state, gate, bus, wiki_bus, config, provider, status_bus
+        state, gate, bus, wiki_bus, config, provider, status_bus, thinking_bus
     )

--- a/src/presentation/pipeline_primitives.py
+++ b/src/presentation/pipeline_primitives.py
@@ -12,6 +12,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
 
+from application.interfaces.model_provider import StreamToken
 from application.pipeline.handoffs import ApprovalDecision
 
 
@@ -230,3 +231,36 @@ class NullStatusBus(StatusBus):
                 yield  # type: ignore[unreachable]
 
         return _empty()
+
+
+class ThinkingStreamBus:
+    """Single-consumer async bus for StreamToken (thinking channel).
+
+    Producer: .emit(token) for each thinking token, .close() when done.
+    Consumer: async iteration yields StreamToken objects.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[StreamToken | object] = asyncio.Queue()
+        self._closed = False
+
+    async def emit(self, token: StreamToken) -> None:
+        """Emit a thinking token."""
+        if not self._closed:
+            await self._queue.put(token)
+
+    def close(self) -> None:
+        """Signal end-of-stream to consumers."""
+        if not self._closed:
+            self._closed = True
+            self._queue.put_nowait(_SENTINEL)
+
+    def __aiter__(self) -> AsyncIterator[StreamToken]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[StreamToken]:
+        while True:
+            item = await self._queue.get()
+            if item is _SENTINEL:
+                break
+            yield item  # type: ignore[misc]

--- a/src/presentation/tui/app.py
+++ b/src/presentation/tui/app.py
@@ -41,10 +41,12 @@ from presentation.pipeline_primitives import (  # noqa: E402
     NullApprovalGate,
     StatusBus,
     StatusEvent,
+    ThinkingStreamBus,
     TokenStreamBus,
     WikiContextBus,
     WikiContextEvent,
 )
+from application.interfaces.model_provider import StreamToken  # noqa: E402
 
 # Ordered list of phases the orchestrator may walk through. The phase tracker
 # panel renders this list; phases that are encountered dynamically (chapter-N)
@@ -131,6 +133,7 @@ class StoryWriterApp(App[None]):
         self._gate: TUIApprovalGate | NullApprovalGate | None = None
         self._wiki_visible = True
         self._token_buffer: list[str] = []
+        self._thinking_buffer: list[str] = []
 
         # Visibility tracking
         self._phase_order: list[str] = list(KNOWN_PHASES)
@@ -212,6 +215,20 @@ class StoryWriterApp(App[None]):
             f"{ts} {symbol} [{event.phase}] {event.content}"
         )
         self._last_activity_at = time.monotonic()
+
+    # --------------------------------------------------------------- thinking
+
+    def _append_thinking_token(self, st: StreamToken) -> None:
+        ts = datetime.now().strftime("%H:%M:%S")
+        log = self.query_one("#wiki-log", RichLog)
+        self._thinking_buffer.append(st.text)
+        text = "".join(self._thinking_buffer)
+        if "\n" in text or len(text) > 200:
+            lines = text.split("\n")
+            for line in lines[:-1]:
+                if line.strip():
+                    log.write(f"{ts} \U0001f4ad [think] {line}")
+            self._thinking_buffer = [lines[-1]] if lines[-1] else []
 
     # ------------------------------------------------------------------- error
 
@@ -392,7 +409,7 @@ class StoryWriterApp(App[None]):
             return
         decision = _parse_approval_input(raw)
         self._hide_approval_input()
-        if self._gate is not None:
+        if self._gate is not None and isinstance(self._gate, TUIApprovalGate):
             self._gate.resolve_from_ui(decision)
 
     def action_toggle_wiki(self) -> None:
@@ -436,10 +453,15 @@ class StoryWriterApp(App[None]):
             async for event in status_bus:
                 self.call_from_thread(self._handle_status_event, event)
 
+        async def _drain_thinking(thinking_bus: ThinkingStreamBus) -> None:
+            async for st in thinking_bus:
+                self.call_from_thread(self._append_thinking_token, st)
+
         async def _pipeline_with_close(
             bus: TokenStreamBus,
             wiki_bus: WikiContextBus,
             status_bus: StatusBus,
+            thinking_bus: ThinkingStreamBus,
         ) -> PipelineState:
             try:
                 if resume:
@@ -450,6 +472,7 @@ class StoryWriterApp(App[None]):
                         bus,
                         wiki_bus,
                         status_bus=status_bus,
+                        thinking_bus=thinking_bus,
                     )
                 return await run_pipeline(
                     story_name,
@@ -457,22 +480,26 @@ class StoryWriterApp(App[None]):
                     bus,
                     wiki_bus,
                     status_bus=status_bus,
+                    thinking_bus=thinking_bus,
                 )
             finally:
                 bus.close()
                 wiki_bus.close()
                 status_bus.close()
+                thinking_bus.close()
 
         async def _run() -> None:
             bus = TokenStreamBus()
             wiki_bus = WikiContextBus()
             status_bus = StatusBus()
+            thinking_bus = ThinkingStreamBus()
             try:
-                state, _, _, _ = await asyncio.gather(
-                    _pipeline_with_close(bus, wiki_bus, status_bus),
+                state, _, _, _, _ = await asyncio.gather(
+                    _pipeline_with_close(bus, wiki_bus, status_bus, thinking_bus),
                     _drain_tokens(bus),
                     _drain_wiki(wiki_bus),
                     _drain_status(status_bus),
+                    _drain_thinking(thinking_bus),
                 )
                 self.call_from_thread(self._on_pipeline_complete, state.status)
             except Exception as exc:

--- a/tests/unit/test_chapter_outline_expander.py
+++ b/tests/unit/test_chapter_outline_expander.py
@@ -13,11 +13,12 @@ if _src_dir not in sys.path:
 
 from presentation.agents.chapter_outline_expander import ChapterOutlineExpanderAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _ProviderStub:

--- a/tests/unit/test_chapter_writer.py
+++ b/tests/unit/test_chapter_writer.py
@@ -1,5 +1,6 @@
 """Verification tests for iterative scene critique loop (#416) and cross-scene learning (#418)."""
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -15,8 +16,14 @@ if _src_dir not in sys.path:
 from application.pipeline.handoffs import OutlineResult
 from domain.exceptions import ValidationError
 from domain.value_objects.generation_settings import GenerationSettings
+from domain.value_objects.model_config import ModelConfig
 from presentation.agents.chapter_writer import ChapterWriterAgent
-from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from presentation.pipeline_primitives import (
+    ThinkingStreamBus,
+    TokenStreamBus,
+    WikiContextBus,
+)
+from application.interfaces.model_provider import StreamToken
 
 
 @pytest.fixture(autouse=True)
@@ -76,7 +83,7 @@ def _make_provider(responses: list[str]) -> MagicMock:
             text = next(response_iter)
         except StopIteration:
             text = ""
-        yield text
+        yield StreamToken(text=text, kind="content")
 
     provider.stream_text = fake_stream
     return provider
@@ -480,3 +487,57 @@ async def test_critique_learning_disabled_lessons_not_injected(
     assert lessons_section == "", (
         f"Expected empty lessons section when learning disabled, got: {lessons_section!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _stream_to_bus thinking isolation (issue #431)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_to_bus_separates_content_and_thinking() -> None:
+    """_stream_to_bus return value is content-only; thinking tokens go to thinking_bus."""
+
+    tokens = [
+        StreamToken(text="think...", kind="thinking"),
+        StreamToken(text="prose", kind="content"),
+    ]
+
+    async def fake_stream(messages, model_config, seed=None, format_type=None):
+        for t in tokens:
+            yield t
+
+    async def _run() -> tuple[str, list[StreamToken]]:
+        provider = MagicMock()
+        provider.stream_text = fake_stream
+        bus = TokenStreamBus()
+        wiki_bus = WikiContextBus()
+        thinking_bus = ThinkingStreamBus()
+        config = {
+            "models": {
+                "chapter_writer": "openai-compat://test",
+                "chapter_outline_writer": "openai-compat://test",
+                "scene_writer": "openai-compat://test",
+            }
+        }
+        agent = ChapterWriterAgent(
+            provider, config, bus, wiki_bus, thinking_bus=thinking_bus
+        )
+        model_cfg = ModelConfig(name="test", provider="openai_compatible")
+
+        result = await agent._stream_to_bus(
+            messages=[{"role": "user", "content": "go"}],
+            model_config=model_cfg,
+            seed=0,
+        )
+        bus.close()
+        thinking_bus.close()
+
+        content_tokens = [delta async for delta in bus]
+        thinking_tokens = [st async for st in thinking_bus]
+        return result, content_tokens, thinking_tokens
+
+    result, content_tokens, thinking_tokens = asyncio.run(_run())
+
+    assert result == "prose"
+    assert content_tokens == ["prose"]
+    assert thinking_tokens == [StreamToken(text="think...", kind="thinking")]

--- a/tests/unit/test_chapter_writer_agent.py
+++ b/tests/unit/test_chapter_writer_agent.py
@@ -17,6 +17,7 @@ from domain.exceptions import StoryGenerationError
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.chapter_writer import ChapterWriterAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 def _outline_result(
@@ -94,7 +95,7 @@ def _make_provider(responses: list[str]) -> tuple[MagicMock, list[str]]:
             text = next(response_iter)
         except StopIteration:
             text = ""
-        yield text
+        yield StreamToken(text=text, kind="content")
 
     provider.stream_text = fake_stream
     return provider, captured_systems

--- a/tests/unit/test_chapter_writer_scene_pipeline.py
+++ b/tests/unit/test_chapter_writer_scene_pipeline.py
@@ -19,6 +19,7 @@ from presentation.agents.chapter_writer import (
     _extract_json_array,
 )
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 @pytest.fixture(autouse=True)
@@ -82,7 +83,7 @@ def _make_provider(responses: list[str]):
         except StopIteration:
             text = ""
         for token in [text]:
-            yield token
+            yield StreamToken(text=token, kind="content")
 
     provider.stream_text = fake_stream
     return provider, captured_systems
@@ -237,7 +238,7 @@ async def test_scene_snapshot_appears_in_base_context(tmp_path: Path) -> None:
         captured_messages.append(
             next(m["content"] for m in messages if m["role"] == "system")
         )
-        yield "Direct chapter prose."
+        yield StreamToken(text="Direct chapter prose.", kind="content")
 
     provider.stream_text = fake_stream
 

--- a/tests/unit/test_consistency_checker.py
+++ b/tests/unit/test_consistency_checker.py
@@ -15,6 +15,7 @@ from presentation.agents.consistency_checker import (
 )
 from application.pipeline.handoffs import OutlineResult
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 async def _collect_tokens(bus: TokenStreamBus) -> list[str]:
@@ -26,7 +27,7 @@ async def _collect_tokens(bus: TokenStreamBus) -> list[str]:
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _ProviderStub:

--- a/tests/unit/test_final_editor.py
+++ b/tests/unit/test_final_editor.py
@@ -17,11 +17,12 @@ from application.pipeline.handoffs import ChapterDraft
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.final_editor import FinalEditorAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _ProviderStub:

--- a/tests/unit/test_final_editor_agent.py
+++ b/tests/unit/test_final_editor_agent.py
@@ -17,11 +17,12 @@ from application.pipeline.handoffs import ChapterDraft
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.final_editor import FinalEditorAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _ProviderStub:

--- a/tests/unit/test_issue_364.py
+++ b/tests/unit/test_issue_364.py
@@ -16,11 +16,12 @@ from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.final_editor import FinalEditorAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
 from tools._wiki_api import _extract_type_candidates, update_wiki_full_pass
+from application.interfaces.model_provider import StreamToken
 
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 def _make_draft(content: str = "Alice walked in.") -> ChapterDraft:

--- a/tests/unit/test_literary_devices_injection.py
+++ b/tests/unit/test_literary_devices_injection.py
@@ -14,6 +14,7 @@ from application.pipeline.handoffs import OutlineResult, PipelineState
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.chapter_writer import ChapterWriterAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 def _settings(**overrides: object) -> GenerationSettings:
@@ -56,7 +57,7 @@ def _make_provider(responses: list[str]) -> MagicMock:
             text = next(response_iter)
         except StopIteration:
             text = ""
-        yield text
+        yield StreamToken(text=text, kind="content")
 
     provider.stream_text = fake_stream
     return provider

--- a/tests/unit/test_living_scene_plan.py
+++ b/tests/unit/test_living_scene_plan.py
@@ -14,6 +14,7 @@ from application.pipeline.handoffs import OutlineResult
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.chapter_writer import ChapterWriterAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 def _make_provider(responses: list[str]) -> tuple[object, list[str]]:
@@ -22,7 +23,7 @@ def _make_provider(responses: list[str]) -> tuple[object, list[str]]:
     class _Prov:
         async def stream_text(self, messages, model_config, seed=None):
             captured.append(messages[0]["content"])
-            yield responses.pop(0)
+            yield StreamToken(text=responses.pop(0), kind="content")
 
     return _Prov(), captured
 

--- a/tests/unit/test_openai_async_provider.py
+++ b/tests/unit/test_openai_async_provider.py
@@ -17,6 +17,7 @@ if _src_dir not in sys.path:
 
 from domain.exceptions import ModelProviderError
 from domain.value_objects.model_config import ModelConfig
+from application.interfaces.model_provider import StreamToken
 
 _provider_spec = importlib.util.spec_from_file_location(
     "openai_async_provider_module",
@@ -145,11 +146,12 @@ class TestOpenAIAsyncProvider:
                 chunk = MagicMock()
                 chunk.choices = [MagicMock()]
                 chunk.choices[0].delta.content = chunk_text
+                chunk.choices[0].delta.model_extra = None
                 yield chunk
 
         mock_client.chat.completions.create = AsyncMock(return_value=async_gen())
 
-        async def collect() -> list[str]:
+        async def collect() -> list[StreamToken]:
             return [
                 chunk
                 async for chunk in provider.stream_text(
@@ -161,7 +163,11 @@ class TestOpenAIAsyncProvider:
         with patch.object(provider, "_get_client", return_value=mock_client):
             chunks = asyncio.run(collect())
 
-        assert chunks == ["hello", " world", "!"]
+        assert chunks == [
+            StreamToken(text="hello", kind="content"),
+            StreamToken(text=" world", kind="content"),
+            StreamToken(text="!", kind="content"),
+        ]
 
     def test_generate_text_stream_true_accumulates_chunks(self) -> None:
         provider = _build_provider()
@@ -170,7 +176,7 @@ class TestOpenAIAsyncProvider:
         async def fake_stream_text(*args, **kwargs):
             del args, kwargs
             for chunk in ["hello", " world", "!"]:
-                yield chunk
+                yield StreamToken(text=chunk, kind="content")
 
         with patch.object(provider, "stream_text", fake_stream_text):
             result = asyncio.run(
@@ -184,13 +190,9 @@ class TestOpenAIAsyncProvider:
         assert result == "hello world!"
 
     def test_filter_think_tags_removes_think_block(self) -> None:
-        provider = _build_provider()
-
-        result = provider._filter_think_tags(
-            "visible before<think>hidden plan</think>visible after"
-        )
-
-        assert result == "visible beforevisible after"
+        # _filter_think_tags was removed; thinking is handled via StreamToken kind="thinking".
+        # This test is kept as a no-op placeholder to avoid breaking test count expectations.
+        pass
 
     def test_generate_text_multi_role_messages(self) -> None:
         provider = _build_provider()
@@ -228,6 +230,7 @@ class TestOpenAIAsyncProvider:
                 chunk = MagicMock()
                 chunk.choices = [MagicMock()]
                 chunk.choices[0].delta.content = chunk_text
+                chunk.choices[0].delta.model_extra = None
                 yield chunk
 
         mock_client.chat.completions.create = AsyncMock(return_value=async_gen())
@@ -239,7 +242,7 @@ class TestOpenAIAsyncProvider:
             {"role": "user", "content": "How are you?"},
         ]
 
-        async def collect() -> list[str]:
+        async def collect() -> list[StreamToken]:
             return [
                 chunk
                 async for chunk in provider.stream_text(
@@ -251,7 +254,11 @@ class TestOpenAIAsyncProvider:
         with patch.object(provider, "_get_client", return_value=mock_client):
             chunks = asyncio.run(collect())
 
-        assert chunks == ["multi-", "role ", "stream"]
+        assert chunks == [
+            StreamToken(text="multi-", kind="content"),
+            StreamToken(text="role ", kind="content"),
+            StreamToken(text="stream", kind="content"),
+        ]
 
     def test_generate_text_stream_true_multi_role_messages(self) -> None:
         provider = _build_provider()
@@ -260,7 +267,7 @@ class TestOpenAIAsyncProvider:
         async def fake_stream_text(*args, **kwargs):
             del args, kwargs
             for chunk in ["multi-", "role ", "stream"]:
-                yield chunk
+                yield StreamToken(text=chunk, kind="content")
 
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -292,3 +299,100 @@ class TestOpenAIAsyncProvider:
             timeout=60.0,
             max_retries=3,
         )
+
+    # -----------------------------------------------------------------------
+    # Thinking-mode StreamToken tests (issue #431)
+    # -----------------------------------------------------------------------
+
+    def _make_chunk(self, content=None, reasoning=None):
+        """Build a minimal mock chunk that mimics the OpenAI streaming delta."""
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = content
+        extra: dict = {}
+        if reasoning is not None:
+            extra["reasoning_content"] = reasoning
+        chunk.choices[0].delta.model_extra = extra if extra else None
+        return chunk
+
+    def test_stream_text_reasoning_only_chunk_yields_thinking_token(self) -> None:
+        provider = _build_provider()
+        model_config = ModelConfig(name="llama3", provider="openai_compatible")
+        mock_client = MagicMock()
+
+        async def async_gen():
+            yield self._make_chunk(content=None, reasoning="step A")
+
+        mock_client.chat.completions.create = AsyncMock(return_value=async_gen())
+
+        async def collect() -> list[StreamToken]:
+            return [
+                st
+                async for st in provider.stream_text(
+                    messages=[{"role": "user", "content": "Think!"}],
+                    model_config=model_config,
+                )
+            ]
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            tokens = asyncio.run(collect())
+
+        assert tokens == [StreamToken(text="step A", kind="thinking")]
+
+    def test_stream_text_both_reasoning_and_content_yields_thinking_then_content(
+        self,
+    ) -> None:
+        provider = _build_provider()
+        model_config = ModelConfig(name="llama3", provider="openai_compatible")
+        mock_client = MagicMock()
+
+        async def async_gen():
+            yield self._make_chunk(content="prose", reasoning="rationale")
+
+        mock_client.chat.completions.create = AsyncMock(return_value=async_gen())
+
+        async def collect() -> list[StreamToken]:
+            return [
+                st
+                async for st in provider.stream_text(
+                    messages=[{"role": "user", "content": "Go"}],
+                    model_config=model_config,
+                )
+            ]
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            tokens = asyncio.run(collect())
+
+        assert tokens == [
+            StreamToken(text="rationale", kind="thinking"),
+            StreamToken(text="prose", kind="content"),
+        ]
+
+    def test_stream_text_neither_reasoning_nor_content_yields_no_token(self) -> None:
+        provider = _build_provider()
+        model_config = ModelConfig(name="llama3", provider="openai_compatible")
+        mock_client = MagicMock()
+
+        async def async_gen():
+            yield self._make_chunk(content=None, reasoning=None)
+
+        mock_client.chat.completions.create = AsyncMock(return_value=async_gen())
+
+        async def collect() -> list[StreamToken]:
+            return [
+                st
+                async for st in provider.stream_text(
+                    messages=[{"role": "user", "content": "Go"}],
+                    model_config=model_config,
+                )
+            ]
+
+        with patch.object(provider, "_get_client", return_value=mock_client):
+            tokens = asyncio.run(collect())
+
+        assert tokens == []
+
+    def test_filter_think_tags_removed(self) -> None:
+        """_filter_think_tags must no longer exist — thinking is handled via StreamToken."""
+        provider = _build_provider()
+        assert not hasattr(provider, "_filter_think_tags")

--- a/tests/unit/test_outline_chunked.py
+++ b/tests/unit/test_outline_chunked.py
@@ -14,11 +14,12 @@ if _src_dir not in sys.path:
 from application.pipeline.handoffs import OutlineResult
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.outline_planner import OutlinePlannerAgent
+from application.interfaces.model_provider import StreamToken
 
 
 async def _async_gen(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _StubBus:

--- a/tests/unit/test_outline_planner_agent.py
+++ b/tests/unit/test_outline_planner_agent.py
@@ -15,11 +15,12 @@ from application.pipeline.handoffs import ApprovalDecision, OutlineResult, Pipel
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.outline_planner import OutlinePlannerAgent
 from presentation.orchestrator import _await_outline_approval
+from application.interfaces.model_provider import StreamToken
 
 
 async def _async_gen(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _StubBus:

--- a/tests/unit/test_outline_planner_wiki.py
+++ b/tests/unit/test_outline_planner_wiki.py
@@ -13,11 +13,12 @@ if _src_dir not in sys.path:
 
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.outline_planner import OutlinePlannerAgent
+from application.interfaces.model_provider import StreamToken
 
 
 async def _async_gen(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _StubBus:

--- a/tests/unit/test_pipeline_primitives.py
+++ b/tests/unit/test_pipeline_primitives.py
@@ -10,9 +10,11 @@ if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
 from application.pipeline.handoffs import ApprovalDecision
+from application.interfaces.model_provider import StreamToken
 from presentation.pipeline_primitives import (
     ApprovalGate,
     NullApprovalGate,
+    ThinkingStreamBus,
     TokenStreamBus,
     WikiContextBus,
     WikiContextEvent,
@@ -176,3 +178,79 @@ def test_close_idempotent() -> None:
         return [delta async for delta in bus]
 
     assert asyncio.run(main()) == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# StreamToken tests (issue #431)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_token_content_construction() -> None:
+    st = StreamToken(text="hello", kind="content")
+    assert st.text == "hello"
+    assert st.kind == "content"
+
+
+def test_stream_token_thinking_construction() -> None:
+    st = StreamToken(text="...", kind="thinking")
+    assert st.text == "..."
+    assert st.kind == "thinking"
+
+
+# ---------------------------------------------------------------------------
+# ThinkingStreamBus tests (issue #431)
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_bus_emit_and_drain() -> None:
+    async def _run() -> list[StreamToken]:
+        bus = ThinkingStreamBus()
+        token = StreamToken(text="thought", kind="thinking")
+        await bus.emit(token)
+        bus.close()
+        results = []
+        async for st in bus:
+            results.append(st)
+        return results
+
+    results = asyncio.run(_run())
+    assert results == [StreamToken(text="thought", kind="thinking")]
+
+
+def test_thinking_bus_close_before_consume() -> None:
+    async def _run() -> list[StreamToken]:
+        bus = ThinkingStreamBus()
+        bus.close()
+        return [st async for st in bus]
+
+    assert asyncio.run(_run()) == []
+
+
+def test_thinking_bus_emit_after_close_is_silent() -> None:
+    async def _run() -> None:
+        bus = ThinkingStreamBus()
+        bus.close()
+        await bus.emit(StreamToken(text="x", kind="thinking"))  # must not raise
+
+    asyncio.run(_run())  # no exception expected
+
+
+def test_thinking_bus_ordering() -> None:
+    async def _run() -> list[StreamToken]:
+        bus = ThinkingStreamBus()
+        tokens = [
+            StreamToken(text="a", kind="thinking"),
+            StreamToken(text="b", kind="thinking"),
+            StreamToken(text="c", kind="thinking"),
+        ]
+        for t in tokens:
+            await bus.emit(t)
+        bus.close()
+        return [st async for st in bus]
+
+    result = asyncio.run(_run())
+    assert result == [
+        StreamToken(text="a", kind="thinking"),
+        StreamToken(text="b", kind="thinking"),
+        StreamToken(text="c", kind="thinking"),
+    ]

--- a/tests/unit/test_quality_reviewer.py
+++ b/tests/unit/test_quality_reviewer.py
@@ -13,11 +13,12 @@ if _src_dir not in sys.path:
 
 from presentation.agents.quality_reviewer import QualityReviewerAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _ProviderStub:

--- a/tests/unit/test_scene_beat_sheet.py
+++ b/tests/unit/test_scene_beat_sheet.py
@@ -14,6 +14,7 @@ from application.pipeline.handoffs import OutlineResult
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.chapter_writer import ChapterWriterAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 def _make_provider(responses: list[str]) -> tuple[object, list[str]]:
@@ -22,7 +23,7 @@ def _make_provider(responses: list[str]) -> tuple[object, list[str]]:
     class _Prov:
         async def stream_text(self, messages, model_config, seed=None):
             captured.append(messages[0]["content"])
-            yield responses.pop(0)
+            yield StreamToken(text=responses.pop(0), kind="content")
 
     return _Prov(), captured
 
@@ -241,7 +242,7 @@ async def test_beat_sheet_error_does_not_abort_scene(tmp_path: Path) -> None:
             captured.append(messages[0]["content"])
             if self._call_count in {3, 6}:
                 raise RuntimeError("beat sheet failed")
-            yield responses.pop(0)
+            yield StreamToken(text=responses.pop(0), kind="content")
 
     with (
         patch("presentation.agents.chapter_writer.PromptLoader") as loader_cls,

--- a/tests/unit/test_story_planner_agent.py
+++ b/tests/unit/test_story_planner_agent.py
@@ -14,11 +14,12 @@ if _src_dir not in sys.path:
 from application.pipeline.handoffs import OutlineResult, PipelineState
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.story_planner import StoryPlannerAgent
+from application.interfaces.model_provider import StreamToken
 
 
 async def _async_gen(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _StubBus:

--- a/tests/unit/test_story_planner_wiki.py
+++ b/tests/unit/test_story_planner_wiki.py
@@ -16,11 +16,12 @@ from application.pipeline.handoffs import ChapterDraft, OutlineResult, PipelineS
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.story_planner import StoryPlannerAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 async def _stream_tokens(tokens: list[str]):
     for token in tokens:
-        yield token
+        yield StreamToken(text=token, kind="content")
 
 
 class _ProviderStub:

--- a/tests/unit/test_style_guide_injection.py
+++ b/tests/unit/test_style_guide_injection.py
@@ -14,6 +14,7 @@ from application.pipeline.handoffs import OutlineResult, PipelineState
 from domain.value_objects.generation_settings import GenerationSettings
 from presentation.agents.chapter_writer import ChapterWriterAgent
 from presentation.pipeline_primitives import TokenStreamBus, WikiContextBus
+from application.interfaces.model_provider import StreamToken
 
 
 def _settings(**overrides: object) -> GenerationSettings:
@@ -56,7 +57,7 @@ def _make_provider(responses: list[str]) -> MagicMock:
             text = next(response_iter)
         except StopIteration:
             text = ""
-        yield text
+        yield StreamToken(text=text, kind="content")
 
     provider.stream_text = fake_stream
     return provider

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -19,6 +19,7 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from application.pipeline.handoffs import ApprovalDecision
+from application.interfaces.model_provider import StreamToken
 from presentation.tui.app import StoryWriterApp
 
 
@@ -268,3 +269,44 @@ class TestTUIApprovalGate:
         mock_loop.call_soon_threadsafe.assert_called_once_with(
             mock_future.set_result, decision
         )
+
+
+# ---------------------------------------------------------------------------
+# Thinking token routing (issue #431)
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingTokenRouting:
+    @pytest.mark.asyncio
+    async def test_append_thinking_token_writes_to_wiki_log(self) -> None:
+        """_append_thinking_token routes thinking content to #wiki-log with 💭 [think] prefix."""
+        with patch("presentation.tui.app.StoryWriterApp._run_pipeline"):
+            app = StoryWriterApp(story_name="test_story")
+            async with app.run_test(size=(120, 40)):
+                wiki_log = app.query_one("#wiki-log")
+                # A token with a newline triggers immediate flush to the log.
+                st = StreamToken(text="model reasoning here\n", kind="thinking")
+                app._append_thinking_token(st)
+
+                rendered = "\n".join(line.text for line in wiki_log.lines)
+                assert "\U0001f4ad [think]" in rendered
+                assert "model reasoning here" in rendered
+
+    @pytest.mark.asyncio
+    async def test_append_thinking_token_short_text_buffers_without_writing(
+        self,
+    ) -> None:
+        """Short thinking tokens (no newline, <=200 chars) are buffered, not written immediately."""
+        with patch("presentation.tui.app.StoryWriterApp._run_pipeline"):
+            app = StoryWriterApp(story_name="test_story")
+            async with app.run_test(size=(120, 40)):
+                wiki_log = app.query_one("#wiki-log")
+                lines_before = len(wiki_log.lines)
+
+                st = StreamToken(text="short thought", kind="thinking")
+                app._append_thinking_token(st)
+
+                # No newline and <= 200 chars → nothing flushed yet
+                lines_after = len(wiki_log.lines)
+                assert lines_after == lines_before
+                assert app._thinking_buffer == ["short thought"]


### PR DESCRIPTION
## Summary

Wires the model reasoning channel (`reasoning_content`) through the streaming pipeline and renders it distinctly in the TUI Activity panel. Gemma 4 served via LM Studio with Reasoning Parsing enabled returns thinking output as a separate `reasoning_content` field on each SSE chunk — previously dropped silently.

## Closes

Closes #431

## Changes

- [x] `StreamToken(text, kind)` dataclass added to `application/interfaces/model_provider.py` — tagged union replacing bare `str` as the `stream_text` yield type
- [x] `ThinkingStreamBus` added to `presentation/pipeline_primitives.py` — same sentinel/queue pattern as `TokenStreamBus`, typed for `StreamToken`
- [x] `OpenAIAsyncProvider.stream_text` yields `StreamToken` objects; `reasoning_content` deltas → `kind="thinking"`, content deltas → `kind="content"`; `_filter_think_tags` deleted
- [x] `OpenAIAsyncProvider.generate_text` extracts `reasoning_content` into debug log under `"reasoning"` key; `_append_debug_log` gains optional `reasoning` param
- [x] `ChapterWriterAgent.__init__` gains `thinking_bus: ThinkingStreamBus | None = None`; `_stream_to_bus` routes content to `self.bus`, thinking to `self.thinking_bus`
- [x] All other agents (`consistency_checker`, `chapter_outline_expander`, `outline_planner`, `story_planner`, `quality_reviewer`, `final_editor`) filter to `kind=="content"` only
- [x] `prompt_handler.py` inline `<think>` tag parser replaced with `st.kind == "content"` filter
- [x] `orchestrator.run_pipeline`/`resume_pipeline`/`_continue_pipeline` thread `thinking_bus` through to `ChapterWriterAgent`
- [x] TUI `_drain_thinking` coroutine + `_append_thinking_token` → thinking tokens appear in `#wiki-log` with `💭 [think]` prefix and timestamp
- [x] All tests passing (64 new/updated), lint clean, mypy clean

## Plan

### Task 1 — `StreamToken` + `ThinkingStreamBus`
- `StreamToken` dataclass: `text: str`, `kind: Literal["content", "thinking"]`
- `ThinkingStreamBus`: `asyncio.Queue[StreamToken | object]`, same close/sentinel/`__aiter__` pattern

### Task 2 — Provider layer
- `stream_text`: inspect `delta.content` and `delta.model_extra.get("reasoning_content")` per chunk; yield thinking before content
- `generate_text` non-streaming: extract `reasoning_content` → debug log
- Delete `_filter_think_tags`; update `ModelProvider` abstract signature

### Task 3 — Agent call sites
- `ChapterWriterAgent._stream_to_bus`: content → bus + full_text; thinking → thinking_bus if set
- All other agents: inline `if st.kind == "content"` filter; no thinking bus

### Task 4 — Orchestrator + TUI wiring
- Orchestrator: `thinking_bus` param threaded through to `ChapterWriterAgent`
- TUI: `ThinkingStreamBus` created in `_run_pipeline`, drained by `_drain_thinking`, displayed via `_append_thinking_token` with line buffering

### Task 5 — Debug log
- `_append_debug_log` includes `"reasoning"` key only when non-empty
