### PR TITLE
feat(thinking): extend debug log to capture reasoning_content

### DIFF
--- a/src/infrastructure/providers/openai_async_provider.py
+++ b/src/infrastructure/providers/openai_async_provider.py
@@ -202,7 +202,12 @@ class OpenAIAsyncProvider(ModelProvider):
                     chunks.append(st)
                 print()
                 full_text = "".join(st.text for st in chunks if st.kind == "content")
-                _append_debug_log(messages, model_config.name, full_text)
+                reasoning_text = "".join(
+                    st.text for st in chunks if st.kind == "thinking"
+                )
+                _append_debug_log(
+                    messages, model_config.name, full_text, reasoning=reasoning_text
+                )
                 return full_text
 
             options = self._prepare_options(model_config, seed, format_type)
@@ -336,6 +341,7 @@ class OpenAIAsyncProvider(ModelProvider):
     ) -> AsyncGenerator[StreamToken, None]:
         """Stream text generation using async OpenAI-compatible API."""
         accumulated: List[str] = []
+        accumulated_thinking: List[str] = []
         try:
             options = self._prepare_options(model_config, seed, format_type)
             stream = await self._get_client(model_config).chat.completions.create(
@@ -353,6 +359,7 @@ class OpenAIAsyncProvider(ModelProvider):
                     "reasoning_content"
                 )
                 if reasoning:
+                    accumulated_thinking.append(reasoning)
                     yield StreamToken(text=reasoning, kind="thinking")
                 content = delta_obj.content
                 if content:
@@ -362,7 +369,12 @@ class OpenAIAsyncProvider(ModelProvider):
             raise ModelProviderError(f"OpenAI async streaming failed: {exc}") from exc
         finally:
             if accumulated:
-                _append_debug_log(messages, model_config.name, "".join(accumulated))
+                _append_debug_log(
+                    messages,
+                    model_config.name,
+                    "".join(accumulated),
+                    reasoning="".join(accumulated_thinking),
+                )
 
     async def is_model_available(self, model_config: ModelConfig) -> bool:
         """Check if server model listing is reachable."""

--- a/tests/unit/test_openai_async_provider.py
+++ b/tests/unit/test_openai_async_provider.py
@@ -396,3 +396,89 @@ class TestOpenAIAsyncProvider:
         """_filter_think_tags must no longer exist — thinking is handled via StreamToken."""
         provider = _build_provider()
         assert not hasattr(provider, "_filter_think_tags")
+
+    # -----------------------------------------------------------------------
+    # _append_debug_log tests (issue #436)
+    # -----------------------------------------------------------------------
+
+    def test_append_debug_log_includes_reasoning_when_non_empty(
+        self, tmp_path
+    ) -> None:
+        """JSONL record includes 'reasoning' key when reasoning is non-empty."""
+        import json as _json
+
+        log_file = tmp_path / "debug.jsonl"
+        messages = [{"role": "user", "content": "Think!"}]
+        _provider_module._append_debug_log(
+            messages, "llama3", "some response", reasoning="step A"
+        )
+
+        # Without env var nothing is written
+        assert not log_file.exists()
+
+        import os as _os
+
+        _os.environ["LLM_DEBUG_LOG"] = str(log_file)
+        try:
+            _provider_module._append_debug_log(
+                messages, "llama3", "some response", reasoning="step A"
+            )
+        finally:
+            del _os.environ["LLM_DEBUG_LOG"]
+
+        record = _json.loads(log_file.read_text())
+        assert record["response"] == "some response"
+        assert record["reasoning"] == "step A"
+
+    def test_append_debug_log_omits_reasoning_key_when_empty(
+        self, tmp_path
+    ) -> None:
+        """JSONL record omits 'reasoning' key entirely when reasoning is empty."""
+        import json as _json
+        import os as _os
+
+        log_file = tmp_path / "debug.jsonl"
+        messages = [{"role": "user", "content": "Hello"}]
+
+        _os.environ["LLM_DEBUG_LOG"] = str(log_file)
+        try:
+            _provider_module._append_debug_log(messages, "llama3", "response")
+        finally:
+            del _os.environ["LLM_DEBUG_LOG"]
+
+        record = _json.loads(log_file.read_text())
+        assert record["response"] == "response"
+        assert "reasoning" not in record
+
+    def test_generate_text_stream_captures_thinking_tokens_in_debug_log(
+        self, tmp_path
+    ) -> None:
+        """generate_text streaming path writes reasoning to debug log."""
+        import json as _json
+        import os as _os
+
+        provider = _build_provider()
+        model_config = ModelConfig(name="llama3", provider="openai_compatible")
+
+        async def fake_stream_text(*args, **kwargs):
+            del args, kwargs
+            yield StreamToken(text="rationale", kind="thinking")
+            yield StreamToken(text="prose", kind="content")
+
+        log_file = tmp_path / "debug.jsonl"
+        _os.environ["LLM_DEBUG_LOG"] = str(log_file)
+        try:
+            with patch.object(provider, "stream_text", fake_stream_text):
+                asyncio.run(
+                    provider.generate_text(
+                        messages=[{"role": "user", "content": "Go"}],
+                        model_config=model_config,
+                        stream=True,
+                    )
+                )
+        finally:
+            del _os.environ["LLM_DEBUG_LOG"]
+
+        record = _json.loads(log_file.read_text())
+        assert record["response"] == "prose"
+        assert record["reasoning"] == "rationale"


### PR DESCRIPTION
## Summary

Extends `_append_debug_log` in `OpenAIAsyncProvider` to capture `reasoning_content` (thinking-mode tokens) alongside the existing response content log.

## Closes
Closes #436

## Changes
- `generate_text` streaming path: extract `kind="thinking"` tokens from accumulated `StreamToken` list and pass as `reasoning` to `_append_debug_log`
- `stream_text` `finally` block: track `accumulated_thinking` list, pass to `_append_debug_log`
- 3 new unit tests: `_append_debug_log` with reasoning, without reasoning, and streaming path end-to-end

## Plan
- [x] Implementation complete
- [x] All tests passing (21/21)
- [x] Linting clean