### PR TITLE
Mid-chunk resume for chunked outline generation and scene generation

### DIFF
--- a/prompts/agents/chapter-outline-expander.md
+++ b/prompts/agents/chapter-outline-expander.md
@@ -42,9 +42,16 @@ Received from the orchestrator at dispatch time:
 Execute these steps sequentially.
 
 1. If `expand_outline` is false, return immediately with `{"status": "skipped", "reason": "expand_outline disabled"}`.
-2. Initialise `current_chapter = 1`.
+2. **Pre-loop scan — identify complete chapters:**
+
+   Call `savepoint-mgr list` for the story. Filter the returned names for entries matching `expanded_chapter_{N}_{N}`. Build the set of chapter numbers N that are already fully expanded.
+
+   Find `first_incomplete_chapter` = the smallest N in [1..`wanted_chapters`] that does **not** have an `expanded_chapter_{N}_{N}` savepoint. If all chapters are complete, skip to step 5 (return complete).
+
+   If `first_incomplete_chapter > 1`: chapters 1 through `first_incomplete_chapter - 1` are already done. The tool auto-loads `expansion_continuity_{N-1}_{N-1}` internally when `phase == "chapter"`, so no agent-side continuity loading is required.
+
 3. **Do not manually load the approved outline or prior continuity analysis.** The `outline-generator expand-chapter` call (step 4a) loads the `outline` savepoint and the previous chapter's `expansion_continuity_{N-1}_{N-1}` savepoint internally when `phase == "chapter"`. Skipping these manual loads keeps multi-KB outline and continuity text off the orchestrator LLM's context. If the `outline` / `refined_outline` / `initial_outline` savepoints are all missing, `expand-chapter` will still run against `story_elements` alone and emit a warning in its response — inspect and abort if that happens.
-4. Loop for chapter N from 1 to `wanted_chapters`:
+4. Loop for chapter N from `first_incomplete_chapter` to `wanted_chapters`:
    a. Call `outline-generator` with:
       - `operation`: `"expand-chapter"`
       - `name`: `story_name`
@@ -58,7 +65,7 @@ Execute these steps sequentially.
    b. Parse the JSON response string from `outline-generator` for logging only:
       - `data.chunk_outline` and `data.continuity_analysis` are already persisted to `expanded_chapter_{N}_{N}` and `expansion_continuity_{N}_{N}` savepoints by the tool.
    c. **Do not write `chapters.{N}.expanded_outline` to `story-state`.** The `outline-generator expand-chapter` call in step a already saves the expanded outline to the `expanded_chapter_{N}_{N}` savepoint (when `phase == "chapter"`), which is the single source of truth. The `story-state` field is forbidden — writes will be rejected.
-   d. **(When `scene_expansion_enabled` is true) Expand synopsis to scenes:** Call `outline-generator` with:
+   d. **(When `scene_expansion_enabled` is true) Expand synopsis to scenes:** First check: if `chapter_{N}/scene_definitions` savepoint already exists (i.e., it appears in the `savepoint-mgr list` output from the pre-loop scan), skip `expand-to-scenes` for this chapter N. Otherwise, call `outline-generator` with:
       - `operation`: `"expand-to-scenes"`
       - `name`: `story_name`
       - `chapterNum`: `N`

--- a/prompts/agents/chapter-writer.md
+++ b/prompts/agents/chapter-writer.md
@@ -62,7 +62,17 @@ In normal pipeline execution, all entity information is accessed through the wik
 
 Generate scenes **sequentially** — never in parallel. Narrative flow depends on each prior scene's content.
 
-For each scene M in the chapter (M = 1, 2, ..., scene_count):
+**Pre-loop scan — identify complete scenes:**
+
+Before entering the scene loop, call `savepoint-mgr list` for the story. Filter the returned names for entries matching `chapter_{N}/scene_{M}` where N is the current chapter number. Parse the M values to determine which scene numbers are already complete.
+
+Find `first_incomplete_scene` = the smallest M in [1..`scene_count`] that does **not** have a `chapter_{N}/scene_{M}` savepoint. If all scenes are complete, skip directly to step 6 (assemble the chapter).
+
+For scenes 1 through `first_incomplete_scene - 1`: they are already persisted on disk. Do **not** call `wiki-snapshot` for these scenes. Do **not** call `scene-writer generate` for these scenes. The `scene-writer generate` tool auto-loads the previous scene from its savepoint for continuity — no agent-side action is needed.
+
+Begin the `wiki-snapshot` + `scene-writer generate` loop from `first_incomplete_scene`.
+
+For each scene M in the chapter (M = `first_incomplete_scene`, `first_incomplete_scene + 1`, ..., `scene_count`):
 
 1. **Assemble context.** Call `wiki-snapshot` (operation: `snapshot`) with:
    - `name`: the current story name
@@ -110,10 +120,11 @@ Savepoints are created at each significant milestone within a chapter, enabling 
 | `chapter_{N}/scene_{M}` | Scene M generated successfully (written internally by `scene-writer`) |
 | `chapter_{N}/chapter_content` | All scenes assembled into chapter (written automatically by `scene-writer assemble-chapter`) |
 
-**Resuming from a savepoint:**
-1. Load the savepoint via `savepoint-mgr` (operation: `load`)
-2. Determine the last completed scene from the savepoint name
-3. Resume the scene generation loop from the next scene, or proceed to assembly if all scenes are complete
+**Resume procedure:**
+1. At the start of the Scene Generation Loop, call `savepoint-mgr list` and filter for `chapter_{N}/scene_{M}` entries.
+2. Find `first_incomplete_scene` — the smallest M without a savepoint.
+3. For scenes before `first_incomplete_scene`: skip both `wiki-snapshot` and `scene-writer generate`. The tool auto-loads previous scene content from savepoints for continuity.
+4. Begin the loop from `first_incomplete_scene`. If all scenes are complete, proceed directly to `scene-writer assemble-chapter`.
 
 ---
 

--- a/prompts/agents/outline-planner.md
+++ b/prompts/agents/outline-planner.md
@@ -62,19 +62,31 @@ Execute these phases sequentially. Each phase must complete before the next begi
 
    **If chunked generation is enabled (`true`):**
 
-   Loop through chapters in chunks of `outline_chunk_size`:
+   **Pre-loop scan — identify complete chunks:**
 
-    - For the first chunk, call `outline-generator` with:
+   Before entering the expansion loop, call `savepoint-mgr list` for the story. Filter the returned names for entries matching `outline_chunk_{start}_{end}`. Build the full ordered list of chunk ranges that would be generated for `wanted_chapters` / `outline_chunk_size` (ranges: `[1..chunk_size]`, `[chunk_size+1..2*chunk_size]`, ... `[last_start..wanted_chapters]`). Initialise an empty `chunk_outlines` accumulator list and set `continuitySummary = ""`.
+
+   For each chunk range **with an existing savepoint** (i.e., `outline_chunk_{start}_{end}` was returned by `savepoint-mgr list`):
+   - Load the chunk outline directly via `savepoint-mgr load` (step: `outline_chunk_{start}_{end}`). Append `data.chunk_outline` to the `chunk_outlines` accumulator.
+   - This is the last complete chunk: load its `continuity_{start}_{end}` savepoint via `savepoint-mgr load` and assign `data.continuity_analysis` as `continuitySummary`. (Each subsequent complete chunk overwrites this — the last complete chunk's continuity becomes the seed for the first real `expand-chapter` call.)
+   - **Do not** call `expand-chapter` for this range.
+
+   Identify the **first incomplete chunk range** — the smallest range in the ordered list whose `outline_chunk_{start}_{end}` savepoint does not exist. If all chunk ranges are already complete, skip directly to the consolidation step below.
+
+   **Expansion loop — from first incomplete chunk:**
+
+   Begin `expand-chapter` calls from the **first incomplete** chunk range. For each remaining range (first incomplete through last):
+
+    - For the **first incomplete** chunk, call `outline-generator` with:
        - `operation`: `"expand-chapter"`
        - `name`: story name
-       - `chunkStart`: 1
-       - `chunkEnd`: `outline_chunk_size`
+       - `chunkStart`: range start
+       - `chunkEnd`: range end
        - `totalChapters`: `wanted_chapters`
+       - `continuitySummary`: the value loaded from the last complete `continuity_{start}_{end}` savepoint (empty string if no chunks were complete)
        - `personaView`: `"outline"` (only when `enable_author_persona` is true; omit when false)
 
-   **After the first `expand-chapter` call**, parse the JSON response and extract `data.chunk_outline` and `data.continuity_analysis` (see note after subsequent chunks below).
-
-    - For subsequent chunks, call `outline-generator` with:
+    - For **subsequent incomplete** chunks, call `outline-generator` with:
        - `operation`: `"expand-chapter"`
        - `name`: story name
        - `chunkStart`: previous chunk end + 1
@@ -88,10 +100,9 @@ Execute these phases sequentially. Each phase must complete before the next begi
    **After each `expand-chapter` call**, parse the JSON response — the tool returns `{"status": "success", "operation": "expand-chapter", "data": {"chunk_outline": "...", "continuity_analysis": "..."}}`:
     - Extract `data.chunk_outline` — rely on the tool's chunk savepoint for persistence
    - Extract `data.continuity_analysis` — use as the `continuitySummary` value for the next chunk's call
+   - Append `data.chunk_outline` to the `chunk_outlines` accumulator
 
-   Continue until all `wanted_chapters` chapters are covered.
-
-   **After all chunks are covered,** consolidate the collected chunk outlines into a single merged outline string:
+   **After all chunks are covered** (both pre-loaded and newly generated), consolidate the collected chunk outlines into a single merged outline string:
    - Concatenate all `data.chunk_outline` values in chapter order (as collected during the loop above), separated by double newlines
    - Store the result as `merged_outline` — this is the complete, consolidated outline for all `wanted_chapters` chapters
    - Assign `current_outline = merged_outline`. This variable will be updated by critique refinements if enabled.


### PR DESCRIPTION
## Summary

Adds explicit pre-loop savepoint scanning to three agent prompts so the pipeline resumes from the first incomplete item rather than restarting from item 1. No Python changes — prompt rewrites only.

## Closes
Closes #441

## Changes

- [x] `prompts/agents/outline-planner.md` — Phase 3 chunked path: pre-loop scan for `outline_chunk_{start}_{end}` savepoints; loads complete chunks directly; seeds `continuitySummary` from last complete `continuity_{start}_{end}`; calls `expand-chapter` only from first incomplete range
- [x] `prompts/agents/chapter-outline-expander.md` — Workflow Step 2/4: pre-loop scan for `expanded_chapter_{N}_{N}` savepoints; loop starts at `first_incomplete_chapter`; Step 4d skips `expand-to-scenes` when `chapter_{N}/scene_definitions` savepoint exists
- [x] `prompts/agents/chapter-writer.md` — Scene Generation Loop: pre-loop scan for `chapter_{N}/scene_{M}` savepoints; skips `wiki-snapshot` + `scene-writer generate` for already-complete scenes; vague "Resuming from a savepoint" note replaced with explicit 4-step resume procedure
- [x] Lint: clean
- [x] Type check: clean

## Plan

**Task 1 — outline-planner:** Pre-loop scan before `expand-chapter` loop. Loads `outline_chunk_{s}_{e}` savepoints directly into accumulator. Seeds `continuitySummary` from last complete `continuity_{s}_{e}`. Loop begins at first missing range.

**Task 2 — chapter-outline-expander:** Pre-loop scan before chapter loop. Identifies `first_incomplete_chapter`. Loop starts there, not at 1. Step 4d checks `chapter_{N}/scene_definitions` before calling `expand-to-scenes`.

**Task 3 — chapter-writer:** Pre-loop scan at Scene Generation Loop start. Identifies `first_incomplete_scene`. Skips both `wiki-snapshot` and `scene-writer generate` for complete scenes. Savepoint Strategy updated with explicit resume procedure.
